### PR TITLE
KITTI W2: convergence fix, gpu_headroom integration, stage spread, 6-seed baselines

### DIFF
--- a/benchmarks/edge/datasets_proposal.md
+++ b/benchmarks/edge/datasets_proposal.md
@@ -1,0 +1,77 @@
+# Additional edge/robotics datasets — proposal
+
+> Author: Karthik — for review by Adit before adding to spec.
+
+Current scope: nuScenes v1.0 + KITTI Object (~47k keyframes combined).
+Below are the next candidates ranked by signal value for the Git.M invariants.
+
+---
+
+## Tier 1 — High signal, worth adding
+
+### Waymo Open Dataset (v2.0)
+- **Size:** ~1,000 segments, 200k frames, 5-beam lidar (top + 4 side)
+- **Why it matters:** Much denser point clouds (64-beam top lidar vs KITTI's 64-beam but wider
+  range + higher annotation quality). Significantly harder for the backbone — GPU active % likely
+  higher, which tightens the stream-concurrency signal.
+- **Concern:** Requires a data access agreement (Google form, ~1 week turnaround).
+  Also non-commercial only — verify with Adit before committing.
+- **Manifest rows:** ~200k (5x current KITTI). Build time ~20 min.
+- **Blocker:** License approval.
+
+### Argoverse 2 (Sensor Dataset)
+- **Size:** 1,000 scenarios, ~30k frames, 2x lidar (spinning + forward-facing).
+- **Why it matters:** Two asynchronous lidar streams per frame — interesting for concurrency
+  invariant because merging two streams before voxelization introduces a sync point.
+  Good test of whether stream-concurrency signal carries to multi-lidar setups.
+- **Download:** Open access via S3 (`s3://argoai-argoverse2/...`). No license gate.
+- **Manifest rows:** ~30k. Adds ~30% to current combined manifest.
+- **Blocker:** None. Could add this week.
+
+---
+
+## Tier 2 — Useful if we want breadth
+
+### ONCE (One Million Scenes)
+- **Size:** ~1M frames, single 40-beam lidar.
+- **Why it matters:** Volume — more frames = tighter convergence bounds and better
+  steady-state GPU utilization measurements. Useful for validating that the 2%
+  convergence requirement holds at scale.
+- **Download:** Open access (Chinese hosting, slow downloads). May need mirror.
+- **Blocker:** Download bandwidth on RunPod. Otherwise no license gate.
+
+### PandaSet
+- **Size:** ~16k frames, dual lidar (mechanical + solid-state).
+- **Why it matters:** Solid-state lidar has a fundamentally different point density
+  pattern (non-uniform angular resolution). Tests whether the voxelization step
+  behaves differently under non-uniform inputs.
+- **Download:** Open access (free sign-up, direct download).
+- **Blocker:** None.
+
+---
+
+## Tier 3 — Lower priority
+
+### SemanticKITTI (KITTI odometry sequences with semantic labels)
+- **Size:** Same lidar as KITTI Object but sequential (not individual frames).
+  22 sequences, ~43k scans.
+- **Why it matters:** Sequential frames are much more cache-friendly — useful
+  as a control condition to isolate the I/O cache locality effect.
+- **Blocker:** None. Builds on top of existing KITTI download.
+
+### nuScenes-lidarseg
+- **Same data as nuScenes v1.0** but with per-point semantic labels.
+  No new lidar frames; adds annotation load to the post-processing step.
+- **Why it matters:** Tests sync_stall_pct sensitivity to heavier post-processing.
+
+---
+
+## Recommendation
+
+Add **Argoverse 2** first — no license gate, open S3, meaningful new signal
+(multi-lidar sync point). After that, pursue **Waymo** if the license approval
+clears, since it's the most widely used benchmark for 3D detection and having
+it in the manifest would make the benchmark credible to external readers.
+
+Skip ONCE for now (download pain) and SemanticKITTI/PandaSet unless we need
+more control conditions.

--- a/benchmarks/kitti/results.md
+++ b/benchmarks/kitti/results.md
@@ -2,17 +2,21 @@
 
 ## Baseline measurements
 
-| Run | Seed | fps | GPU active % | Data stall % | Sync % | CPU % |
-|-----|------|-----|--------------|-------------|--------|-------|
-| Baseline 1 | 42 | TBD | TBD | TBD | TBD | TBD |
-| Baseline 2 | 43 | TBD | TBD | TBD | TBD | TBD |
-| Baseline 3 | 44 | TBD | TBD | TBD | TBD | TBD |
-| Mean | — | TBD | TBD | TBD | TBD | TBD |
-| Stddev | — | TBD | TBD | TBD | TBD | TBD |
+| Run | Seed | fps | GPU active % | Data stall % | Sync % | CPU % | Compute headroom % |
+|-----|------|-----|--------------|-------------|--------|-------|-------------------|
+| Baseline 1 | 42 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Baseline 2 | 43 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Baseline 3 | 44 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Baseline 4 | 45 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Baseline 5 | 46 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Baseline 6 | 47 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Mean | -- | TBD | TBD | TBD | TBD | TBD | TBD |
+| Stddev | -- | TBD | TBD | TBD | TBD | TBD | -- |
 
-3-seed fps spread: TBD% — within 2%: TBD
+6-seed fps spread: TBD% -- within 2%: TBD
 
-NVML cross-check (mean utilization): TBD%
+GPU headroom (compute_headroom_pct = 100 - mean NVML util): TBD%
+Memory free at peak: TBD GB
 
 ## Stream-concurrency verification
 
@@ -23,7 +27,7 @@ Host-side voxelization overlaps device-side backbone inference: **TBD**
        python harness/smoke_kitti.py --cfg $OPENPCDET_CFG --ckpt $OPENPCDET_CKPT --n-frames 200
      Open the .nsys-rep in Nsight Systems GUI, zoom in on a few consecutive frames,
      look for CPU voxelization bar overlapping GPU backbone bar.
-     Screenshot → benchmarks/kitti/concurrency_timeline.png
+     Screenshot -> benchmarks/kitti/concurrency_timeline.png
 -->
 
 ![nsys concurrency timeline](concurrency_timeline.png)
@@ -36,11 +40,11 @@ invariant has no signal for this workload and the benchmark needs review.
 
 ## Notes
 
-- Machine: TBD
+- Machine: RunPod y4xbh7yws2e4tu-64410cb0
 - GPU: TBD
 - Driver version: TBD
 - CUDA version: TBD
-- OpenPCDet commit: TBD
-- Config sha256: TBD
+- OpenPCDet commit: 233f849829b6ac19afb8af8837a0246890908755
+- Config sha256: 170a9ffe76cfd8509d1044cfbcf1cbd44c5d320fda81bf0089a8d5efaf1c91c8
 - Checkpoint sha256: 4c83fc0fa02575b9b3e9dec676f698e7a70bb5a795e89f91df8a96b916fa19e2
 - Date: TBD

--- a/benchmarks/kitti/spec.md
+++ b/benchmarks/kitti/spec.md
@@ -4,63 +4,69 @@
 
 Datasets used:
 - KITTI 3D Object Detection: 7,481 training frames, Velodyne lidar + calibration + labels
-- Data location: `$GITM_DATA_ROOT/datasets/kitti/object/training/`
+- Data location: `$GITM_DATA_ROOT/kitti/training/`
 - Directory layout:
-  - `velodyne/`   — 000000.bin … 007480.bin  (float32 XYZI point clouds)
-  - `calib/`      — 000000.txt … 007480.txt  (camera-lidar calibration)
-  - `label_2/`    — 000000.txt … 007480.txt  (3D bounding box annotations)
+  - `velodyne/`   -- 000000.bin to 007480.bin  (float32 XYZI point clouds)
+  - `calib/`      -- 000000.txt to 007480.txt  (camera-lidar calibration)
+  - `label_2/`    -- 000000.txt to 007480.txt  (3D bounding box annotations)
 - Manifest: `benchmarks/kitti/manifest.yaml`
   - Every file sha256-verified. Pass/fail gated by `python harness/verify_manifest.py`.
+  - Generate: `python harness/gen_kitti_manifest.py --root $GITM_DATA_ROOT/kitti/training`
 
 ## Section 2: Work unit
 
 One frame processed end-to-end through:
 
-    voxelization → 3D backbone (PointPillars) → BEV head → NMS → detections
+    voxelization -> 3D backbone (PointPillars) -> BEV head -> NMS -> detections
 
-Model: OpenPCDet CenterPoint config on PointPillars backbone
+Model: OpenPCDet PointPillars (KITTI config)
 
-Pinned OpenPCDet commit: [TBD — fill in after cloning on RunPod]
-Pinned config sha256: [TBD — sha256sum tools/cfgs/kitti_models/pointpillar.yaml]
-Checkpoint: `pointpillar_7728.pth`
-Checkpoint sha256: c9c84e5cf1059b84fb37a4d47f8e58fc16b22e2c3e9ddf47ed59700d7b0e9ccd
+- OpenPCDet commit: `233f849829b6ac19afb8af8837a0246890908755`
+- Config (pointpillar.yaml) sha256: `170a9ffe76cfd8509d1044cfbcf1cbd44c5d320fda81bf0089a8d5efaf1c91c8`
+- Checkpoint: `pointpillar_7728.pth`
+- Checkpoint sha256: `4c83fc0fa02575b9b3e9dec676f698e7a70bb5a795e89f91df8a96b916fa19e2`
 
 Stage breakdown per frame:
-1. Load .bin (np.fromfile) — CPU / data stall
-2. Voxelization + H2D copy — CPU / data stall
-3. Backbone + BEV head — GPU active
-4. NMS + box assembly — CPU / sync stall
+1. Load .bin (np.fromfile) -- CPU / data stall
+2. Voxelization + H2D copy -- CPU / data stall
+3. Backbone + BEV head -- GPU active
+4. NMS + box assembly -- CPU / sync stall
+
+Implementation: `gitm.benchmarks.kitti.WorkUnit`
 
 ## Section 3: Success metric
 
-- Top-line metric: `frames_per_second` (warm window)
+- Top-line metric: `frames_per_second` (timed warm window)
 - Warm-up: 100 frames discarded before timing begins
-- Warm window: 7,381 frames (all training frames minus warmup)
-- Three seeds (42, 43, 44) must agree within 2%
-- Auxiliary metric: `total_detections` per run (sanity check, not a target)
-- GPU active % must be < 85% (saturation check)
+- Disk pre-warm: all frames read once before GPU warmup (eliminates OS page cache
+  locality as a seed-ordering confound)
+- Timed window: 7,381 frames (all training frames minus warmup)
+- Convergence: 6 seeds (42-47) must agree within 2% fps spread
+- GPU saturation check: GPU active % must be < 85%
+- Auxiliary: `total_detections` per run (regression sentinel, not a target)
 
-Baseline result:
+Baseline result (fill after running `bash harness/run_baselines.sh`):
 
-| Seed | fps | GPU active % | Data stall % | Sync % | CPU % |
-|------|-----|--------------|-------------|--------|-------|
-| 42   | TBD | TBD          | TBD         | TBD    | TBD   |
-| 43   | TBD | TBD          | TBD         | TBD    | TBD   |
-| 44   | TBD | TBD          | TBD         | TBD    | TBD   |
-| Mean | TBD | TBD          | TBD         | TBD    | TBD   |
-| Stddev | TBD | TBD        | TBD         | TBD    | TBD   |
+| Seed | fps | GPU active % | Data stall % | Sync % | CPU % | Compute headroom % |
+|------|-----|--------------|-------------|--------|-------|-------------------|
+| 42   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| 43   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| 44   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| 45   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| 46   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| 47   | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| Mean | TBD | TBD          | TBD         | TBD    | TBD   | TBD               |
+| Stddev | TBD | TBD        | TBD         | TBD    | TBD   | --                |
 
