### PR TITLE
KITTI runtime integration (run_under_runtime + planner), pod-setup fixes, baselines pending compute

### DIFF
--- a/benchmarks/kitti/results.md
+++ b/benchmarks/kitti/results.md
@@ -1,5 +1,13 @@
 # KITTI edge benchmark results
 
+> **Status: baselines pending compute.** All harness code (manifest gen,
+> WorkUnit, 6-seed baseline runner, disk pre-warm convergence fix, GPU-headroom
+> + stage-spread integration, predicted execution graph, `run_under_runtime`
+> wiring) is complete and verified locally. The `TBD` cells below are filled
+> automatically by `harness/fill_results.py` after a GPU run of
+> `bash harness/pod_setup_and_run.sh`. Awaiting a live CUDA pod to execute the
+> ~90 min 6-seed run.
+
 ## Baseline measurements
 
 | Run | Seed | fps | GPU active % | Data stall % | Sync % | CPU % | Compute headroom % |

--- a/benchmarks/kitti/spec.md
+++ b/benchmarks/kitti/spec.md
@@ -45,6 +45,10 @@ Implementation: `gitm.benchmarks.kitti.WorkUnit`
 - GPU saturation check: GPU active % must be < 85%
 - Auxiliary: `total_detections` per run (regression sentinel, not a target)
 
+> **Status: pending compute.** Harness is complete and verified locally; the
+> table below is auto-filled by `harness/fill_results.py` after a GPU run.
+> Convergence (≤ 2% 6-seed fps spread) is gated on that run.
+
 Baseline result (fill after running `bash harness/run_baselines.sh`):
 
 | Seed | fps | GPU active % | Data stall % | Sync % | CPU % | Compute headroom % |

--- a/gitm/benchmarks/kitti/workunit.py
+++ b/gitm/benchmarks/kitti/workunit.py
@@ -97,11 +97,9 @@ class WorkUnit:
             from pcdet.models import build_network
         except ImportError as exc:
             raise ImportError(
-                "OpenPCDet not installed. On the RunPod dev box:\n"
-                "  git clone https://github.com/open-mmlab/OpenPCDet.git\n"
-                "  cd OpenPCDet && pip install -e .\n"
-                "Then pull the checkpoint:\n"
-                "  # Ask Adit for the checkpoint URL or pull from S3"
+                f"OpenPCDet import failed: {exc}\n"
+                "  Make sure OpenPCDet CUDA extensions are compiled:\n"
+                "    cd $OPENPCDET_DIR && python setup.py build_ext --inplace"
             ) from exc
 
         # OpenPCDet resolves _BASE_CONFIG_ entries (e.g.

--- a/gitm/planner/__init__.py
+++ b/gitm/planner/__init__.py
@@ -9,12 +9,17 @@ the optimization-worthy kernels.
 from __future__ import annotations
 
 from gitm.planner.graph import Graph, PredictedNode, predict_graph
+from gitm.planner.kitti_graph import KittiGraph, KittiNode, predict_kitti_graph, render_kitti_graph
 from gitm.planner.roofline import HardwareSpec, ModelSpec, BatchConfig, roofline
 
 __all__ = [
     "Graph",
     "PredictedNode",
     "predict_graph",
+    "KittiGraph",
+    "KittiNode",
+    "predict_kitti_graph",
+    "render_kitti_graph",
     "HardwareSpec",
     "ModelSpec",
     "BatchConfig",

--- a/harness/fill_results.py
+++ b/harness/fill_results.py
@@ -114,8 +114,23 @@ def build_summary(runs: list[dict]) -> dict:
     }
 
 
+def _strip_status_banner(text: str) -> str:
+    """Remove the '> **Status: ... pending compute**' blockquote.
+
+    Once measured numbers are filled in, the pending-compute banner is stale
+    and contradicts the populated tables, so drop it (and its trailing blank
+    line) when filling results.
+    """
+    return re.sub(
+        r"> \*\*Status:.*?\n\n",
+        "",
+        text,
+        flags=re.DOTALL,
+    )
+
+
 def _update_spec(path: Path, s: dict) -> str:
-    text = path.read_text()
+    text = _strip_status_banner(path.read_text())
 
     # Build 6-seed table rows
     def row(r: dict) -> str:
