### PR TITLE
Add scoring module and input contract (Track 4)

### DIFF
--- a/docs/scoring/input_contract.md
+++ b/docs/scoring/input_contract.md
@@ -1,0 +1,43 @@
+# Scoring Input Contract v0
+
+**Owner:** Danny Le
+
+**Track:** Track 4 - Routing & Priority Modeling
+
+**Version:** v0
+
+**Last updated:** June 3, 2026
+
+## Purpose
+
+This document defines the exact schema the scorer expects. Every field listed below must be present in Airtable before `scorer_v0.py` can run. Khoa and Arshad: if anything here is unclear or conflicts with how you're structuring your outputs, flag it before you finalize your schemas.
+
+## Identifier Fields
+
+These fields are not scorer inputs. They exist to uniquely identify records and join data across Airtable tables.
+
+| Field | Type | Produced By | Description |
+|---|---|---|---|
+| prospect_id | string | Arshad | Unique identifier per prospect. Used to join enrichment, company, and outreach data. |
+| sender_id | string | Danny | FDE this prospect is assigned to. Used to select the correct sender-specific warmth value at scoring time. Values: `asmar`, `jane`, `giancarlos`. |
+
+## Scorer Input Fields
+
+These are the six fields the scorer reads directly. All must be present and within the specified range or the scorer will error.
+
+| Field | Type | Range | Produced By | Description |
+|---|---|---|---|---|
+| warmth | float | 0-1 | Khoa | Sender-specific connection strength. Must be computed per sender, not globally. A cold stranger = 0.1, a direct prior colleague = 0.9. |
+| signal_recency | float | 0-1 | Khoa | Recency of the prospect's most recent public GPU pain signal. Computed as `np.exp(-days_since_signal / half_life)`, half_life tentatively 30 days. If no signal found, set to 0. |
+| company_tier | int | 1, 2, or 3 | Arshad | 1 = orchestrator / managed GPU platform, 2 = non-text mid-market (biotech, robotics, edge, HPC), 3 = weak or unclear fit. |
+| pain_acknowledged | int | 0 or 1 | Khoa | 1 if the prospect has publicly expressed a GPU pain signal (post, comment, article, talk). 0 otherwise. |
+| engagement_score | float | 0-1 | Khoa | Continuous measure of how much this person has interacted with Git.M content, ex. liked posts, commented, connected with someone at Git.M. 0 = no interaction, 1 = high engagement. |
+| prior_engagement | int | 0 or 1 | Jorge (via HeyReach reply pipeline) | 1 if this prospect has previously replied to or interacted with Git.M outreach. Defaults to 0 for all prospects at sprint start. Git.M has not yet contacted them. Will become meaningful as reply data flows in. |
+
+## Notes
+
+- `warmth` is sender-specific. Khoa should produce a warmth value per prospect per sender, not a single global value.
+- `signal_recency` decay formula: `np.exp(-days_since_signal / half_life)`. Half-life is tentatively 30 days, pending confirmation from Jalon.
+- `prior_engagement` defaults to 0 at sprint start. Jorge's HeyReach reply pipeline will update this field as reply data comes in.
+- All float fields must be in range [0, 1]. Out-of-range values will not be caught silently, and the scorer will produce incorrect scores.
+- `company_tier` must be exactly 1, 2, or 3. Any other value defaults to tier 3 (score = 0.2) in the current scorer logic.