-3-seed fps within 2%: TBD
+6-seed fps spread: TBD -- within 2%: TBD
 
 ## Section 4: Expected stall profile
 
-Expected from architecture analysis (fill in from measured baselines):
-
 | Category | What it is | Expected % | Measured % |
 |----------|-----------|------------|------------|
-| Data stall | lidar .bin decode + host-side voxelization + H2D copy | 20–35% | TBD |
-| Sync stall | NMS serialization on CPU | 10–20% | TBD |
-| GPU active | backbone + BEV head forward pass | 50–65% | TBD |
+| Data stall | lidar .bin decode + host-side voxelization + H2D copy | 20-35% | TBD |
+| Sync stall | NMS serialization on CPU | 10-20% | TBD |
+| GPU active | backbone + BEV head forward pass | 50-65% | TBD |
 | CPU overhead | Python dispatch, dataloader | ~5% | TBD |
 
 **Critical check:** GPU active must be < 85%. If saturated, flag Adit same day
@@ -69,12 +75,35 @@ for 500-frame shard fallback.
 **Stream-concurrency check (nsys):** host-side voxelization of frame N+1 should
 overlap device-side backbone inference on frame N. Capture nsys timeline and
 commit screenshot to `benchmarks/kitti/results.md`. If overlap is absent, the
-stream-concurrency invariant has no signal — flag Adit immediately.
+stream-concurrency invariant has no signal -- flag Adit immediately.
+
+## Section 5: GPU headroom (runtime integration)
+
+Measured via `gitm.optimizer.headroom_kernel_rank.gpu_headroom()` using NVML
+samples collected at 5 Hz during the timed window.
+
+| Metric | Expected | Measured |
+|--------|----------|---------|
+| Compute headroom (100 - mean util) | >35% | TBD |
+| Memory free at peak | >10 GB | TBD |
+
+Per-stage spread (p50/p95 latency per stage across all frames):
+
+| Stage | mean ms | p50 ms | p95 ms | % of frame |
+|-------|---------|--------|--------|------------|
+| load  | TBD | TBD | TBD | TBD |
+| preprocess (voxelize + H2D) | TBD | TBD | TBD | TBD |
+| inference (backbone + BEV + NMS) | TBD | TBD | TBD | TBD |
+| postprocess (D2H) | TBD | TBD | TBD | TBD |
+
+Stage spread is emitted as `stage_spread` in each baseline JSON and as
+`stage_spread_report.txt` alongside it.
 
 ## Environment
 
-Machine: [TBD — fill in after RunPod setup]
-Driver version: [TBD]
-GPU: [TBD]
-OpenPCDet commit: [TBD]
-Date: [TBD]
+- Machine: RunPod y4xbh7yws2e4tu-64410cb0 (2 TB persistent /workspace)
+- GPU: TBD
+- Driver: TBD
+- CUDA: TBD
+- OpenPCDet commit: 233f849829b6ac19afb8af8837a0246890908755
+- Date: TBD

--- a/gitm/benchmarks/kitti/baseline.py
+++ b/gitm/benchmarks/kitti/baseline.py
@@ -45,6 +45,66 @@ NVML_SAMPLE_HZ = 5
 # KITTI canonical layout relative to GITM_DATA_ROOT, matching kitti_source.py
 _KITTI_VELODYNE_SUBDIR = Path("kitti") / "training" / "velodyne"
 
+_STAGE_NAMES = ["load", "preprocess", "inference", "postprocess"]
+
+
+def _stage_spread(
+    load_s: list[float],
+    preprocess_s: list[float],
+    inference_s: list[float],
+    postprocess_s: list[float],
+) -> dict:
+    """Compute p50/p95 latency and % of frame for each pipeline stage.
+
+    Surfaces the runtime's kernel-level spread signal: high p95/p50 ratio on a
+    stage means long-tail invocations that are good intervention targets.
+    Mirrors the shape of headroom_kernel_rank.render_roi_table() but for
+    PointPillars pipeline stages rather than CUDA kernel families.
+    """
+    import statistics
+
+    totals = [l + p + i + q for l, p, i, q in
+              zip(load_s, preprocess_s, inference_s, postprocess_s)]
+    mean_total = statistics.mean(totals) if totals else 1.0
+
+    def _stats(xs: list[float]) -> dict:
+        s = sorted(xs)
+        n = len(s)
+        p50 = s[int(0.50 * (n - 1))] if n else 0.0
+        p95 = s[int(0.95 * (n - 1))] if n else 0.0
+        mean = statistics.mean(xs) if xs else 0.0
+        return {
+            "mean_ms": round(mean * 1000, 3),
+            "p50_ms": round(p50 * 1000, 3),
+            "p95_ms": round(p95 * 1000, 3),
+            "p95_p50_ratio": round(p95 / p50, 2) if p50 > 0 else None,
+            "mean_pct": round(mean / mean_total * 100, 2) if mean_total > 0 else 0.0,
+        }
+
+    return {
+        "load": _stats(load_s),
+        "preprocess": _stats(preprocess_s),
+        "inference": _stats(inference_s),
+        "postprocess": _stats(postprocess_s),
+    }
+
+
+def render_stage_spread(spread: dict) -> str:
+    """Human-readable stage spread table (stdout + saved as stage_spread_report.txt)."""
+    lines = ["PointPillars stage spread (p50 / p95 latency per stage):", ""]
+    hdr = f"{'stage':<14} {'mean_ms':>9} {'p50_ms':>9} {'p95_ms':>9} {'p95/p50':>8} {'% frame':>8}"
+    lines += [hdr, "-" * len(hdr)]
+    for stage in _STAGE_NAMES:
+        s = spread.get(stage, {})
+        ratio = s.get("p95_p50_ratio")
+        lines.append(
+            f"{stage:<14} {s.get('mean_ms', 0):>9.3f} {s.get('p50_ms', 0):>9.3f} "
+            f"{s.get('p95_ms', 0):>9.3f} {ratio if ratio else 'N/A':>8} "
+            f"{s.get('mean_pct', 0):>7.1f}%"
+        )
+    lines += ["", "High p95/p50 ratio = long-tail invocations = intervention target."]
+    return "\n".join(lines)
+
 
 def _load_frame_paths(data_root: Path) -> list[Path]:
     """Return sorted velodyne .bin paths from $GITM_DATA_ROOT/kitti/training/velodyne/.
@@ -184,6 +244,12 @@ def run_baseline(
     gpu_active_fracs: list[float] = []
     total_detections = 0
 
+    # Per-frame stage timings for spread analysis
+    t_load_list: list[float] = []
+    t_preprocess_list: list[float] = []
+    t_inference_list: list[float] = []
+    t_postprocess_list: list[float] = []
+
     for i, path in enumerate(warm_paths):
         if i % 500 == 0:
             print(f"  {i}/{len(warm_paths)}")
@@ -192,6 +258,10 @@ def run_baseline(
         sync_stall_fracs.append(result.sync_stall_frac)
         gpu_active_fracs.append(result.gpu_active_frac)
         total_detections += result.n_detections
+        t_load_list.append(result.t_load_s)
+        t_preprocess_list.append(result.t_preprocess_s)
+        t_inference_list.append(result.t_inference_s)
+        t_postprocess_list.append(result.t_postprocess_s)
 
     t_wall_end = time.perf_counter()
     stop_event.set()
@@ -205,6 +275,11 @@ def run_baseline(
     sync_stall_pct = sum(sync_stall_fracs) / n_warm * 100
     gpu_active_pct = sum(gpu_active_fracs) / n_warm * 100
     cpu_pct = max(0.0, 100.0 - data_stall_pct - sync_stall_pct - gpu_active_pct)
+
+    # Stage spread — kernel-level spread signal for PointPillars pipeline stages
+    spread = _stage_spread(t_load_list, t_preprocess_list, t_inference_list, t_postprocess_list)
+    spread_report = render_stage_spread(spread)
+    print("\n" + spread_report)
 
     # GPU headroom from NVML samples via gitm.optimizer.headroom_kernel_rank
     headroom_dict: dict[str, Any] = {}
@@ -236,6 +311,7 @@ def run_baseline(
         "sync_stall_pct": round(sync_stall_pct, 2),
         "cpu_pct": round(cpu_pct, 2),
         **headroom_dict,
+        "stage_spread": spread,
         "total_detections": total_detections,
         "elapsed_s": round(elapsed, 3),
         "hostname": socket.gethostname(),
@@ -247,6 +323,9 @@ def run_baseline(
     }
 
     output_path.write_text(json.dumps(output, indent=2))
+    # Save stage spread report alongside the JSON for easy review
+    report_path = output_path.with_name(output_path.stem + "_stage_spread.txt")
+    report_path.write_text(spread_report)
     print(
         f"\nResult: {fps:.1f} fps | GPU active {gpu_active_pct:.1f}% "
         f"| data stall {data_stall_pct:.1f}% | wrote {output_path}"

--- a/gitm/benchmarks/kitti/baseline.py
+++ b/gitm/benchmarks/kitti/baseline.py
@@ -1,16 +1,17 @@
 """KITTI PointPillars baseline runner.
 
-Runs three convergent baselines over the 7,481 training frames, records the
-stall breakdown, and writes a JSON result file per run.
+Runs convergent baselines over the 7,481 training frames, records the
+stall breakdown and GPU headroom, and writes a JSON result file per run.
 
 Usage (on the RunPod GPU box):
 
     python -m gitm.benchmarks.kitti.baseline \\
-        --cfg   /path/to/OpenPCDet/tools/cfgs/kitti_models/pointpillar.yaml \\
-        --ckpt  $GITM_DATA_ROOT/checkpoints/kitti/pointpillar_7728.pth \\
-        --seed  42 \\
-        --frames 7481 \\
-        --output $GITM_DATA_ROOT/runs/kitti_baseline_1.json
+        --cfg        /path/to/OpenPCDet/tools/cfgs/kitti_models/pointpillar.yaml \\
+        --ckpt       $GITM_DATA_ROOT/checkpoints/kitti/pointpillar_7728.pth \\
+        --data-root  $GITM_DATA_ROOT \\
+        --seed       42 \\
+        --frames     7481 \\
+        --output     $GITM_DATA_ROOT/runs/kitti_baseline_1.json
 
 Stall breakdown methodology (proxy without CUPTI):
     data_stall_pct  = mean fraction of frame time on file-load + voxelization
@@ -18,9 +19,12 @@ Stall breakdown methodology (proxy without CUPTI):
     gpu_active_pct  = mean fraction of frame time in GPU backbone + BEV head
     cpu_pct         = 100 - data_stall_pct - sync_stall_pct - gpu_active_pct
 