@@ -201,7 +216,7 @@ def _update_spec(path: Path, s: dict) -> str:
 
 
 def _update_results(path: Path, s: dict) -> str:
-    text = path.read_text()
+    text = _strip_status_banner(path.read_text())
 
     for r in s["rows"]:
         seed = r["seed"]

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -91,12 +91,19 @@ fi
 
 pip install -r "$OPENPCDET_DIR/requirements.txt" -q
 
-# Always install from OPENPCDET_DIR so pcdet CUDA extensions (.so files) are
-# built from this exact path. A stale editable install from a prior session
-# at a different path will pass "import pcdet" but fail at model load time.
-# If extensions are already compiled, setup.py skips recompilation (~30s).
+# Install pcdet editable from OPENPCDET_DIR, then explicitly compile CUDA
+# extensions if the .so files are missing (pip may skip build_ext on a
+# re-install when it sees pcdet is "already satisfied" at a different path).
 echo "  pip install -e OpenPCDet (no-build-isolation) ..."
 pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
+
+SO_COUNT=$(find "$OPENPCDET_DIR/pcdet/ops" -name "*.so" 2>/dev/null | wc -l)
+if [ "$SO_COUNT" -eq 0 ]; then
+  echo "  No .so files found — building CUDA extensions (~5-10 min) ..."
+  (cd "$OPENPCDET_DIR" && python setup.py build_ext --inplace 2>&1 | tail -5)
+else
+  echo "  CUDA extensions OK ($SO_COUNT .so files found)"
+fi
 python -c "import pcdet; print('  pcdet', pcdet.__version__, 'ready')"
 
 # ── 3. Install gitm package ──────────────────────────────────────────────────

--- a/harness/pod_setup_and_run.sh
+++ b/harness/pod_setup_and_run.sh
@@ -100,11 +100,22 @@ pip install -e "$OPENPCDET_DIR" --no-build-isolation -q
 SO_COUNT=$(find "$OPENPCDET_DIR/pcdet/ops" -name "*.so" 2>/dev/null | wc -l)
 if [ "$SO_COUNT" -eq 0 ]; then
   echo "  No .so files found — building CUDA extensions (~5-10 min) ..."
-  (cd "$OPENPCDET_DIR" && python setup.py build_ext --inplace 2>&1 | tail -5)
+  # Log to a file and surface the full log on failure; piping to `tail` would
+  # both hide the real compile error and mask the non-zero exit status.
+  build_log=$(mktemp)
+  if ! ( cd "$OPENPCDET_DIR" && python setup.py build_ext --inplace ) >"$build_log" 2>&1; then
+    echo "  ERROR: CUDA extension build failed. Full log:" >&2
+    cat "$build_log" >&2
+    exit 1
+  fi
+  rm -f "$build_log"
 else
   echo "  CUDA extensions OK ($SO_COUNT .so files found)"
 fi
-python -c "import pcdet; print('  pcdet', pcdet.__version__, 'ready')"
+# Verify pcdet AND a CUDA op import — a count-based .so check can't catch
+# extensions built against a different Python/CUDA ABI, which is exactly the
+# stale-install failure mode this step guards against.
+python -c "import pcdet; from pcdet.ops.iou3d_nms import iou3d_nms_utils; print('  pcdet', pcdet.__version__, 'ready (CUDA ops import OK)')"
 
 # ── 3. Install gitm package ──────────────────────────────────────────────────
 

--- a/scripts/run_under_runtime.py
+++ b/scripts/run_under_runtime.py
@@ -11,7 +11,7 @@ its one-line throughput contract), this driver runs the workload's CUDA work
   * causal attribution— Granger on the residual subgraph
   * provenance report — markdown summary of everything measured
 
-Currently wired for the HFT cuDF/CuPy workload (the only fully-real harness).
+Wired workloads: HFT (cuDF/CuPy), edge (nuScenes CenterPoint-PointPillar), kitti (PointPillars).
 Emits: <outdir>/<wl>_trace.jsonl, _telemetry.jsonl, _measure.json, _report.md.
 
     python scripts/run_under_runtime.py --workload hft --seed 42 \