--- a/gitm/routing/scorer_v0.py
+++ b/gitm/routing/scorer_v0.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import numpy as np
+
+def score_prospect(
+    warmth: float,
+    signal_recency: float,
+    company_tier: int,
+    pain_acknowledged: int,
+    engagement_score: float,
+    prior_engagement: int
+) -> float:
+    """
+    Compute priority score for a single prospect.
+
+    Inputs:
+        warmth (float): 0-1, sender-specific connection strength
+        signal_recency (float): 0-1, recency of GPU pain signal
+        company_tier (int): 1 = orchestrator/managed GPU platform,
+                            2 = non-text mid-market (biotech, robotics, edge, HPC),
+                            3 = weak or unclear fit
+        pain_acknowledged (int): 1 if prospect expressed GPU pain publicly, 0 if not
+        engagement_score (float): 0-1, interaction with Git.M content
+        prior_engagement (int): 1 if prospect previously replied to Git.M, 0 if not
+
+    Returns:
+        float: priority score between 0 and 100
+    """
+
+    # Weights
+    W_WARMTH = 0.35
+    W_SIGNAL_RECENCY = 0.25
+    W_COMPANY_TIER = 0.20
+    W_PAIN = 0.10
+    W_ENGAGEMENT = 0.05
+    W_PRIOR = 0.05
+
+    # Company tier score
+    tier_score_map = {1: 1.0, 2: 0.6, 3: 0.2}
+    tier_score = tier_score_map.get(company_tier, 0.2)
+
+    score = (
+        warmth * W_WARMTH +
+        signal_recency * W_SIGNAL_RECENCY +
+        tier_score * W_COMPANY_TIER +
+        pain_acknowledged * W_PAIN +
+        engagement_score * W_ENGAGEMENT +
+        prior_engagement * W_PRIOR
+    )
+
+    return round(score * 100, 2)
+
+
+def score_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Score a full dataframe of prospects.
+    Expects columns matching the input contract.
+    Returns dataframe with priority_score column added, sorted descending.
+    """
+    df = df.copy()
+    df["priority_score"] = df.apply(
+        lambda row: score_prospect(
+            warmth=row["warmth"],
+            signal_recency=row["signal_recency"],
+            company_tier=row["company_tier"],
+            pain_acknowledged=row["pain_acknowledged"],
+            engagement_score=row["engagement_score"],
+            prior_engagement=row["prior_engagement"]
+        ),
+        axis=1
+    )
+    return df.sort_values("priority_score", ascending=False).reset_index(drop=True)
+
+
+if __name__ == "__main__":
+    # Example usage with dummy data
+    sample_data = {
+        "prospect_id": ["p001", "p002", "p003"],
+        "sender_id": ["asmar", "jane", "giancarlos"],
+        "warmth": [0.8, 0.3, 0.5],
+        "signal_recency": [0.9, 0.2, 0.7],
+        "company_tier": [1, 2, 2],
+        "pain_acknowledged": [1, 0, 1],
+        "engagement_score": [0.4, 0.0, 0.2],
+        "prior_engagement": [0, 0, 1]
+    }
+
+    df = pd.DataFrame(sample_data)
+    results = score_dataframe(df)
+    print(results[["prospect_id", "sender_id", "priority_score"]])

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,51 @@
+from gitm.routing.scorer_v0 import score_prospect, score_dataframe
+import pandas as pd
+
+def test_score_prospect_basic():
+    score = score_prospect(
+        warmth=0.8,
+        signal_recency=0.9,
+        company_tier=1,
+        pain_acknowledged=1,
+        engagement_score=0.4,
+        prior_engagement=0
+    )
+    assert score == 82.5
+
+def test_score_prospect_cold():
+    score = score_prospect(
+        warmth=0.1,
+        signal_recency=0.0,
+        company_tier=3,
+        pain_acknowledged=0,
+        engagement_score=0.0,
+        prior_engagement=0
+    )
+    assert score == 7.5
+
+def test_score_prospect_unknown_tier():
+    score = score_prospect(
+        warmth=0.5,
+        signal_recency=0.5,
+        company_tier=99,
+        pain_acknowledged=0,
+        engagement_score=0.0,
+        prior_engagement=0
+    )
+    # Unknown tier should default to tier 3 (0.2)
+    assert score == 34.0
+
+def test_score_dataframe_sorted():
+    df = pd.DataFrame({
+        "prospect_id": ["p001", "p002"],
+        "sender_id": ["asmar", "jane"],
+        "warmth": [0.8, 0.3],
+        "signal_recency": [0.9, 0.2],
+        "company_tier": [1, 2],
+        "pain_acknowledged": [1, 0],
+        "engagement_score": [0.4, 0.0],
+        "prior_engagement": [0, 0]
+    })
+    results = score_dataframe(df)
+    assert results.iloc[0]["prospect_id"] == "p001"
+    assert results.iloc[0]["priority_score"] > results.iloc[1]["priority_score"]


### PR DESCRIPTION
Track 4 - Scoring module and input contract v0

- gitm/routing/scorer_v0.py - weighted linear scorer, scores prospects 0-100 per sender
- gitm/routing/__init__.py - package init
- docs/scoring/input_contract.md - defines input schema for Khoa and Arshad
- tests/test_scorer.py - unit tests for scorer_v0.py

Weights are v0 estimates, will be updated once reply data flows in from HeyReach.