-NVML utilization is sampled at 5 Hz throughout the warm window as an
-independent cross-check. It is stored in the JSON but not used for the
-primary stall breakdown.
+GPU headroom (via NVML + gitm.optimizer.headroom_kernel_rank):
+    compute_headroom_pct = 100 - mean NVML utilization
+    mem_free_at_peak_gb  = free VRAM at peak memory pressure
+
+NVML utilization is sampled at 5 Hz throughout the warm window.
+Kernel-level ROI (kernel_roi) requires CUPTI traces — not captured here.
 """
 
 from __future__ import annotations
@@ -35,32 +39,38 @@ from pathlib import Path
 from typing import Any
 
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-MANIFEST_PATH = REPO_ROOT / "benchmarks" / "kitti" / "manifest.yaml"
-
 WARM_FRAMES = 100  # discard before timing window
 NVML_SAMPLE_HZ = 5
 
+# KITTI canonical layout relative to GITM_DATA_ROOT, matching kitti_source.py
+_KITTI_VELODYNE_SUBDIR = Path("kitti") / "training" / "velodyne"
 
-def _load_manifest_frame_paths(manifest_path: Path) -> list[Path]:
-    """Return ordered list of velodyne .bin paths from the manifest."""
-    import yaml
 
-    with manifest_path.open() as fh:
-        manifest = yaml.safe_load(fh)
+def _load_frame_paths(data_root: Path) -> list[Path]:
+    """Return sorted velodyne .bin paths from $GITM_DATA_ROOT/kitti/training/velodyne/.
 
-    root = Path(manifest["kitti_object"]["root"])
-    paths = []
-    for frame in manifest["frames"]:
-        entry = frame.get("velodyne")
-        if entry is None:
-            continue
-        paths.append(root / entry["path"])
+    Sorted by stem (000000, 000001, ...) for deterministic, reproducible ordering
+    across machines — same order as kitti_source.py's iter_rows().
+    """
+    velodyne_dir = data_root / _KITTI_VELODYNE_SUBDIR
+    if not velodyne_dir.is_dir():
+        raise FileNotFoundError(
+            f"KITTI velodyne directory not found: {velodyne_dir}\n"
+            f"Expected extracted KITTI Object data at {data_root}/kitti/training/\n"
+            f"Ask Adit for the S3 path, or set GITM_DATA_ROOT correctly."
+        )
+    paths = sorted(velodyne_dir.glob("*.bin"), key=lambda p: p.stem)
+    if not paths:
+        raise FileNotFoundError(f"No .bin lidar files found in {velodyne_dir}.")
     return paths
 
 
-def _sample_nvml(samples: list[float], stop_event: threading.Event) -> None:
-    """Background thread: sample GPU 0 utilization at NVML_SAMPLE_HZ."""
+def _sample_nvml(samples: list[dict], stop_event: threading.Event) -> None:
+    """Background thread: sample GPU 0 util + memory at NVML_SAMPLE_HZ.
+
+    Each sample is a dict with util_pct, mem_used_bytes, mem_total_bytes —
+    the format expected by gitm.optimizer.headroom_kernel_rank.gpu_headroom().
+    """
     try:
         import pynvml
 
@@ -69,11 +79,16 @@ def _sample_nvml(samples: list[float], stop_event: threading.Event) -> None:
         interval = 1.0 / NVML_SAMPLE_HZ
         while not stop_event.is_set():
             util = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
-            samples.append(float(util))
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            samples.append({
+                "util_pct": float(util),
+                "mem_used_bytes": int(mem.used),
+                "mem_total_bytes": int(mem.total),
+            })
             time.sleep(interval)
         pynvml.nvmlShutdown()
     except Exception:
-        pass  # no GPU or pynvml absent — nvml_mean_pct will be null in output
+        pass  # no GPU or pynvml absent — headroom fields will be null in output
 
 
 def _convergence_check(results: list[dict]) -> tuple[bool, float]:
@@ -91,23 +106,41 @@ def run_baseline(
     seed: int,
     n_frames: int,
     output_path: str | Path,
-    manifest_path: str | Path = MANIFEST_PATH,
+    data_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Run one baseline over n_frames KITTI frames and write JSON to output_path.
 
-    Returns the result dict (same content as the JSON file).
+    Args:
+        cfg_path:    Path to pointpillar.yaml (OpenPCDet config).
+        ckpt_path:   Path to pointpillar_7728.pth checkpoint.
+        seed:        Random seed controlling frame traversal order.
+        n_frames:    Total frames to process (WARM_FRAMES discarded + timing window).
+        output_path: Destination JSON file.
+        data_root:   GITM_DATA_ROOT — root of kitti/training/velodyne/. Falls back
+                     to the GITM_DATA_ROOT env var if None.
+
+    Returns:
+        Result dict (same content as the JSON file).
     """
     import random
 
+    import numpy as np
+
     from gitm.benchmarks.kitti.workunit import WorkUnit
 
-    manifest_path = Path(manifest_path)
+    if data_root is None:
+        env = os.environ.get("GITM_DATA_ROOT")
+        if not env:
+            raise RuntimeError(
+                "data_root not provided and GITM_DATA_ROOT env var is not set."
+            )
+        data_root = env
+
+    data_root = Path(data_root)
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    all_paths = _load_manifest_frame_paths(manifest_path)
-    if not all_paths:
-        raise RuntimeError(f"Manifest {manifest_path} has no valid velodyne entries")
+    all_paths = _load_frame_paths(data_root)
 
     rng = random.Random(seed)
     shuffled = list(all_paths)
@@ -120,15 +153,24 @@ def run_baseline(
             f"n_frames={n_frames} is too small; need > {WARM_FRAMES} for warm window"
         )
 
+    # Disk pre-warm: read all timing-window frames into the OS page cache before
+    # any GPU warmup or measurement. Without this, seeds that shuffle frames into
+    # a non-sequential (cache-cold) access pattern report lower fps than seeds
+    # that happen to be cache-warm from prior runs — causing spurious divergence.
+    # KITTI training velodyne is ~750 MB, comfortably fits in page cache.
+    print(f"Pre-warming disk cache ({len(run_paths)} frames)…")
+    for path in run_paths:
+        np.fromfile(str(path), dtype=np.float32)
+
     unit = WorkUnit.from_checkpoint(cfg_path=cfg_path, ckpt_path=ckpt_path)
 
-    print(f"Warming up ({WARM_FRAMES} frames)…")
+    print(f"GPU warmup ({WARM_FRAMES} frames)…")
     for path in run_paths[:WARM_FRAMES]:
         unit.run(path)
 
-    # Warm window
+    # Timed warm window
     warm_paths = run_paths[WARM_FRAMES:]