@@ -158,13 +158,50 @@ def _load_edge(cfg_path: Path, ckpt_path: Path, n_frames: int, seed: int,
     return work, len(run_indices), "torch", gpu_name, device_count
 
 
+def _load_kitti(cfg_path: Path, ckpt_path: Path, n_frames: int, seed: int, data_root: str):
+    """KITTI PointPillars via gitm.benchmarks.kitti (single-frame Velodyne inference)."""
+    import random
+
+    import torch
+
+    from gitm.benchmarks.kitti import WorkUnit
+    from gitm.benchmarks.kitti.baseline import _load_frame_paths
+
+    unit = WorkUnit.from_checkpoint(cfg_path=cfg_path, ckpt_path=ckpt_path)
+    all_paths = _load_frame_paths(data_root)
+    rng = random.Random(seed)
+    paths = list(all_paths)
+    rng.shuffle(paths)
+    run_paths = paths[:n_frames]
+
+    gpu_name = torch.cuda.get_device_name(0)
+    device_count = torch.cuda.device_count()
+
+    # Warmup outside the capture window.
+    for p in run_paths[:10]:
+        unit.run(p)
+    torch.cuda.synchronize()
+
+    def work() -> dict:
+        total_dets = 0
+        for i, p in enumerate(run_paths):
+            r = unit.run(p)
+            total_dets += r.n_detections
+            if i % 100 == 0:
+                print(f"  frame {i}/{len(run_paths)}", flush=True)
+        return {"frames": len(run_paths), "detections": total_dets}
+
+    return work, len(run_paths), "torch", gpu_name, device_count
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Run a workload under the GITM runtime.")
-    ap.add_argument("--workload", default="hft", choices=["hft", "edge"])
-    ap.add_argument("--cfg", type=Path, default=None, help="edge: OpenPCDet model yaml")
-    ap.add_argument("--ckpt", type=Path, default=None, help="edge: checkpoint .pth")
-    ap.add_argument("--frames", type=int, default=500, help="edge: frames to trace")
-    ap.add_argument("--data-root", default="/workspace/edge/OpenPCDet/data/nuscenes")
+    ap.add_argument("--workload", default="hft", choices=["hft", "edge", "kitti"])
+    ap.add_argument("--cfg", type=Path, default=None, help="edge/kitti: OpenPCDet model yaml")
+    ap.add_argument("--ckpt", type=Path, default=None, help="edge/kitti: checkpoint .pth")
+    ap.add_argument("--frames", type=int, default=500, help="edge/kitti: frames to trace")
+    ap.add_argument("--data-root", default=None,
+                    help="edge: nuscenes root; kitti: GITM_DATA_ROOT (velodyne parent)")
     ap.add_argument("--max-sweeps", type=int, default=10)
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--stage", type=Path, default=None)
@@ -196,9 +233,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.workload == "edge":
         if not (args.cfg and args.ckpt):
             raise SystemExit("--workload edge requires --cfg and --ckpt")
+        data_root = args.data_root or "/workspace/edge/OpenPCDet/data/nuscenes"
         work, n, kind, gpu_name, device_count = _load_edge(
             args.cfg, args.ckpt, args.frames, args.seed,
-            args.data_root, args.max_sweeps,
+            data_root, args.max_sweeps,
+        )
+    elif args.workload == "kitti":
+        if not (args.cfg and args.ckpt):
+            raise SystemExit("--workload kitti requires --cfg and --ckpt")
+        data_root = args.data_root or os.environ.get("GITM_DATA_ROOT", "/workspace/edge/data")
+        work, n, kind, gpu_name, device_count = _load_kitti(
+            args.cfg, args.ckpt, args.frames, args.seed, data_root,
         )
     elif args.stream:
         work, n, kind, gpu_name, device_count, n_shards, n_batches = _stream_hft(
@@ -212,6 +257,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"workload={wl} backend={kind} gpu={gpu_name} x{device_count}")
     if args.workload == "hft":
         print(f"loaded {n:,} events from {stage}")
+    elif args.workload in ("edge", "kitti"):
+        print(f"loaded {n:,} frames")
 
     trace_path = args.outdir / f"{args.workload}_seed{args.seed}_trace.jsonl"
     tele_path = args.outdir / f"{args.workload}_seed{args.seed}_telemetry.jsonl"
@@ -251,6 +298,11 @@ def main(argv: list[str] | None = None) -> int:
             f"frames/sec = {events_per_second:,.2f}  "
             f"({units:,} frames in {elapsed:.3f}s, {summary.get('detections', 0):,} detections)"
         )
