### PR TITLE
Workflow test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+# Run the full pytest suite on every commit and PR. No GPU on the runners, so
+# the HFT harness exercises its pandas/NumPy fallback (same as a CPU dev box).
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package (dev + bench extras)
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev,bench]"
+
+      - name: Run pytest
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# Pre-commit gate: fast lint + hygiene on every commit, full test suite before
+# push. Mirrors CI (.github/workflows/tests.yml) so red never reaches GitHub.
+#
+# One-time setup (after `pip install -e ".[dev]"`):
+#   pre-commit install -t pre-commit -t pre-push
+# Run manually against everything:
+#   pre-commit run --all-files
+#
+# NB: `ruff format` is intentionally NOT enabled — the repo isn't ruff-formatted
+# (most files would churn). We lint only, matching [tool.ruff.lint] in pyproject.
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^tests/golden/        # byte-exact snapshot fixture
+      - id: end-of-file-fixer
+        exclude: ^tests/golden/
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files     # keep generated parquet out of git
+
+  - repo: local
+    hooks:
+      # Uses the ruff/pytest from the installed [dev] extra, so versions match
+      # pyproject rather than drifting from a separately pinned hook.
+      - id: ruff
+        name: ruff (lint + autofix)
+        entry: ruff check --fix --force-exclude
+        language: system
+        types: [python]
+        require_serial: true
+
+      - id: pytest
+        name: pytest (full suite, pre-push)
+        entry: pytest
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
     "build>=1.0",  # `python -m build` for the wheel-build verification check
+    "pre-commit>=3.5",  # local lint/test gate; see .pre-commit-config.yaml
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
Adds continuous testing and a local pre-commit gate so the suite runs automatically on GitHub and lint issues are caught before they're pushed.

## What's included
### CI — [.github/workflows/tests.yml](vscode-webview://1okmt0u54gskst43qmt35m492o48gqovo4orbtsegaf97aq75vi8/.github/workflows/tests.yml)

Runs the full pytest suite on every push and PR, across a Python 3.10 / 3.11 / 3.12 matrix (fail-fast: false, so one version failing still reports the others).
Installs pip install -e ".[dev,bench]"; runners have no GPU, so the HFT harness exercises its pandas/NumPy fallback (same path as a CPU dev box).

### Pre-commit — [.pre-commit-config.yaml](vscode-webview://1okmt0u54gskst43qmt35m492o48gqovo4orbtsegaf97aq75vi8/.pre-commit-config.yaml)

On commit (fast): ruff check --fix plus hygiene hooks (trailing whitespace, end-of-file, YAML/TOML validation, large-file guard). The byte-exact tests/golden/ snapshot is excluded so hooks can't corrupt it.
On push: the full pytest suite, so red never reaches the remote.
Uses the ruff/pytest from the installed [dev] extra, so versions track pyproject instead of drifting.
Adds pre-commit>=3.5 to the [dev] extra.
Enable locally with:


pip install -e ".[dev]"
pre-commit install -t pre-commit -t pre-push

## Notes
Pre-commit only checks files in a given commit, so the repo's existing lint backlog won't block work; repo-wide ruff in CI can be added once that's cleaned.
The workflow currently triggers on both push and pull_request, so an open-PR branch runs each matrix entry twice. Scoping push to branches: [main] collapses that to one run per commit — easy follow-up if the duplicate runs are noise.