### PR TITLE
Switch to OpenRouter for embeddings in gitm-context-store

### DIFF
--- a/skills/gitm-context-store.md
+++ b/skills/gitm-context-store.md
@@ -41,8 +41,11 @@ Each vector has metadata:
 ```
 PINECONE_API_KEY
 PINECONE_INDEX_NAME=gitm-context-store
-OPENAI_API_KEY        # for embeddings (text-embedding-3-small)
+OPENROUTER_API_KEY          # already active in Hermes env
+OPENROUTER_EMBEDDING_MODEL=openai/text-embedding-3-small
 ```
+
+Note: OpenRouter is used instead of OpenAI directly. The embedding model `openai/text-embedding-3-small` is available via OpenRouter's OpenAI-compatible endpoint at `https://openrouter.ai/api/v1/embeddings`. Use `OPENROUTER_API_KEY` as the bearer token.
 
 ---
 
@@ -207,7 +210,7 @@ Reference wins for social proof in messaging.
 To seed the context store, run inside a Hermes chat session:
 
 ```
-Seed the gitm-context-store. For each table in context_voice_rules, context_sender_personas, context_copy_variants, context_product_state, and context_objection_responses: read the seed data from the gitm-context-store skill, write each row to Airtable, generate an embedding for each record using OpenAI text-embedding-3-small, and upsert into the Pinecone index gitm-context-store with the correct metadata fields (record_type, record_id, label, sender, vertical).
+Seed the gitm-context-store. For each table in context_voice_rules, context_sender_personas, context_copy_variants, context_product_state, and context_objection_responses: read the seed data from the gitm-context-store skill, write each row to Airtable, generate an embedding for each record using OpenRouter with model openai/text-embedding-3-small (endpoint: https://openrouter.ai/api/v1/embeddings, bearer token: OPENROUTER_API_KEY), and upsert into the Pinecone index gitm-context-store with the correct metadata fields (record_type, record_id, label, sender, vertical).
 ```
 
 ---


### PR DESCRIPTION
Updated instructions to use OpenRouter API for embeddings instead of OpenAI directly. Clarified the embedding model and provided the endpoint details.