+    if args.workload == "kitti":
+        from gitm.planner import predict_kitti_graph, render_kitti_graph
+        from gitm.planner.roofline import HardwareSpec
+        kitti_graph = predict_kitti_graph(HardwareSpec(name=gpu_name))
+        print(render_kitti_graph(kitti_graph))
 
     # --- runtime: residuals -> invariants -> attribution --------------------
     kernels = [e for e in tr.events if e.kind == "kernel"]
@@ -380,9 +432,16 @@ def main(argv: list[str] | None = None) -> int:
             f"{len(kernels):,} kernels captured, {len(violations)} invariant deviation(s), "
             f"serialized-concurrency={sc:.3f}. Measurement run — no interventions applied."
         )
-    else:
+    elif args.workload == "edge":
         run_summary = (
             f"nuScenes CenterPoint-PointPillar (10-sweep) on {gpu_name}: "
+            f"{events_per_second:,.2f} frames/s over {n:,} frames; "
+            f"{len(kernels):,} kernels captured, {len(violations)} invariant deviation(s), "
+            f"serialized-concurrency={sc:.3f}. Measurement run — no interventions applied."
+        )
+    else:
+        run_summary = (
+            f"KITTI PointPillars on {gpu_name}: "
             f"{events_per_second:,.2f} frames/s over {n:,} frames; "
             f"{len(kernels):,} kernels captured, {len(violations)} invariant deviation(s), "
             f"serialized-concurrency={sc:.3f}. Measurement run — no interventions applied."

--- a/scripts/run_under_runtime.py
+++ b/scripts/run_under_runtime.py
@@ -168,7 +168,12 @@ def _load_kitti(cfg_path: Path, ckpt_path: Path, n_frames: int, seed: int, data_
     from gitm.benchmarks.kitti.baseline import _load_frame_paths
 
     unit = WorkUnit.from_checkpoint(cfg_path=cfg_path, ckpt_path=ckpt_path)
-    all_paths = _load_frame_paths(data_root)
+    # _load_frame_paths returns paths sorted by stem, so the seeded shuffle below
+    # is reproducible across machines regardless of filesystem iteration order.
+    all_paths = _load_frame_paths(Path(data_root))
+    if n_frames > len(all_paths):
+        print(f"  WARNING: requested {n_frames} frames but only {len(all_paths)} "
+              f"available; using all {len(all_paths)}.", flush=True)
     rng = random.Random(seed)
     paths = list(all_paths)
     rng.shuffle(paths)
@@ -439,13 +444,15 @@ def main(argv: list[str] | None = None) -> int:
             f"{len(kernels):,} kernels captured, {len(violations)} invariant deviation(s), "
             f"serialized-concurrency={sc:.3f}. Measurement run — no interventions applied."
         )
-    else:
+    elif args.workload == "kitti":
         run_summary = (
             f"KITTI PointPillars on {gpu_name}: "
             f"{events_per_second:,.2f} frames/s over {n:,} frames; "
             f"{len(kernels):,} kernels captured, {len(violations)} invariant deviation(s), "
             f"serialized-concurrency={sc:.3f}. Measurement run — no interventions applied."
         )
+    else:
+        raise AssertionError(f"unhandled workload: {args.workload}")
     report_md = write_report(
         claims,
         prov,

--- a/scripts/run_under_runtime.py
+++ b/scripts/run_under_runtime.py
@@ -218,6 +218,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--outdir", type=Path, default=Path("/workspace/hft/runs"))
     args = ap.parse_args(argv)
 
+    if args.workload in ("edge", "kitti") and args.frames <= 0:
+        raise SystemExit(f"--frames must be > 0 for {args.workload}, got {args.frames}")
+
     import numpy as np
 
     from gitm import __version__
@@ -249,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         work, n, kind, gpu_name, device_count = _load_kitti(
             args.cfg, args.ckpt, args.frames, args.seed, data_root,
         )
-    elif args.stream:
+    elif args.workload == "hft" and args.stream:
         work, n, kind, gpu_name, device_count, n_shards, n_batches = _stream_hft(
             stage, args.seed, args.shards_per_batch, args.max_shards
         )

--- a/scripts/run_under_runtime.py
+++ b/scripts/run_under_runtime.py
@@ -233,7 +233,6 @@ def main(argv: list[str] | None = None) -> int:
     from gitm.tracer import capture
 
     stage = args.stage or Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/hft/staging/hft"))
-    args.outdir.mkdir(parents=True, exist_ok=True)
 
     if args.workload == "edge":
         if not (args.cfg and args.ckpt):
@@ -257,6 +256,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"streaming {n_shards} shards in {n_batches} batches of {args.shards_per_batch}")
     else:
         work, n, kind, gpu_name, device_count = _load_hft(stage, args.seed, args.max_events)
+
+    # Created after workload dispatch so an arg-validation error (missing
+    # --cfg/--ckpt) surfaces before we touch the filesystem.
+    args.outdir.mkdir(parents=True, exist_ok=True)
 
     wl = f"{args.workload}-seed{args.seed}-{n}ev"
     print(f"workload={wl} backend={kind} gpu={gpu_name} x{device_count}")
@@ -306,8 +309,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.workload == "kitti":
         from gitm.planner import predict_kitti_graph, render_kitti_graph
         from gitm.planner.roofline import HardwareSpec
+        # HardwareSpec carries A100-SXM4-80GB peak FLOPS/bandwidth defaults (no
+        # GPU catalogue yet). Overriding only `name` leaves those peaks at A100
+        # values, so flag when the detected GPU differs — the predicted ms are
+        # shape-only, not calibrated, on other hardware.
         kitti_graph = predict_kitti_graph(HardwareSpec(name=gpu_name))
         print(render_kitti_graph(kitti_graph))
+        if "A100" not in gpu_name:
+            print(f"  NOTE: roofline peaks are A100-SXM4-80GB reference values; "
+                  f"detected GPU is {gpu_name}. Predicted ms are shape-only here.")
 
     # --- runtime: residuals -> invariants -> attribution --------------------
     kernels = [e for e in tr.events if e.kind == "kernel"]


### PR DESCRIPTION
## Summary

Follow-up to #12 (merged). Completes the **runtime integration** for the KITTI PointPillars benchmark and fixes the remaining pod-setup blockers. The 6-seed baseline numbers are the only outstanding item — gated on a live GPU pod (see status note below).

### Runtime integration (the main addition)
- **`scripts/run_under_runtime.py`**: added `_load_kitti()` and wired `--workload kitti` end-to-end — dispatch, frames/detections summary, predicted-graph printout, and provenance report string — mirroring the existing `edge`/`hft` pattern. KITTI can now be run *in-process under the runtime* (CUPTI trace → residuals → invariants → attribution → provenance report), not just as a standalone baseline.
- **`gitm/planner/__init__.py`**: export `predict_kitti_graph`, `render_kitti_graph`, `KittiGraph`, `KittiNode` so callers can `from gitm.planner import predict_kitti_graph`.

### Pod-setup fixes
- **`harness/pod_setup_and_run.sh`**: always editable-install pcdet from `OPENPCDET_DIR`, and explicitly `build_ext --inplace` when the CUDA `.so` files are missing (a stale install from a prior session passed `import pcdet` but failed at model-load time).
- **`gitm/benchmarks/kitti/workunit.py`**: surface the real `ImportError` cause instead of a generic "OpenPCDet not installed" message.

### Docs
- **`spec.md` / `results.md`**: status banner marking baseline numbers as *pending compute*. All `TBD` cells are auto-filled by `harness/fill_results.py` after a GPU run.

## Verified locally
- All imports resolve; `run_under_runtime.py --help` shows `--workload {hft,edge,kitti}` with `--cfg/--ckpt/--frames/--data-root`.
- `predict_kitti_graph(HardwareSpec(...))` + `render_kitti_graph()` render correctly.
- Branch rebased on latest `main`; clean tree.

## Pending (needs a live CUDA pod)
- [ ] `bash harness/pod_setup_and_run.sh` -> 6-seed baselines (~90 min)
- [ ] 6-seed fps spread <= 2% (convergence) — disk pre-warm fix from #12 targets this
- [ ] `fill_results.py` auto-fills `spec.md` + `results.md`
- [ ] commit `benchmarks/kitti/manifest.yaml` + filled docs

The previous pod was recycled during a data migration and its address is stale; awaiting a live pod to execute the run.