-    nvml_samples: list[float] = []
+    nvml_samples: list[dict] = []
     stop_event = threading.Event()
     nvml_thread = threading.Thread(
         target=_sample_nvml, args=(nvml_samples, stop_event), daemon=True
@@ -163,12 +205,29 @@ def run_baseline(
     sync_stall_pct = sum(sync_stall_fracs) / n_warm * 100
     gpu_active_pct = sum(gpu_active_fracs) / n_warm * 100
     cpu_pct = max(0.0, 100.0 - data_stall_pct - sync_stall_pct - gpu_active_pct)
-    nvml_mean = sum(nvml_samples) / len(nvml_samples) if nvml_samples else None
+
+    # GPU headroom from NVML samples via gitm.optimizer.headroom_kernel_rank
+    headroom_dict: dict[str, Any] = {}
+    try:
+        from gitm.optimizer.headroom_kernel_rank import gpu_headroom
+
+        h = gpu_headroom(nvml_samples)
+        if h is not None:
+            headroom_dict = {
+                "compute_headroom_pct": round(h.compute_headroom_pct, 2),
+                "mean_util_pct": round(h.mean_util_pct, 2),
+                "peak_util_pct": round(h.peak_util_pct, 2),
+                "mem_free_at_peak_gb": round(h.mem_free_at_peak_bytes / 1e9, 3),
+                "mem_total_gb": round(h.mem_total_bytes / 1e9, 3),
+                "nvml_n_samples": h.n_samples,
+            }
+    except Exception:
+        pass  # graceful degradation if headroom_kernel_rank unavailable
 
     import platform
     import socket
 
-    output = {
+    output: dict[str, Any] = {
         "frames_per_second": round(fps, 3),
         "seed": seed,
         "n_frames_warm_window": n_warm,
@@ -176,24 +235,32 @@ def run_baseline(
         "data_stall_pct": round(data_stall_pct, 2),
         "sync_stall_pct": round(sync_stall_pct, 2),
         "cpu_pct": round(cpu_pct, 2),
-        "nvml_mean_util_pct": round(nvml_mean, 2) if nvml_mean is not None else None,
+        **headroom_dict,
         "total_detections": total_detections,
         "elapsed_s": round(elapsed, 3),
         "hostname": socket.gethostname(),
         "python": platform.python_version(),
         "cfg_path": str(cfg_path),
         "ckpt_path": str(ckpt_path),
-        "manifest_path": str(manifest_path),
+        "data_root": str(data_root),
         "captured_at_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
 
     output_path.write_text(json.dumps(output, indent=2))
-    print(f"\nResult: {fps:.1f} fps | GPU active {gpu_active_pct:.1f}% | wrote {output_path}")
-
-    if nvml_mean is not None and nvml_mean > 85.0:
+    print(
+        f"\nResult: {fps:.1f} fps | GPU active {gpu_active_pct:.1f}% "
+        f"| data stall {data_stall_pct:.1f}% | wrote {output_path}"
+    )
+    if headroom_dict:
         print(
-            f"\nWARNING: NVML util={nvml_mean:.1f}% > 85% — flag Adit: workload may be "
-            "near-saturated. Consider the 500-frame fallback."
+            f"Headroom: compute {headroom_dict['compute_headroom_pct']:.1f}% free "
+            f"| mem {headroom_dict['mem_free_at_peak_gb']:.1f} GB free at peak"
+        )
+
+    if headroom_dict.get("mean_util_pct", 0) > 85.0:
+        print(
+            f"\nWARNING: NVML util={headroom_dict['mean_util_pct']:.1f}% > 85% — "
+            "flag Adit: workload may be near-saturated. Consider the 500-frame fallback."
         )
 
     return output
@@ -219,8 +286,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run one KITTI PointPillars baseline.")
     parser.add_argument("--cfg", required=True, help="OpenPCDet config .yaml path.")
     parser.add_argument("--ckpt", required=True, help="PointPillars checkpoint .pth path.")
-    parser.add_argument("--seed", type=int, default=42, help="Random seed (42/43/44).")
-    parser.add_argument("--frames", type=int, default=7481, help="Frames in warm window.")
+    parser.add_argument(
+        "--data-root",
+        default=os.environ.get("GITM_DATA_ROOT"),
+        help="GITM_DATA_ROOT — root of kitti/training/velodyne/. "
+             "Defaults to $GITM_DATA_ROOT env var.",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--frames", type=int, default=7481, help="Frames to process.")
     parser.add_argument("--output", required=True, help="Output .json path.")
     parser.add_argument(
         "--check-convergence",
@@ -230,12 +303,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if not args.data_root:
+        parser.error("--data-root is required (or set GITM_DATA_ROOT env var)")
+
     run_baseline(
         cfg_path=args.cfg,
         ckpt_path=args.ckpt,
         seed=args.seed,
         n_frames=args.frames,
         output_path=args.output,
+        data_root=args.data_root,
     )
 
     if args.check_convergence:

--- a/gitm/benchmarks/kitti/workunit.py
+++ b/gitm/benchmarks/kitti/workunit.py
@@ -30,12 +30,10 @@ from typing import Any
 
 # SHA256 of pointpillar_7728.pth (OpenPCDet KITTI PointPillars checkpoint).
 # Confirm with: sha256sum pointpillar_7728.pth
-CHECKPOINT_SHA256 = "c9c84e5cf1059b84fb37a4d47f8e58fc16b22e2c3e9ddf47ed59700d7b0e9ccd"
+CHECKPOINT_SHA256 = "4c83fc0fa02575b9b3e9dec676f698e7a70bb5a795e89f91df8a96b916fa19e2"
 
-# SHA256 of the pinned tools/cfgs/kitti_models/pointpillar.yaml.
-# Fill in after cloning OpenPCDet at the pinned commit:
-#   sha256sum tools/cfgs/kitti_models/pointpillar.yaml
-CONFIG_SHA256 = ""
+# sha256sum tools/cfgs/kitti_models/pointpillar.yaml (pinned commit 233f849)
+CONFIG_SHA256 = "170a9ffe76cfd8509d1044cfbcf1cbd44c5d320fda81bf0089a8d5efaf1c91c8"
 
 
 @dataclass

--- a/gitm/planner/kitti_graph.py
+++ b/gitm/planner/kitti_graph.py
@@ -1,0 +1,261 @@
+"""Predicted execution graph for PointPillars on KITTI.
+
+Models the 4-stage PointPillars pipeline as roofline nodes on the GPU,
+then annotates CPU-bound stages (load, voxelization, NMS) that the roofline
+does not cover. The gap between total predicted GPU time and actual measured
+frame time is the CPU overhead the stream-concurrency invariant targets.
+
+Usage::
+
+    from gitm.planner.kitti_graph import predict_kitti_graph, render_kitti_graph
+    from gitm.planner.roofline import HardwareSpec
+
+    hw = HardwareSpec()  # defaults to A100-SXM4-80GB
+    graph = predict_kitti_graph(hw=hw)
+    print(render_kitti_graph(graph))
+
+    # Compare against a measured baseline JSON:
+    import json
+    baseline = json.loads(Path("kitti_baseline_1.json").read_text())
+    print(render_kitti_graph(graph, measured=baseline))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from gitm.planner.roofline import HardwareSpec, RooflinePrediction, roofline
+
+
+# ── PointPillars KITTI frame shape constants ──────────────────────────────────
+# Based on OpenPCDet pointpillar.yaml (kitti_models) defaults.
+# These are per-frame averages; real variance is captured in stage_spread.
+
+_MEAN_POINTS_PER_FRAME = 15_000       # typical KITTI Velodyne points
+_MAX_PILLARS          = 12_000        # DATA_PROCESSOR max_number_of_voxels (train)
+_MAX_POINTS_PER_PILLAR = 100          # max_points_per_voxel
+_PILLAR_FEATURES       = 10           # NUM_POINT_FEATURES after augmentation
+_VFE_OUT_CHANNELS      = 64           # PillarVFE output channels
+_BEV_H, _BEV_W         = 248, 216     # BEV feature map size (after stride-2 conv)
+_BACKBONE_CHANNELS     = 64           # initial 2D backbone channels
+_HEAD_ANCHORS          = 70400        # SSD-style anchor grid (KITTI default)
+_NUM_CLASSES           = 3            # Car, Pedestrian, Cyclist
+_DTYPE_BYTES           = 4            # float32
+
+
+@dataclass
+class KittiNode:
+    """One pipeline stage — GPU-side stages get a roofline prediction."""
+    name: str
+    device: str          # "gpu" | "cpu" | "pcie"
+    prediction: RooflinePrediction | None = None
+    note: str = ""
+    expected_stream_id: int = 0  # -1 for CPU, 0+ for CUDA streams
+
+
+@dataclass
+class KittiGraph:
+    hw: HardwareSpec
+    nodes: list[KittiNode] = field(default_factory=list)
+
+    @property
+    def total_gpu_pred_ms(self) -> float:
+        return sum(
+            n.prediction.t_pred_s * 1000
+            for n in self.nodes
+            if n.prediction is not None
+        )
+
+    @property
+    def total_pcie_pred_ms(self) -> float:
+        return sum(
+            n.prediction.t_pred_s * 1000
+            for n in self.nodes
+            if n.device == "pcie" and n.prediction is not None
+        )
+
+
+def predict_kitti_graph(hw: HardwareSpec | None = None) -> KittiGraph:
+    """Return a predicted execution graph for one PointPillars KITTI frame.
+
+    GPU stages use the roofline model (max of compute-bound and memory-bound).
+    CPU stages are annotated but not predicted — they depend on the host CPU
+    and are measured directly by WorkUnit.
+
+    The stream-concurrency invariant predicts that voxelization (CPU, stream=-1)
+    for frame N+1 should overlap backbone inference (GPU, stream=0) for frame N.
+    The graph makes this expectation explicit via expected_stream_id.
+    """
+    hw = hw or HardwareSpec()
+    g = KittiGraph(hw=hw)
+
+    # Stage 1: Load .bin from disk (CPU / I/O — not modeled by roofline)
+    g.nodes.append(KittiNode(
+        name="load_bin",
+        device="cpu",
+        note="np.fromfile: ~15k points x 4 float32 = ~240 KB I/O. Not roofline-modeled.",
+        expected_stream_id=-1,
+    ))
+
+    # Stage 2: Voxelization (CPU — scatter 15k points into 12k pillars)
+    # Memory: read points (15k x 10 x 4B = 600KB) + write pillar buffer
+    # (12k pillars x 100 pts x 10 feat x 4B = ~48 MB). Memory-bound on CPU.
+    g.nodes.append(KittiNode(
+        name="voxelization",
+        device="cpu",
+        note="Host-side scatter into voxel grid. CPU memory-bound. ~48 MB writes.",
+        expected_stream_id=-1,  # CPU thread — overlaps GPU stream 0 (stream-concurrency invariant)
+    ))
+
+    # Stage 3: H2D copy (PCIe — pillar features host -> device)
+    # Bytes: max_pillars x max_pts_per_pillar x features x float32
+    h2d_bytes = _MAX_PILLARS * _MAX_POINTS_PER_PILLAR * _PILLAR_FEATURES * _DTYPE_BYTES
+    # PCIe Gen4 x16 peak: ~32 GB/s; use conservative 20 GB/s effective
+    pcie_bw = 20e9
+    g.nodes.append(KittiNode(
+        name="h2d_copy",
+        device="pcie",
+        prediction=RooflinePrediction(
+            op="h2d_copy",
+            flops=0,
+            bytes=h2d_bytes,
+            t_compute_s=0.0,
+            t_memory_s=h2d_bytes / pcie_bw,
+            t_pred_s=h2d_bytes / pcie_bw,
+            bound="memory",
+        ),
+        note=f"pillar features: {h2d_bytes / 1e6:.1f} MB @ ~20 GB/s PCIe",
+        expected_stream_id=0,
+    ))
+
+    # Stage 4: Pillar Feature Encoder / VFE (GPU)
+    # Linear: (max_pts_per_pillar x pillar_features) -> vfe_out per pillar
+    # FLOPs: 2 x active_pillars x max_pts_per_pillar x pillar_features x vfe_out
+    # (~12k active pillars in practice; use max_pillars as upper bound)
+    vfe_flops = 2 * _MAX_PILLARS * _MAX_POINTS_PER_PILLAR * _PILLAR_FEATURES * _VFE_OUT_CHANNELS
+    vfe_bytes = _DTYPE_BYTES * (
+        _MAX_PILLARS * _MAX_POINTS_PER_PILLAR * _PILLAR_FEATURES   # input
+        + _PILLAR_FEATURES * _VFE_OUT_CHANNELS                      # weight
+        + _MAX_PILLARS * _VFE_OUT_CHANNELS                          # output
+    )
+    g.nodes.append(KittiNode(
+        name="pillar_vfe",
+        device="gpu",
+        prediction=roofline("pillar_vfe", vfe_flops, vfe_bytes, hw, dtype="fp32"),
+        note="PointPillar feature encoder: linear + BN + ReLU per pillar",
+        expected_stream_id=0,
+    ))
+
+    # Stage 5: BEV scatter (GPU — pillar features -> spatial BEV grid)
+    # Scatter write: max_pillars x vfe_out -> bev_h x bev_w x vfe_out
+    # Essentially a gather/scatter; compute is trivial, memory dominates.
+    bev_scatter_bytes = _DTYPE_BYTES * (
+        _MAX_PILLARS * _VFE_OUT_CHANNELS                   # read pillar features
+        + _BEV_H * _BEV_W * 2 * _VFE_OUT_CHANNELS         # write BEV (2 strides)
+    )
+    g.nodes.append(KittiNode(
+        name="bev_scatter",
+        device="gpu",
+        prediction=roofline("bev_scatter", 0, bev_scatter_bytes, hw, dtype="fp32"),
+        note="Scatter pillar features -> 2D BEV pseudo-image",
+        expected_stream_id=0,
+    ))
+
+    # Stage 6: 2D Backbone CNN (GPU)
+    # Simplified estimate for PointPillars backbone (3 conv blocks, ~6 GFLOPs total)
+    # BEV input: (BEV_H x BEV_W x VFE_OUT) processed through strided convolutions.
+    # FLOPs dominated by early layers (large spatial, many channels).
+    # Rough estimate: 6 GFLOP for KITTI resolution (published benchmarks).
+    backbone_flops = 6e9
+    # Activations: ~4 layers with growing channels, total ~300 MB
+    backbone_bytes = 300e6
+    g.nodes.append(KittiNode(
+        name="backbone_2d",
+        device="gpu",
+        prediction=roofline("backbone_2d", backbone_flops, backbone_bytes, hw, dtype="fp32"),
+        note="Strided 2D CNN: 3 blocks, progressively downsampled BEV features",
+        expected_stream_id=0,
+    ))
+
+    # Stage 7: Detection head (GPU — anchor-based classification + regression)
+    # FLOPs: 2 x head_anchors x (channels_in x num_classes + channels_in x 7_box)
+    head_flops = 2 * _HEAD_ANCHORS * _BACKBONE_CHANNELS * (_NUM_CLASSES + 7)
+    head_bytes = _DTYPE_BYTES * (
+        _HEAD_ANCHORS * _BACKBONE_CHANNELS   # input activations
+        + _BACKBONE_CHANNELS * (_NUM_CLASSES + 7) * 2  # cls + reg weights (conv1x1)
+        + _HEAD_ANCHORS * (_NUM_CLASSES + 7)  # output
+    )
+    g.nodes.append(KittiNode(
+        name="detection_head",
+        device="gpu",
+        prediction=roofline("detection_head", head_flops, head_bytes, hw, dtype="fp32"),
+        note="SSD-style anchor cls + box regression, 1x1 conv",
+        expected_stream_id=0,
+    ))
+
+    # Stage 8: NMS (CPU — CPU-accelerated iou3d_nms_cuda is a separate CUDA kernel
+    # but serialized against the backbone stream via CPU synchronization)
+    g.nodes.append(KittiNode(
+        name="nms",
+        device="cpu",
+        note="iou3d_nms_cuda: box decode + IoU matrix + suppression. CPU-sync stall.",
+        expected_stream_id=-1,
+    ))
+
+    return g
+
+
+def render_kitti_graph(
+    graph: KittiGraph,
+    measured: dict | None = None,
+) -> str:
+    """Human-readable predicted execution graph, optionally compared to measured.
+
+    Args:
+        graph:    From predict_kitti_graph().
+        measured: Optional baseline JSON dict (from run_baseline()) for comparison.
+    """
+    hw = graph.hw
+    lines = [
+        f"PointPillars predicted execution graph ({hw.name})",
+        f"  peak FLOPS (fp32): {hw.peak_flops_fp32_per_s/1e12:.1f} TFLOP/s",
+        f"  peak HBM BW:       {hw.peak_mem_bw_bytes_per_s/1e9:.0f} GB/s",
+        "",
+    ]
+
+    hdr = f"{'stage':<20} {'device':<6} {'pred_ms':>9} {'bound':<8} note"
+    lines += [hdr, "-" * 80]
+
+    for node in graph.nodes:
+        pred_ms = f"{node.prediction.t_pred_s * 1000:.3f}" if node.prediction else "N/A (CPU)"
+        bound = node.prediction.bound if node.prediction else "--"
+        lines.append(
+            f"{node.name:<20} {node.device:<6} {pred_ms:>9} {bound:<8} {node.note[:50]}"
+        )
+
+    lines += [
+        "-" * 80,
+        f"{'total GPU pred':>26}: {graph.total_gpu_pred_ms:.3f} ms",
+        f"{'PCIe H2D pred':>26}: {graph.total_pcie_pred_ms:.3f} ms",
+    ]
+
+    if measured:
+        fps      = measured.get("frames_per_second", 0)
+        frame_ms = 1000 / fps if fps > 0 else 0
+        gpu_pct  = measured.get("gpu_active_pct", 0)
+        data_pct = measured.get("data_stall_pct", 0)
+        lines += [
+            "",
+            "Measured (baseline):",
+            f"  frame time:   {frame_ms:.1f} ms  ({fps:.1f} fps)",
+            f"  GPU active:   {frame_ms * gpu_pct / 100:.1f} ms  ({gpu_pct:.1f}%)",
+            f"  data stall:   {frame_ms * data_pct / 100:.1f} ms  ({data_pct:.1f}%)",
+            "",
+            f"  Roofline predicts {graph.total_gpu_pred_ms:.1f} ms GPU time.",
+            f"  Actual GPU active is {frame_ms * gpu_pct / 100:.1f} ms "
+            f"({'FASTER' if frame_ms * gpu_pct / 100 < graph.total_gpu_pred_ms else 'SLOWER'} than roofline).",
+            f"  Remaining {frame_ms * (100 - gpu_pct) / 100:.1f} ms ({100 - gpu_pct:.1f}%) is",
+            "  CPU overhead (voxelization + NMS) -- the stream-concurrency invariant target.",
+        ]
+
+    return "\n".join(lines)

--- a/harness/fill_results.py
+++ b/harness/fill_results.py
@@ -1,0 +1,301 @@
+"""Auto-fill benchmarks/kitti/spec.md and results.md from baseline JSON outputs.
+
+Run after all baseline seeds complete:
+
+    python harness/fill_results.py
+    # or with explicit path:
+    GITM_DATA_ROOT=/workspace/edge python harness/fill_results.py
+
+Reads $GITM_DATA_ROOT/runs/kitti_baseline_{1..6}.json and replaces every TBD
+field in spec.md and results.md with measured values. Prints a diff summary
+so you can review before committing.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC_PATH = REPO_ROOT / "benchmarks" / "kitti" / "spec.md"
+RESULTS_PATH = REPO_ROOT / "benchmarks" / "kitti" / "results.md"
+
+
+def _load_runs(runs_dir: Path, n_seeds: int = 6) -> list[dict]:
+    runs = []
+    for i in range(1, n_seeds + 1):
+        p = runs_dir / f"kitti_baseline_{i}.json"
+        if not p.exists():
+            print(f"  WARNING: {p} not found — skipping", file=sys.stderr)
+            continue
+        with p.open() as f:
+            runs.append(json.load(f))
+    return runs
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _std(xs: list[float]) -> float:
+    if len(xs) < 2:
+        return 0.0
+    m = _mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (len(xs) - 1))
+
+
+def _fmt(v: float | None, decimals: int = 2) -> str:
+    if v is None:
+        return "N/A"
+    return f"{v:.{decimals}f}"
+
+
+def _spread(fps_vals: list[float]) -> float:
+    if len(fps_vals) < 2:
+        return 0.0
+    return (max(fps_vals) - min(fps_vals)) / max(fps_vals) * 100
+
+
+def build_summary(runs: list[dict]) -> dict:
+    seeds      = [r["seed"] for r in runs]
+    fps        = [r["frames_per_second"] for r in runs]
+    gpu_pct    = [r["gpu_active_pct"] for r in runs]
+    data_pct   = [r["data_stall_pct"] for r in runs]
+    sync_pct   = [r["sync_stall_pct"] for r in runs]
+    cpu_pct    = [r["cpu_pct"] for r in runs]
+    headroom   = [r.get("compute_headroom_pct") for r in runs]
+    mem_free   = [r.get("mem_free_at_peak_gb") for r in runs]
+
+    spread_pct = _spread(fps)
+
+    # Per-seed rows
+    rows = []
+    for r in runs:
+        rows.append({
+            "seed": r["seed"],
+            "fps": r["frames_per_second"],
+            "gpu_pct": r["gpu_active_pct"],
+            "data_pct": r["data_stall_pct"],
+            "sync_pct": r["sync_stall_pct"],
+            "cpu_pct": r["cpu_pct"],
+            "headroom_pct": r.get("compute_headroom_pct"),
+        })
+
+    # Stage spread from first run (representative)
+    stage_spread = runs[0].get("stage_spread", {}) if runs else {}
+
+    # Environment from first run
+    env = runs[0] if runs else {}
+
+    return {
+        "seeds": seeds,
+        "rows": rows,
+        "mean_fps": _mean(fps),
+        "std_fps": _std(fps),
+        "mean_gpu": _mean(gpu_pct),
+        "std_gpu": _std(gpu_pct),
+        "mean_data": _mean(data_pct),
+        "std_data": _std(data_pct),
+        "mean_sync": _mean(sync_pct),
+        "std_sync": _std(sync_pct),
+        "mean_cpu": _mean(cpu_pct),
+        "std_cpu": _std(cpu_pct),
+        "spread_pct": spread_pct,
+        "converged": spread_pct <= 2.0,
+        "mean_headroom": _mean([h for h in headroom if h is not None]) if any(h is not None for h in headroom) else None,
+        "mean_mem_free": _mean([m for m in mem_free if m is not None]) if any(m is not None for m in mem_free) else None,
+        "stage_spread": stage_spread,
+        "hostname": env.get("hostname", "TBD"),
+        "date": env.get("captured_at_iso", "TBD")[:10] if env.get("captured_at_iso") else "TBD",
+    }
+
+
+def _update_spec(path: Path, s: dict) -> str:
+    text = path.read_text()
+
+    # Build 6-seed table rows
+    def row(r: dict) -> str:
+        h = _fmt(r.get("headroom_pct"))
+        return (
+            f"| {r['seed']}   | {_fmt(r['fps'])} | {_fmt(r['gpu_pct'])}          "
+            f"| {_fmt(r['data_pct'])}         | {_fmt(r['sync_pct'])}    "
+            f"| {_fmt(r['cpu_pct'])}   | {h}               |"
+        )
+
+    seed_rows_new = "\n".join(row(r) for r in s["rows"])
+    mean_row = (
+        f"| Mean | {_fmt(s['mean_fps'])} | {_fmt(s['mean_gpu'])}          "
+        f"| {_fmt(s['mean_data'])}         | {_fmt(s['mean_sync'])}    "
+        f"| {_fmt(s['mean_cpu'])}   | {_fmt(s['mean_headroom'])}               |"
+    )
+    std_row = (
+        f"| Stddev | {_fmt(s['std_fps'])} | {_fmt(s['std_gpu'])}          "
+        f"| {_fmt(s['std_data'])}         | {_fmt(s['std_sync'])}    "
+        f"| {_fmt(s['std_cpu'])}   | --                |"
+    )
+
+    # Replace seed rows individually
+    for r in s["rows"]:
+        seed = r["seed"]
+        h = _fmt(r.get("headroom_pct"))
+        new_row = (
+            f"| {seed}   | {_fmt(r['fps'])} | {_fmt(r['gpu_pct'])}          "
+            f"| {_fmt(r['data_pct'])}         | {_fmt(r['sync_pct'])}    "
+            f"| {_fmt(r['cpu_pct'])}   | {h}               |"
+        )
+        text = re.sub(
+            rf"\| {seed}\s+\| TBD.*?\|",
+            new_row,
+            text,
+        )
+
+    # Mean + stddev rows
+    text = re.sub(r"\| Mean \| TBD.*?\|", mean_row, text)
+    text = re.sub(r"\| Stddev \| TBD.*?\|", std_row, text)
+
+    # Spread line
+    conv = "YES" if s["converged"] else "NO"
+    text = text.replace(
+        "6-seed fps spread: TBD -- within 2%: TBD",
+        f"6-seed fps spread: {_fmt(s['spread_pct'])}% -- within 2%: {conv}",
+    )
+
+    # GPU headroom table rows
+    if s["mean_headroom"] is not None:
+        text = text.replace(
+            "| Compute headroom (100 - mean util) | >35% | TBD |",
+            f"| Compute headroom (100 - mean util) | >35% | {_fmt(s['mean_headroom'])}% |",
+        )
+    if s["mean_mem_free"] is not None:
+        text = text.replace(
+            "| Memory free at peak | >10 GB | TBD |",
+            f"| Memory free at peak | >10 GB | {_fmt(s['mean_mem_free'], 1)} GB |",
+        )
+
+    # Stage spread table
+    ss = s.get("stage_spread", {})
+    for stage_key, stage_label in [
+        ("load", "load"),
+        ("preprocess", "preprocess (voxelize + H2D)"),
+        ("inference", "inference (backbone + BEV + NMS)"),
+        ("postprocess", "postprocess (D2H)"),
+    ]:
+        st = ss.get(stage_key, {})
+        if st:
+            text = text.replace(
+                f"| {stage_label}  | TBD | TBD | TBD | TBD |",
+                f"| {stage_label}  | {st.get('mean_ms', 0):.1f} | {st.get('p50_ms', 0):.1f} | {st.get('p95_ms', 0):.1f} | {st.get('mean_pct', 0):.1f}% |",
+            )
+
+    # Environment
+    text = text.replace("- GPU: TBD", f"- GPU: TBD (check nvidia-smi on pod)")
+    text = text.replace("- Driver: TBD", f"- Driver: TBD (check nvidia-smi)")
+    text = text.replace("- CUDA: TBD", f"- CUDA: TBD (check nvcc --version)")
+    text = text.replace("- Date: TBD", f"- Date: {s['date']}")
+
+    return text
+
+
+def _update_results(path: Path, s: dict) -> str:
+    text = path.read_text()
+
+    for r in s["rows"]:
+        seed = r["seed"]
+        h = _fmt(r.get("headroom_pct"))
+        new_row = (
+            f"| Baseline {s['rows'].index(r)+1} | {seed} | {_fmt(r['fps'])} "
+            f"| {_fmt(r['gpu_pct'])} | {_fmt(r['data_pct'])} "
+            f"| {_fmt(r['sync_pct'])} | {_fmt(r['cpu_pct'])} | {h} |"
+        )
+        text = re.sub(
+            rf"\| Baseline {s['rows'].index(r)+1} \| {seed} \| TBD.*?\|",
+            new_row,
+            text,
+        )
+
+    mean_row = (
+        f"| Mean | -- | {_fmt(s['mean_fps'])} | {_fmt(s['mean_gpu'])} "
+        f"| {_fmt(s['mean_data'])} | {_fmt(s['mean_sync'])} | {_fmt(s['mean_cpu'])} "
+        f"| {_fmt(s['mean_headroom'])} |"
+    )
+    std_row = (
+        f"| Stddev | -- | {_fmt(s['std_fps'])} | {_fmt(s['std_gpu'])} "
+        f"| {_fmt(s['std_data'])} | {_fmt(s['std_sync'])} | {_fmt(s['std_cpu'])} | -- |"
+    )
+    text = re.sub(r"\| Mean \| -- \| TBD.*?\|", mean_row, text)
+    text = re.sub(r"\| Stddev \| -- \| TBD.*?\|", std_row, text)
+
+    conv = "YES" if s["converged"] else "NO"
+    text = text.replace(
+        "6-seed fps spread: TBD% -- within 2%: TBD",
+        f"6-seed fps spread: {_fmt(s['spread_pct'])}% -- within 2%: {conv}",
+    )
+    if s["mean_headroom"] is not None:
+        text = text.replace(
+            "GPU headroom (compute_headroom_pct = 100 - mean NVML util): TBD%",
+            f"GPU headroom (compute_headroom_pct = 100 - mean NVML util): {_fmt(s['mean_headroom'])}%",
+        )
+    if s["mean_mem_free"] is not None:
+        text = text.replace(
+            "Memory free at peak: TBD GB",
+            f"Memory free at peak: {_fmt(s['mean_mem_free'], 1)} GB",
+        )
+
+    text = text.replace(
+        "- Machine: RunPod y4xbh7yws2e4tu-64410cb0",
+        f"- Machine: RunPod y4xbh7yws2e4tu-64410cb0 ({s['hostname']})",
+    )
+    text = text.replace("- Date: TBD", f"- Date: {s['date']}")
+
+    return text
+
+
+def main() -> int:
+    data_root = os.environ.get("GITM_DATA_ROOT", "/workspace/edge")
+    runs_dir = Path(data_root) / "runs"
+
+    print(f"Reading baselines from {runs_dir} …")
+    runs = _load_runs(runs_dir)
+
+    if not runs:
+        print("ERROR: no baseline JSON files found.", file=sys.stderr)
+        print(f"  Expected: {runs_dir}/kitti_baseline_1.json … kitti_baseline_6.json", file=sys.stderr)
+        return 1
+
+    print(f"  Loaded {len(runs)} run(s).")
+    s = build_summary(runs)
+
+    print()
+    print(f"  fps: {' | '.join(_fmt(r['fps']) for r in s['rows'])}")
+    print(f"  spread: {_fmt(s['spread_pct'])}%  ({'PASS' if s['converged'] else 'FAIL'})")
+    if s["mean_headroom"] is not None:
+        print(f"  compute headroom: {_fmt(s['mean_headroom'])}%")
+
+    # Update spec.md
+    spec_new = _update_spec(SPEC_PATH, s)
+    SPEC_PATH.write_text(spec_new)
+    print(f"\n  Updated: {SPEC_PATH}")
+
+    # Update results.md
+    results_new = _update_results(RESULTS_PATH, s)
+    RESULTS_PATH.write_text(results_new)
+    print(f"  Updated: {RESULTS_PATH}")
+
+    print()
+    if s["converged"]:
+        print("Convergence PASS. Commit and open PR:")
+        print("  git add benchmarks/kitti/manifest.yaml benchmarks/kitti/spec.md benchmarks/kitti/results.md")
+        print("  git commit -m 'KITTI: fill measured baseline numbers'")
+        print("  git push")
+    else:
+        print(f"WARNING: convergence FAIL — spread {_fmt(s['spread_pct'])}% > 2%. Flag Adit.")
+
+    return 0 if s["converged"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -104,7 +104,8 @@ fi
 # ── 3. Install gitm package ──────────────────────────────────────────────────
 
 step "Installing gitm package ..."
-pip install -e "$REPO_ROOT[dev,bench,nvidia]" --no-build-isolation -q
+pip install hatchling -q   # build backend required by pyproject.toml
+pip install -e "$REPO_ROOT[dev,bench,nvidia]" -q
 echo "  gitm package installed."
 
 # ── 4. Pull + verify checkpoint ─────────────────────────────────────────────

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -91,15 +91,13 @@ fi
 
 pip install -r "$OPENPCDET_DIR/requirements.txt" -q
 
-# Check if pcdet is already importable; if so, skip the editable install.
-if python -c "import pcdet; print('  pcdet', pcdet.__version__, 'already installed')" 2>/dev/null; then
-  echo "  OpenPCDet already installed -- skipping editable install"
-else
-  # --no-build-isolation lets setup.py see the pre-installed torch so the
-  # CUDA version check in setup.py does not fail with ModuleNotFoundError.
-  echo "  pip install -e OpenPCDet (no-build-isolation) ..."
-  pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
-fi
+# Always install from OPENPCDET_DIR so pcdet CUDA extensions (.so files) are
+# built from this exact path. A stale editable install from a prior session
+# at a different path will pass "import pcdet" but fail at model load time.
+# If extensions are already compiled, setup.py skips recompilation (~30s).
+echo "  pip install -e OpenPCDet (no-build-isolation) ..."
+pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
+python -c "import pcdet; print('  pcdet', pcdet.__version__, 'ready')"
 
 # ── 3. Install gitm package ──────────────────────────────────────────────────
 

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# One-shot KITTI benchmark setup + baseline run for a fresh RunPod pod.
+#
+# Run AFTER kitti data is downloaded (fetch.py --step kitti already ran).
+# Checks the download is complete, sets up OpenPCDet, generates the manifest,
+# runs 6-seed baselines, and prints a convergence summary.
+#
+# Usage (from /workspace/runtime on the RunPod pod):
+#   bash harness/pod_setup_and_run.sh
+#
+# Override defaults:
+#   GITM_DATA_ROOT=/workspace/edge bash harness/pod_setup_and_run.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GITM_DATA_ROOT="${GITM_DATA_ROOT:-/workspace/edge}"
+OPENPCDET_DIR="${OPENPCDET_DIR:-/workspace/edge/OpenPCDet}"
+CKPT_DIR="${CKPT_DIR:-$GITM_DATA_ROOT/checkpoints/kitti}"
+CKPT_PATH="$CKPT_DIR/pointpillar_7728.pth"
+CKPT_URL="${CKPT_URL:-}"
+
+CFG_PATH="$OPENPCDET_DIR/tools/cfgs/kitti_models/pointpillar.yaml"
+KITTI_VELODYNE="$GITM_DATA_ROOT/kitti/training/velodyne"
+EXPECTED_FRAMES=7481
+EXPECTED_CKPT_SHA="4c83fc0fa02575b9b3e9dec676f698e7a70bb5a795e89f91df8a96b916fa19e2"
+
+step() { echo ""; echo "==> $*"; }
+
+# ── 1. Verify KITTI data ────────────────────────────────────────────────────
+
+step "Checking KITTI data at $KITTI_VELODYNE …"
+if [ ! -d "$KITTI_VELODYNE" ]; then
+  echo "ERROR: KITTI velodyne dir not found: $KITTI_VELODYNE" >&2
+  echo "  Run first: python $REPO_ROOT/benchmarks/edge/fetch.py --step kitti --out $GITM_DATA_ROOT" >&2
+  exit 1
+fi
+n_bins=$(find "$KITTI_VELODYNE" -name "*.bin" | wc -l)
+if [ "$n_bins" -lt "$EXPECTED_FRAMES" ]; then
+  echo "ERROR: only $n_bins .bin files found (expected $EXPECTED_FRAMES). Download still running?" >&2
+  exit 1
+fi
+echo "  KITTI: $n_bins frames found OK"
+
+# ── 2. Clone + install OpenPCDet (pinned commit) ────────────────────────────
+
+PINNED_COMMIT="233f849829b6ac19afb8af8837a0246890908755"
+
+step "Setting up OpenPCDet …"
+if [ ! -d "$OPENPCDET_DIR/.git" ]; then
+  echo "  Cloning OpenPCDet …"
+  git clone https://github.com/open-mmlab/OpenPCDet.git "$OPENPCDET_DIR"
+fi
+
+actual_commit=$(git -C "$OPENPCDET_DIR" rev-parse HEAD)
+if [ "$actual_commit" != "$PINNED_COMMIT" ]; then
+  echo "  Pinning to commit $PINNED_COMMIT …"
+  git -C "$OPENPCDET_DIR" checkout "$PINNED_COMMIT"
+fi
+echo "  OpenPCDet at $PINNED_COMMIT"
+
+step "Installing PyTorch + OpenPCDet deps …"
+pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cu124 -q
+pip install spconv-cu124 -q
+pip install -r "$OPENPCDET_DIR/requirements.txt" -q
+pip install -e "$OPENPCDET_DIR" -q
+
+step "Installing gitm package …"
+pip install -e "$REPO_ROOT[dev,bench,nvidia]" -q
+
+# ── 3. Pull + verify checkpoint ──────────────────────────────────────────────
+
+step "Checking checkpoint …"
+mkdir -p "$CKPT_DIR"
+if [ ! -f "$CKPT_PATH" ]; then
+  if [ -z "$CKPT_URL" ]; then
+    echo "ERROR: checkpoint not found and CKPT_URL is not set." >&2
+    echo "  Download manually or set CKPT_URL to the pre-signed URL from Adit." >&2
+    echo "  Checkpoint: https://drive.google.com/file/d/1wMxWTpU1qUoY3DsCH31WJmvJxcjFXKlm" >&2
+    exit 1
+  fi
+  echo "  Downloading checkpoint …"
+  curl -L "$CKPT_URL" -o "$CKPT_PATH"
+fi
+actual_sha=$(sha256sum "$CKPT_PATH" | awk '{print $1}')
+if [ "$actual_sha" != "$EXPECTED_CKPT_SHA" ]; then
+  echo "ERROR: checkpoint sha256 mismatch" >&2
+  echo "  expected: $EXPECTED_CKPT_SHA" >&2
+  echo "  actual:   $actual_sha" >&2
+  exit 1
+fi
+echo "  Checkpoint sha256 OK"
+
+# ── 4. Generate sha256 manifest ──────────────────────────────────────────────
+
+step "Generating sha256 manifest …"
+python "$REPO_ROOT/harness/gen_kitti_manifest.py" \
+  --root "$GITM_DATA_ROOT/kitti/training" \
+  --out  "$REPO_ROOT/benchmarks/kitti/manifest.yaml"
+echo "  Manifest written."
+
+step "Verifying manifest (fast mode) …"
+python "$REPO_ROOT/harness/verify_manifest.py" --fast
+echo "  Manifest verified."
+
+# ── 5. Smoke test ────────────────────────────────────────────────────────────
+
+step "Smoke test (10 frames) …"
+export GITM_DATA_ROOT OPENPCDET_CFG="$CFG_PATH" OPENPCDET_CKPT="$CKPT_PATH"
+python "$REPO_ROOT/harness/smoke_kitti.py" \
+  --cfg "$CFG_PATH" --ckpt "$CKPT_PATH" --n-frames 10
+echo "  Smoke test passed."
+
+# ── 6. Run 6-seed baselines ──────────────────────────────────────────────────
+
+step "Running 6-seed baselines (this takes ~1 hour) …"
+GITM_DATA_ROOT="$GITM_DATA_ROOT" \
+OPENPCDET_CFG="$CFG_PATH" \
+OPENPCDET_CKPT="$CKPT_PATH" \
+  bash "$REPO_ROOT/harness/run_baselines.sh"
+
+# ── 7. Remind: commit results ────────────────────────────────────────────────
+
+echo ""
+echo "================================================================"
+echo "  All done. Fill measured numbers into:"
+echo "    benchmarks/kitti/spec.md    (Section 3 + 5 tables)"
+echo "    benchmarks/kitti/results.md (baseline table)"
+echo ""
+echo "  Then commit and push:"
+echo "    git add benchmarks/kitti/manifest.yaml benchmarks/kitti/spec.md benchmarks/kitti/results.md"
+echo "    git commit -m 'KITTI: fill measured baseline numbers'"
+echo "    git push"
+echo "================================================================"

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -73,20 +73,33 @@ step "Installing OpenPCDet deps ..."
 # on the pod. Installing a mismatched torch breaks torchaudio/torchvision.
 python -c "import torch; print('  torch', torch.__version__, '| CUDA', torch.version.cuda)"
 
-# spconv: pick wheel matching the pod's CUDA version (12.x -> cu120 or cu121)
-CUDA_SHORT=$(python -c "import torch; v=torch.version.cuda or '12.0'; print(''.join(v.split('.')[:2]))" 2>/dev/null || echo "120")
-echo "  Installing spconv-cu${CUDA_SHORT} ..."
-pip install spconv-cu"${CUDA_SHORT}" -q 2>/dev/null || {
-  echo "  spconv-cu${CUDA_SHORT} not found, falling back to spconv-cu120 ..."
-  pip install spconv-cu120 -q
-}
+# spconv: check if already importable (pod may have it from prior work), else
+# try versioned wheels newest-to-oldest, fall back to building from source.
+# spconv does not publish cu128 wheels; cu122 is the closest and is ABI-compatible
+# with CUDA 12.x when torch is pre-installed.
+if python -c "import spconv; print('  spconv', spconv.__version__, 'already installed')" 2>/dev/null; then
+  echo "  spconv already present -- skipping install"
+else
+  echo "  Installing spconv (trying pre-built wheels then source) ..."
+  pip install spconv-cu122 -q 2>/dev/null || \
+  pip install spconv-cu121 -q 2>/dev/null || \
+  pip install spconv-cu118 -q 2>/dev/null || {
+    echo "  No pre-built wheel found -- building spconv from source (~10 min) ..."
+    pip install "spconv @ git+https://github.com/traveller59/spconv.git@v2.3.6" --no-build-isolation -q
+  }
+fi
 
 pip install -r "$OPENPCDET_DIR/requirements.txt" -q
 
-# --no-build-isolation: lets the editable install see the already-installed
-# torch so setup.py's torch.cuda version check doesn't fail.
-echo "  pip install -e OpenPCDet (no-build-isolation) ..."
-pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
+# Check if pcdet is already importable; if so, skip the editable install.
+if python -c "import pcdet; print('  pcdet', pcdet.__version__, 'already installed')" 2>/dev/null; then
+  echo "  OpenPCDet already installed -- skipping editable install"
+else
+  # --no-build-isolation lets setup.py see the pre-installed torch so the
+  # CUDA version check in setup.py does not fail with ModuleNotFoundError.
+  echo "  pip install -e OpenPCDet (no-build-isolation) ..."
+  pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
+fi
 
 # ── 3. Install gitm package ──────────────────────────────────────────────────
 

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -15,21 +15,29 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GITM_DATA_ROOT="${GITM_DATA_ROOT:-/workspace/edge}"
-OPENPCDET_DIR="${OPENPCDET_DIR:-/workspace/edge/OpenPCDet}"
+OPENPCDET_DIR="${OPENPCDET_DIR:-${GITM_DATA_ROOT}/OpenPCDet}"
 CKPT_DIR="${CKPT_DIR:-$GITM_DATA_ROOT/checkpoints/kitti}"
 CKPT_PATH="$CKPT_DIR/pointpillar_7728.pth"
 CKPT_URL="${CKPT_URL:-}"
 
 CFG_PATH="$OPENPCDET_DIR/tools/cfgs/kitti_models/pointpillar.yaml"
-KITTI_VELODYNE="$GITM_DATA_ROOT/kitti/training/velodyne"
+# Accept either $GITM_DATA_ROOT/kitti/training or $GITM_DATA_ROOT/data/kitti/training
+if [ -d "$GITM_DATA_ROOT/kitti/training/velodyne" ]; then
+  KITTI_TRAINING="$GITM_DATA_ROOT/kitti/training"
+elif [ -d "$GITM_DATA_ROOT/data/kitti/training/velodyne" ]; then
+  KITTI_TRAINING="$GITM_DATA_ROOT/data/kitti/training"
+else
+  KITTI_TRAINING="$GITM_DATA_ROOT/kitti/training"
+fi
+KITTI_VELODYNE="$KITTI_TRAINING/velodyne"
 EXPECTED_FRAMES=7481
 EXPECTED_CKPT_SHA="4c83fc0fa02575b9b3e9dec676f698e7a70bb5a795e89f91df8a96b916fa19e2"
 
 step() { echo ""; echo "==> $*"; }
 
-# ── 1. Verify KITTI data ────────────────────────────────────────────────────
+# ── 1. Verify KITTI data ─────────────────────────────────────────────────────
 
-step "Checking KITTI data at $KITTI_VELODYNE …"
+step "Checking KITTI data at $KITTI_VELODYNE ..."
 if [ ! -d "$KITTI_VELODYNE" ]; then
   echo "ERROR: KITTI velodyne dir not found: $KITTI_VELODYNE" >&2
   echo "  Run first: python $REPO_ROOT/benchmarks/edge/fetch.py --step kitti --out $GITM_DATA_ROOT" >&2
@@ -40,94 +48,122 @@ if [ "$n_bins" -lt "$EXPECTED_FRAMES" ]; then
   echo "ERROR: only $n_bins .bin files found (expected $EXPECTED_FRAMES). Download still running?" >&2
   exit 1
 fi
-echo "  KITTI: $n_bins frames found OK"
+echo "  KITTI: $n_bins frames found OK at $KITTI_VELODYNE"
 
-# ── 2. Clone + install OpenPCDet (pinned commit) ────────────────────────────
+# ── 2. Clone + install OpenPCDet (pinned commit) ─────────────────────────────
 
 PINNED_COMMIT="233f849829b6ac19afb8af8837a0246890908755"
 
-step "Setting up OpenPCDet …"
+step "Setting up OpenPCDet ..."
 if [ ! -d "$OPENPCDET_DIR/.git" ]; then
-  echo "  Cloning OpenPCDet …"
+  echo "  Cloning OpenPCDet ..."
   git clone https://github.com/open-mmlab/OpenPCDet.git "$OPENPCDET_DIR"
 fi
 
 actual_commit=$(git -C "$OPENPCDET_DIR" rev-parse HEAD)
 if [ "$actual_commit" != "$PINNED_COMMIT" ]; then
-  echo "  Pinning to commit $PINNED_COMMIT …"
+  echo "  Pinning to commit $PINNED_COMMIT ..."
+  git -C "$OPENPCDET_DIR" fetch --quiet
   git -C "$OPENPCDET_DIR" checkout "$PINNED_COMMIT"
 fi
 echo "  OpenPCDet at $PINNED_COMMIT"
 
-step "Installing PyTorch + OpenPCDet deps …"
-pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cu124 -q
-pip install spconv-cu124 -q
+step "Installing OpenPCDet deps ..."
+# Do NOT install a fresh torch -- use whatever CUDA-matched version is already
+# on the pod. Installing a mismatched torch breaks torchaudio/torchvision.
+python -c "import torch; print('  torch', torch.__version__, '| CUDA', torch.version.cuda)"
+
+# spconv: pick wheel matching the pod's CUDA version (12.x -> cu120 or cu121)
+CUDA_SHORT=$(python -c "import torch; v=torch.version.cuda or '12.0'; print(''.join(v.split('.')[:2]))" 2>/dev/null || echo "120")
+echo "  Installing spconv-cu${CUDA_SHORT} ..."
+pip install spconv-cu"${CUDA_SHORT}" -q 2>/dev/null || {
+  echo "  spconv-cu${CUDA_SHORT} not found, falling back to spconv-cu120 ..."
+  pip install spconv-cu120 -q
+}
+
 pip install -r "$OPENPCDET_DIR/requirements.txt" -q
-pip install -e "$OPENPCDET_DIR" -q
 
-step "Installing gitm package …"
-pip install -e "$REPO_ROOT[dev,bench,nvidia]" -q
+# --no-build-isolation: lets the editable install see the already-installed
+# torch so setup.py's torch.cuda version check doesn't fail.
+echo "  pip install -e OpenPCDet (no-build-isolation) ..."
+pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
 
-# ── 3. Pull + verify checkpoint ──────────────────────────────────────────────
+# ── 3. Install gitm package ──────────────────────────────────────────────────
 
-step "Checking checkpoint …"
+step "Installing gitm package ..."
+pip install -e "$REPO_ROOT[dev,bench,nvidia]" --no-build-isolation -q
+echo "  gitm package installed."
+
+# ── 4. Pull + verify checkpoint ─────────────────────────────────────────────
+
+step "Checking checkpoint ..."
 mkdir -p "$CKPT_DIR"
 if [ ! -f "$CKPT_PATH" ]; then
   if [ -z "$CKPT_URL" ]; then
-    echo "ERROR: checkpoint not found and CKPT_URL is not set." >&2
-    echo "  Download manually or set CKPT_URL to the pre-signed URL from Adit." >&2
-    echo "  Checkpoint: https://drive.google.com/file/d/1wMxWTpU1qUoY3DsCH31WJmvJxcjFXKlm" >&2
-    exit 1
+    # Try gdown for the public OpenPCDet Google Drive release
+    echo "  No CKPT_URL set -- trying gdown for public OpenPCDet checkpoint ..."
+    pip install gdown -q
+    gdown "1wMxWTpU1qUoY3DsCH31WJmvJxcjFXKlm" -O "$CKPT_PATH" || {
+      echo "ERROR: checkpoint not found and gdown failed." >&2
+      echo "  Set CKPT_URL to a pre-signed download URL and re-run." >&2
+      exit 1
+    }
+  else
+    echo "  Downloading checkpoint from CKPT_URL ..."
+    curl -L "$CKPT_URL" -o "$CKPT_PATH"
   fi
-  echo "  Downloading checkpoint …"
-  curl -L "$CKPT_URL" -o "$CKPT_PATH"
 fi
 actual_sha=$(sha256sum "$CKPT_PATH" | awk '{print $1}')
 if [ "$actual_sha" != "$EXPECTED_CKPT_SHA" ]; then
-  echo "ERROR: checkpoint sha256 mismatch" >&2
+  echo "ERROR: checkpoint sha256 mismatch." >&2
   echo "  expected: $EXPECTED_CKPT_SHA" >&2
   echo "  actual:   $actual_sha" >&2
   exit 1
 fi
 echo "  Checkpoint sha256 OK"
 
-# ── 4. Generate sha256 manifest ──────────────────────────────────────────────
+# ── 5. Generate + verify sha256 manifest ────────────────────────────────────
 
-step "Generating sha256 manifest …"
+step "Generating sha256 manifest ..."
 python "$REPO_ROOT/harness/gen_kitti_manifest.py" \
-  --root "$GITM_DATA_ROOT/kitti/training" \
+  --root "$KITTI_TRAINING" \
   --out  "$REPO_ROOT/benchmarks/kitti/manifest.yaml"
 echo "  Manifest written."
 
-step "Verifying manifest (fast mode) …"
+step "Verifying manifest (fast mode) ..."
 python "$REPO_ROOT/harness/verify_manifest.py" --fast
 echo "  Manifest verified."
 
-# ── 5. Smoke test ────────────────────────────────────────────────────────────
+# ── 6. Smoke test ───────────────────────────────────────────────────────────
 
-step "Smoke test (10 frames) …"
-export GITM_DATA_ROOT OPENPCDET_CFG="$CFG_PATH" OPENPCDET_CKPT="$CKPT_PATH"
-python "$REPO_ROOT/harness/smoke_kitti.py" \
-  --cfg "$CFG_PATH" --ckpt "$CKPT_PATH" --n-frames 10
+step "Smoke test (10 frames) ..."
+export PYTHONPATH="$OPENPCDET_DIR:${PYTHONPATH:-}"
+GITM_DATA_ROOT="$GITM_DATA_ROOT" \
+OPENPCDET_CFG="$CFG_PATH" \
+OPENPCDET_CKPT="$CKPT_PATH" \
+  python "$REPO_ROOT/harness/smoke_kitti.py" \
+    --cfg "$CFG_PATH" --ckpt "$CKPT_PATH" --n-frames 10
 echo "  Smoke test passed."
 
-# ── 6. Run 6-seed baselines ──────────────────────────────────────────────────
+# ── 7. Run 6-seed baselines ─────────────────────────────────────────────────
 
-step "Running 6-seed baselines (this takes ~1 hour) …"
+step "Running 6-seed baselines (approx 75-100 min) ..."
 GITM_DATA_ROOT="$GITM_DATA_ROOT" \
 OPENPCDET_CFG="$CFG_PATH" \
 OPENPCDET_CKPT="$CKPT_PATH" \
   bash "$REPO_ROOT/harness/run_baselines.sh"
 
-# ── 7. Remind: commit results ────────────────────────────────────────────────
+# ── 8. Auto-fill results docs ────────────────────────────────────────────────
+
+step "Filling spec.md + results.md ..."
+GITM_DATA_ROOT="$GITM_DATA_ROOT" python "$REPO_ROOT/harness/fill_results.py"
+
+# ── 9. Remind: commit ───────────────────────────────────────────────────────
 
 echo ""
 echo "================================================================"
-echo "  All done. Fill measured numbers into:"
-echo "    benchmarks/kitti/spec.md    (Section 3 + 5 tables)"
-echo "    benchmarks/kitti/results.md (baseline table)"
-echo ""
-echo "  Then commit and push:"
+echo "  All done. Commit and push:"
+echo "    cd $REPO_ROOT"
 echo "    git add benchmarks/kitti/manifest.yaml benchmarks/kitti/spec.md benchmarks/kitti/results.md"
 echo "    git commit -m 'KITTI: fill measured baseline numbers'"
 echo "    git push"

--- a/harness/run_baselines.sh
+++ b/harness/run_baselines.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# Run all three KITTI PointPillars baselines (seeds 42, 43, 44) and
-# check convergence.
+# Run 6-seed KITTI PointPillars baselines (seeds 42–47) and check convergence.
 #
 # Usage:
 #   bash harness/run_baselines.sh
 #
 # Required env vars:
-#   GITM_DATA_ROOT      — root for datasets, checkpoints, and run outputs
+#   GITM_DATA_ROOT      — root of kitti/training/velodyne/ + output dir
 #   OPENPCDET_CFG       — path to pointpillar.yaml  (set by setup_openpcdet.sh)
 #   OPENPCDET_CKPT      — path to pointpillar_7728.pth  (set by setup_openpcdet.sh)
 #
-# Each baseline writes to $GITM_DATA_ROOT/runs/kitti_baseline_{1,2,3}.json
-# After all three complete, the script prints a convergence summary.
+# Each run writes to $GITM_DATA_ROOT/runs/kitti_baseline_{1..6}.json
+# After all runs complete, the script prints a convergence summary.
+#
+# For a quick 3-seed check: N_SEEDS=3 bash harness/run_baselines.sh
 
 set -euo pipefail
 
@@ -23,7 +24,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUNS_DIR="$GITM_DATA_ROOT/runs"
 mkdir -p "$RUNS_DIR"
 
-N_FRAMES="${N_FRAMES:-7481}"   # set to smaller number for a quick check
+N_FRAMES="${N_FRAMES:-7481}"
+N_SEEDS="${N_SEEDS:-6}"   # set to 3 for a quick 3-seed check
+
+SEEDS=(42 43 44 45 46 47)
 
 run_baseline() {
   local seed="$1"
@@ -36,27 +40,32 @@ run_baseline() {
   echo "══════════════════════════════════════════"
 
   python -m gitm.benchmarks.kitti.baseline \
-    --cfg    "$OPENPCDET_CFG" \
-    --ckpt   "$OPENPCDET_CKPT" \
-    --seed   "$seed" \
-    --frames "$N_FRAMES" \
-    --output "$out"
+    --cfg        "$OPENPCDET_CFG" \
+    --ckpt       "$OPENPCDET_CKPT" \
+    --data-root  "$GITM_DATA_ROOT" \
+    --seed       "$seed" \
+    --frames     "$N_FRAMES" \
+    --output     "$out"
 
   echo "  Wrote: $out"
 }
 
-run_baseline 42 1
-run_baseline 43 2
-run_baseline 44 3
+for i in $(seq 1 "$N_SEEDS"); do
+  run_baseline "${SEEDS[$((i-1))]}" "$i"
+done
 
 echo ""
 echo "══════════════════════════════════════════"
-echo "  Convergence check"
+echo "  Convergence check ($N_SEEDS seeds)"
 echo "══════════════════════════════════════════"
 
-python - "$RUNS_DIR/kitti_baseline_1.json" \
-         "$RUNS_DIR/kitti_baseline_2.json" \
-         "$RUNS_DIR/kitti_baseline_3.json" << 'PYEOF'
+# Build the list of result files written above
+result_files=()
+for i in $(seq 1 "$N_SEEDS"); do
+  result_files+=("$RUNS_DIR/kitti_baseline_${i}.json")
+done
+
+python - "${result_files[@]}" << 'PYEOF'
 import json, sys
 
 paths = sys.argv[1:]
@@ -65,26 +74,35 @@ for p in paths:
     with open(p) as f:
         results.append(json.load(f))
 
-fps_vals = [r["frames_per_second"] for r in results]
-gpu_vals = [r["gpu_active_pct"] for r in results]
+fps_vals  = [r["frames_per_second"] for r in results]
+gpu_vals  = [r["gpu_active_pct"] for r in results]
+data_vals = [r["data_stall_pct"] for r in results]
+seeds     = [r["seed"] for r in results]
 
 spread = (max(fps_vals) - min(fps_vals)) / max(fps_vals) * 100
 ok = spread <= 2.0
 
-print(f"  fps:  {' | '.join(f'{v:.2f}' for v in fps_vals)}")
-print(f"  gpu%: {' | '.join(f'{v:.1f}' for v in gpu_vals)}")
-print(f"  spread: {spread:.2f}%  ({'PASS ✓' if ok else 'FAIL — re-run and investigate'})")
+print(f"  seeds: {' | '.join(str(s) for s in seeds)}")
+print(f"  fps:   {' | '.join(f'{v:.2f}' for v in fps_vals)}")
+print(f"  gpu%:  {' | '.join(f'{v:.1f}' for v in gpu_vals)}")
+print(f"  data%: {' | '.join(f'{v:.1f}' for v in data_vals)}")
+print(f"  spread: {spread:.2f}%  ({'PASS' if ok else 'FAIL -- re-run and investigate'})")
+
+# Print headroom if available
+headroom_vals = [r.get("compute_headroom_pct") for r in results]
+if any(v is not None for v in headroom_vals):
+    print(f"  headroom%: {' | '.join(f'{v:.1f}' if v is not None else 'N/A' for v in headroom_vals)}")
 
 max_gpu = max(gpu_vals)
 if max_gpu > 85.0:
-    print(f"\n  WARNING: GPU active {max_gpu:.1f}% > 85% — flag Adit for 500-frame fallback.")
+    print(f"\n  WARNING: GPU active {max_gpu:.1f}% > 85% -- flag Adit for 500-frame fallback.")
 else:
-    print(f"\n  GPU active < 85% ✓")
+    print(f"\n  GPU active < 85% OK")
 
 if not ok:
     sys.exit(1)
 PYEOF
 
 echo ""
-echo "All three baselines complete."
-echo "Fill fps + stall numbers into benchmarks/kitti/spec.md and benchmarks/kitti/results.md"
+echo "All $N_SEEDS baselines complete."
+echo "Fill fps + stall numbers into benchmarks/kitti/results.md"


### PR DESCRIPTION
## Summary

- **Fix baseline convergence**: replaced missing `manifest.yaml` dependency with direct filesystem walk of `$GITM_DATA_ROOT/kitti/training/velodyne/`; added disk pre-warm pass before GPU warmup to eliminate OS page cache locality as a seed-ordering confound (was causing ~18% fps spread between seed 42 and seeds 43/44)
- **Runtime integration**: wire NVML samples into `gpu_headroom()` from `gitm.optimizer.headroom_kernel_rank` — `compute_headroom_pct`, `mean_util_pct`, `mem_free_at_peak_gb` now in every baseline JSON
- **Stage spread signal**: per-stage p50/p95 latency + p95/p50 ratio across all frames, mirroring `render_roi_table()` shape; saved as `stage_spread_report.txt` alongside JSON and embedded in output
- **6-seed baselines**: expanded from 3 seeds (42-44) to 6 seeds (42-47) for stronger convergence evidence; `N_SEEDS=3` env var for quick checks
- **Fix CHECKPOINT_SHA256**: was stale `c9c84e5...`, corrected to `4c83fc0...`; filled `CONFIG_SHA256`
- **spec.md**: all known values filled in (pinned commit, config sha256, correct data path, 6-seed table, headroom + spread sections)
- **pod_setup_and_run.sh**: one-shot script for fresh RunPod pod -- verifies download, pins OpenPCDet, installs deps, verifies checkpoint, generates + verifies manifest, smoke test, 6-seed baselines
- **datasets_proposal.md**: Argoverse 2, Waymo, ONCE, PandaSet ranked by signal value for Git.M invariants

## Test plan

- [ ] KITTI download completes on pod (`fetch.py --step kitti` -> 7481 .bin files)
- [ ] `bash harness/pod_setup_and_run.sh` runs end-to-end without error
- [ ] 6-seed fps spread < 2% (convergence passes)
- [ ] GPU active % < 85%
- [ ] `benchmarks/kitti/manifest.yaml` committed after pod run
- [ ] Measured numbers filled into `spec.md` and `results.md`

Generated with [Claude Code](https://claude.com/claude-code)