### PR TITLE
Integrate hft run with gitm run flag

### DIFF
--- a/gitm/benchmarks/hft/optimize.py
+++ b/gitm/benchmarks/hft/optimize.py
@@ -26,6 +26,7 @@ import time
 from dataclasses import dataclass
 
 from gitm.benchmarks.hft.harness import microprice, run_pipeline, vwap_1s
+from gitm.kernels.spec import Applicability, InterventionSpec, SafetyGate
 
 # Sentinels strictly outside the integer-tick price range, so filling the
 # opposite side with them lets a single cummax/cummin carry the running best.
@@ -134,3 +135,153 @@ def optimize_hft(df, dflib, *, reps: int = 3, sync=None) -> ABResult:
         baseline_summary=base_summary,
         candidate_summary=cand_summary,
     )
+
+
+def optimize_hft_streaming(batches, dflib, *, sync=None, on_batch=None) -> ABResult:
+    """Streaming A/B: run the measure→prove loop over an iterable of frames.
+
+    The single-frame :func:`optimize_hft` needs both pipelines resident on one
+    device frame, which caps the A/B at what fits in GPU memory. This processes
+    the dataset ``batches`` at a time instead — each ``df`` yielded by ``batches``
+    is run through *both* pipelines (baseline then candidate), their per-batch
+    outputs are checked byte-identical, and the timings accumulate. So a 1B-event
+    set that won't fit one frame still yields a verified speedup over the *whole*
+    dataset.
+
+    ``batches`` is any iterable of device frames (the caller owns loading/freeing
+    them). ``sync`` is the device-sync callable (so GPU timing is honest). The
+    overall run is "identical" iff *every* batch matched — a single divergent
+    batch rolls the whole thing back, same gate as the single-frame path.
+    ``on_batch(i, ABResult-like dict)`` is an optional progress callback.
+    """
+    sync = sync or (lambda: None)
+    total_events = 0
+    total_vwap = 0
+    base_t = 0.0
+    cand_t = 0.0
+    identical = True
+    n_batches = 0
+
+    for df in batches:
+        n_batches += 1
+        t0 = time.perf_counter()
+        bs = run_pipeline(df, dflib)
+        sync()
+        base_t += time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        cs = run_pipeline_fast(df, dflib)
+        sync()
+        cand_t += time.perf_counter() - t0
+
+        if _signature(bs) != _signature(cs):
+            identical = False
+        total_events += int(bs["events"])
+        total_vwap += int(cs["vwap_buckets"])
+        if on_batch is not None:
+            on_batch(n_batches, {"events": int(bs["events"]), "identical": identical})
+
+    base_eps = total_events / max(base_t, 1e-9)
+    cand_eps = total_events / max(cand_t, 1e-9)
+    speedup = cand_eps / base_eps if base_eps else 0.0
+    kept = "candidate" if (identical and cand_eps > base_eps) else "baseline"
+    # Aggregate counts only — the identical verdict is the per-batch AND above,
+    # not a signature over these sums (mean_microprice isn't summable).
+    agg = {"events": total_events, "vwap_buckets": total_vwap}
+    return ABResult(
+        baseline_eps=base_eps,
+        candidate_eps=cand_eps,
+        speedup=speedup,
+        identical=identical,
+        kept=kept,
+        baseline_summary=agg,
+        candidate_summary=agg,
+    )
+
+
+# --- the intervention, wired for the autonomous loop -------------------------
+#
+# Everything above is the standalone A/B. The pieces below express that same
+# optimization as a *curated intervention* the runtime can observe → attribute →
+# select → apply → prove through the standard rollback gate
+# (:func:`gitm.optimizer.apply.apply_intervention`), so HFT is no longer
+# measurement-only — it actually applies a verified speedup.
+
+
+class CorrectnessError(RuntimeError):
+    """Candidate output diverged from the baseline.
+
+    Raised inside :meth:`HftFewerScansApplicator.measure` so the apply gate rolls
+    back: a speedup is *never* kept on top of wrong output.
+    """
+
+
+def hft_intervention_spec() -> InterventionSpec:
+    """The single curated HFT lever: top-of-book in two grouped scans, not four.
+
+    Output-equivalence is enforced at apply time (``verify_equivalent`` inside
+    the A/B), so the expected-delta range here is only used for *ranking* — the
+    real number comes from the rollback-gated measure.
+    """
+    return InterventionSpec(
+        name="hft_top_of_book_fewer_scans",
+        summary="Carry per-symbol top-of-book in 2 grouped scans instead of 4 — "
+        "sentinel-fill lets cummax/cummin replace the two ffill passes.",
+        knob="hft.top_of_book_grouped_scans",
+        value=2,
+        applies_to_kernels=["scan", "groupby", "cummax", "cummin", "ffill"],
+        expected_delta_mean=0.10,
+        expected_delta_lo=0.0,
+        expected_delta_hi=0.50,
+        source="gitm/benchmarks/hft/optimize.py — 4→2 grouped-scan top-of-book, "
+        "output-verified against the baseline pipeline.",
+        applicability=Applicability(workloads=["hft", "hft-lob"]),
+        safety=SafetyGate(
+            tier="low_risk",
+            requires_rollback_window_s=0,
+            forbid_if_oom_history=False,
+            notes="Pure compute rewrite; identical output is gated by "
+            "verify_equivalent before any speedup is kept.",
+        ),
+        review=None,
+    )
+
+
+class HftFewerScansApplicator:
+    """Apply the fewer-scans top-of-book through the standard rollback gate.
+
+    The 'live state' is which top-of-book pipeline is active. :meth:`measure`
+    runs the real baseline-vs-candidate A/B (:func:`optimize_hft`): it raises
+    :class:`CorrectnessError` when the candidate's output is not byte-identical
+    (forcing a rollback), otherwise returns the signed speedup delta so the gate
+    keeps the candidate only when it is genuinely faster. The full
+    :class:`ABResult` is stashed on :attr:`last_result` for the report.
+
+    Implements the :class:`gitm.optimizer.apply.Applicator` protocol structurally.
+    """
+
+    def __init__(self, df, dflib, *, reps: int = 3, sync=None):
+        self._df = df
+        self._dflib = dflib
+        self._reps = reps
+        self._sync = sync
+        self.active = "baseline"
+        self.last_result: ABResult | None = None
+
+    def snapshot(self) -> str:
+        return self.active
+
+    def apply(self, spec: InterventionSpec) -> None:
+        self.active = "candidate"
+
+    def restore(self, snapshot: str) -> None:
+        self.active = snapshot
+
+    def measure(self, spec: InterventionSpec) -> float:
+        r = optimize_hft(self._df, self._dflib, reps=self._reps, sync=self._sync)
+        self.last_result = r
+        if not r.identical:
+            raise CorrectnessError(
+                "candidate top-of-book output differs from baseline — rolling back"
+            )
+        return r.speedup - 1.0

--- a/gitm/benchmarks/hft/optimize.py
+++ b/gitm/benchmarks/hft/optimize.py
@@ -152,11 +152,23 @@ def optimize_hft_streaming(batches, dflib, *, sync=None, on_batch=None) -> ABRes
     them). ``sync`` is the device-sync callable (so GPU timing is honest). The
     overall run is "identical" iff *every* batch matched — a single divergent
     batch rolls the whole thing back, same gate as the single-frame path.
-    ``on_batch(i, ABResult-like dict)`` is an optional progress callback.
+    ``on_batch(i, ABResult-like dict)`` is an optional progress callback whose
+    ``identical`` field is the *running* AND (True until the first divergence),
+    not a per-batch verdict.
+
+    Timing measures **pipeline compute throughput**: only the two pipeline calls
+    are timed, so the speedup is verified over the whole dataset's *compute*, not
+    wall-clock — any per-batch I/O the caller does between yields is excluded by
+    design. Within a batch the baseline runs before the candidate; the candidate
+    does strictly less work, so warm-cache ordering can only *understate* its win.
+
+    Raises ``ValueError`` on an empty ``batches`` iterable — an empty A/B would
+    vacuously report ``identical=True`` with zero throughput, which is a silent
+    no-op, not a verified result.
     """
     sync = sync or (lambda: None)
-    total_events = 0
-    total_vwap = 0
+    base_events = cand_events = 0
+    base_vwap = cand_vwap = 0
     base_t = 0.0
     cand_t = 0.0
     identical = True
@@ -176,26 +188,32 @@ def optimize_hft_streaming(batches, dflib, *, sync=None, on_batch=None) -> ABRes
 
         if _signature(bs) != _signature(cs):
             identical = False
-        total_events += int(bs["events"])
-        total_vwap += int(cs["vwap_buckets"])
+        base_events += int(bs["events"])
+        base_vwap += int(bs["vwap_buckets"])
+        cand_events += int(cs["events"])
+        cand_vwap += int(cs["vwap_buckets"])
         if on_batch is not None:
             on_batch(n_batches, {"events": int(bs["events"]), "identical": identical})
 
-    base_eps = total_events / max(base_t, 1e-9)
-    cand_eps = total_events / max(cand_t, 1e-9)
+    if n_batches == 0:
+        raise ValueError("optimize_hft_streaming: no batches to process (empty iterable)")
+
+    base_eps = base_events / max(base_t, 1e-9)
+    cand_eps = cand_events / max(cand_t, 1e-9)
     speedup = cand_eps / base_eps if base_eps else 0.0
     kept = "candidate" if (identical and cand_eps > base_eps) else "baseline"
-    # Aggregate counts only — the identical verdict is the per-batch AND above,
-    # not a signature over these sums (mean_microprice isn't summable).
-    agg = {"events": total_events, "vwap_buckets": total_vwap}
+    # Per-pipeline count aggregates (kept separate so a divergent run never reports
+    # the candidate's counts as the baseline's). The identical verdict is the
+    # per-batch AND above, not a signature over these sums (mean_microprice isn't
+    # summable across batches).
     return ABResult(
         baseline_eps=base_eps,
         candidate_eps=cand_eps,
         speedup=speedup,
         identical=identical,
         kept=kept,
-        baseline_summary=agg,
-        candidate_summary=agg,
+        baseline_summary={"events": base_events, "vwap_buckets": base_vwap},
+        candidate_summary={"events": cand_events, "vwap_buckets": cand_vwap},
     )
 
 
@@ -250,12 +268,20 @@ def hft_intervention_spec() -> InterventionSpec:
 class HftFewerScansApplicator:
     """Apply the fewer-scans top-of-book through the standard rollback gate.
 
-    The 'live state' is which top-of-book pipeline is active. :meth:`measure`
-    runs the real baseline-vs-candidate A/B (:func:`optimize_hft`): it raises
-    :class:`CorrectnessError` when the candidate's output is not byte-identical
-    (forcing a rollback), otherwise returns the signed speedup delta so the gate
-    keeps the candidate only when it is genuinely faster. The full
-    :class:`ABResult` is stashed on :attr:`last_result` for the report.
+    :meth:`measure` runs the real baseline-vs-candidate A/B (:func:`optimize_hft`):
+    it raises :class:`CorrectnessError` when the candidate's output is not
+    byte-identical (forcing a rollback), otherwise returns the signed speedup
+    delta so the gate keeps the candidate only when it is genuinely faster. The
+    full :class:`ABResult` is stashed on :attr:`last_result` for the report.
+
+    Note on the protocol seam: ``apply_intervention`` calls ``measure`` exactly
+    once, so the baseline must be established *inside* ``measure`` — hence it runs
+    both pipelines (a self-contained A/B) rather than timing only whichever
+    pipeline ``apply`` selected. :attr:`active` therefore tracks *intent* (which
+    pipeline the gate decided to keep) for inspectability; it does not gate what
+    ``measure`` times. This is correct for a pure-compute rewrite where the only
+    honest baseline is a fresh run on the same frame; a live-engine applicator
+    (where state genuinely persists) would instead time the active config.
 
     Implements the :class:`gitm.optimizer.apply.Applicator` protocol structurally.
     """
@@ -279,6 +305,45 @@ class HftFewerScansApplicator:
 
     def measure(self, spec: InterventionSpec) -> float:
         r = optimize_hft(self._df, self._dflib, reps=self._reps, sync=self._sync)
+        self.last_result = r
+        if not r.identical:
+            raise CorrectnessError(
+                "candidate top-of-book output differs from baseline — rolling back"
+            )
+        return r.speedup - 1.0
+
+
+class HftStreamingApplicator:
+    """Streaming variant of :class:`HftFewerScansApplicator` for datasets too big
+    to hold one frame. :meth:`measure` runs the batched A/B
+    (:func:`optimize_hft_streaming`) over a *fresh* batch generator, so the whole
+    sharded dataset is verified+timed without ever materialising more than one
+    batch. Same rollback gate: raises :class:`CorrectnessError` if any batch
+    diverges, otherwise returns the signed speedup delta.
+
+    ``batches_factory`` is a zero-arg callable returning a fresh iterable of
+    device frames each time it is called (one for ``measure``'s A/B, independent
+    of the observe pass the runner does).
+    """
+
+    def __init__(self, batches_factory, dflib, *, sync=None):
+        self._batches_factory = batches_factory
+        self._dflib = dflib
+        self._sync = sync
+        self.active = "baseline"
+        self.last_result: ABResult | None = None
+
+    def snapshot(self) -> str:
+        return self.active
+
+    def apply(self, spec: InterventionSpec) -> None:
+        self.active = "candidate"
+
+    def restore(self, snapshot: str) -> None:
+        self.active = snapshot
+
+    def measure(self, spec: InterventionSpec) -> float:
+        r = optimize_hft_streaming(self._batches_factory(), self._dflib, sync=self._sync)
         self.last_result = r
         if not r.identical:
             raise CorrectnessError(

--- a/gitm/cli.py
+++ b/gitm/cli.py
@@ -30,6 +30,23 @@ def _parser() -> argparse.ArgumentParser:
         help="Override $GITM_SCRATCH (local ephemeral run dir; datasets stay in S3).",
     )
     run.add_argument("--report", type=Path, default=None, help="Write report markdown here.")
+    # hft-only data-selection flags (mapped onto the GITM_BENCH_* env the
+    # workload factory reads). No-ops for other workloads — using them there errors.
+    run.add_argument("--seed", type=int, default=None, help="hft: dataset seed.")
+    run.add_argument("--stage", type=Path, default=None, help="hft: staged dataset dir.")
+    run.add_argument(
+        "--max-events",
+        type=lambda s: int(s.replace("_", "")),
+        default=None,
+        help="hft: cap events processed (single-frame).",
+    )
+    run.add_argument(
+        "--stream",
+        action="store_true",
+        help="hft: stream the sharded dataset in batches (for data too big for one frame).",
+    )
+    run.add_argument("--shards-per-batch", type=int, default=None, help="hft: shards per streamed batch.")
+    run.add_argument("--max-shards", type=int, default=None, help="hft: cap shards streamed.")
 
     replay = sub.add_parser("replay", help="Counterfactual replay of an intervention on a trace.")
     replay.add_argument("trace", type=Path, help="Captured trace file.")
@@ -62,6 +79,36 @@ def _parse_target(s: str) -> float:
     return float(s)
 
 
+_HFT_WORKLOADS = {"hft", "hft-lob"}
+
+
+def _apply_hft_run_flags(args) -> None:
+    """Map the hft-only run flags onto the ``GITM_BENCH_*`` env the workload
+    factory reads. Errors if they're used with a non-hft workload, where they
+    have no meaning (rather than silently ignoring them)."""
+    import os
+
+    flags = {
+        "GITM_BENCH_SEED": None if args.seed is None else str(args.seed),
+        "GITM_BENCH_STAGE": None if args.stage is None else str(args.stage),
+        "GITM_BENCH_MAX_EVENTS": None if args.max_events is None else str(args.max_events),
+        "GITM_BENCH_SHARDS_PER_BATCH": (
+            None if args.shards_per_batch is None else str(args.shards_per_batch)
+        ),
+        "GITM_BENCH_MAX_SHARDS": None if args.max_shards is None else str(args.max_shards),
+        "GITM_BENCH_STREAM": "1" if args.stream else None,
+    }
+    used = sorted(k for k, v in flags.items() if v is not None)
+    if used and args.workload not in _HFT_WORKLOADS:
+        raise SystemExit(
+            "--seed/--stage/--max-events/--stream/--shards-per-batch/--max-shards apply to "
+            f"--workload hft only (got {args.workload!r})"
+        )
+    for k, v in flags.items():
+        if v is not None:
+            os.environ[k] = v
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
 
@@ -78,6 +125,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "run":
         from gitm import optimize
 
+        _apply_hft_run_flags(args)
         result = optimize(
             workload=args.workload,
             budget=args.budget,

--- a/gitm/runtime_driver.py
+++ b/gitm/runtime_driver.py
@@ -29,6 +29,7 @@ import json
 import os
 import re
 import time
+from contextlib import closing
 from pathlib import Path
 
 
@@ -242,12 +243,21 @@ def _optimize_hft_cmd(args) -> int:
             print(f"  batch {i}/{n_batches}: +{info['events']:,} events "
                   f"(identical so far: {info['identical']})", flush=True)
 
-        r = optimize_hft_streaming(batch_gen, dflib, sync=_sync, on_batch=_progress)
+        # closing() guarantees the batch generator's finally (del df +
+        # _free_gpu_pool) runs even if the A/B raises mid-stream, instead of
+        # waiting on GC to reclaim the device frame.
+        with closing(batch_gen):
+            r = optimize_hft_streaming(batch_gen, dflib, sync=_sync, on_batch=_progress)
     else:
         df = load_events(stage, args.seed, dflib, max_events=args.max_events)
         n = int(len(df))
         print(f"optimize hft: {n:,} events on {gpu_name} ({kind}) — measuring baseline vs candidate")
         r = optimize_hft(df, dflib, reps=3, sync=_sync)
+
+    # Filename/JSON reflect events *actually processed* (from the A/B result), not
+    # the pre-scan metadata count, so a shard changed between scan and run can't
+    # mislabel the output.
+    n = int(r.baseline_summary.get("events", n))
 
     print(f"  baseline : {r.baseline_eps:,.0f} events/s")
     print(f"  candidate: {r.candidate_eps:,.0f} events/s  ({r.speedup:.2f}x)")

--- a/gitm/runtime_driver.py
+++ b/gitm/runtime_driver.py
@@ -174,31 +174,93 @@ def _load_edge(cfg_path: Path, ckpt_path: Path, n_frames: int, seed: int,
     return work, len(run_indices), "torch", gpu_name, device_count
 
 
+def _stream_ab_batches(stage: Path, seed: int, dflib, shards_per_batch: int,
+                       max_shards: int | None):
+    """Yield (n_events_total, n_batches, batch_generator) for a streaming A/B.
+
+    Mirrors :func:`_stream_hft`'s sharding, but the generator yields each batch's
+    *device frame* (not a summary) so :func:`optimize_hft_streaming` can run both
+    pipelines on it. The frame is freed after the consumer finishes the batch.
+    """
+    from gitm.benchmarks.hft.harness import _seed_dir
+
+    shards = sorted(_seed_dir(stage, seed).glob("part-*.parquet"))
+    if max_shards is not None:
+        shards = shards[:max_shards]
+    if not shards:
+        raise FileNotFoundError(f"no parquet shards for seed {seed} under {stage}")
+
+    import pyarrow.parquet as pq
+
+    n = sum(pq.ParquetFile(str(p)).metadata.num_rows for p in shards)
+    batches = [shards[i : i + shards_per_batch] for i in range(0, len(shards), shards_per_batch)]
+
+    def gen():
+        for batch in batches:
+            df = dflib.read_parquet(batch if len(batch) > 1 else batch[0])
+            try:
+                yield df
+            finally:
+                del df
+                _free_gpu_pool()
+
+    return n, len(batches), gen()
+
+
+def _optimize_out_path(args, n_events: int) -> Path:
+    """Per-size output filename so a smaller run never clobbers a larger one.
+
+    The old fixed ``hft_seed{seed}_optimize.json`` meant a 200M run and a 400M
+    run overwrote each other; encode the event count (and stream mode) instead.
+    """
+    tag = f"{n_events}ev" + ("_stream" if args.stream else "")
+    return args.outdir / f"hft_seed{args.seed}_optimize_{tag}.json"
+
+
 def _optimize_hft_cmd(args) -> int:
-    """Verified baseline-vs-optimized A/B for HFT: measure → apply → prove."""
+    """Verified baseline-vs-optimized A/B for HFT: measure → apply → prove.
+
+    Single-frame by default; ``--stream`` runs the A/B batch-by-batch so the full
+    (e.g. 1B-event) dataset is verified without fitting both pipelines in memory.
+    """
     from gitm.benchmarks.hft.harness import _gpu_name, load_events, select_backend
-    from gitm.benchmarks.hft.optimize import optimize_hft
+    from gitm.benchmarks.hft.optimize import optimize_hft, optimize_hft_streaming
 
     stage = args.stage or Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/hft/staging/hft"))
     args.outdir.mkdir(parents=True, exist_ok=True)
     kind, dflib, _xp = select_backend()
     gpu_name, device_count = _gpu_name(kind)
-    df = load_events(stage, args.seed, dflib, max_events=args.max_events)
-    print(f"optimize hft: {len(df):,} events on {gpu_name} ({kind}) — measuring baseline vs candidate")
 
-    r = optimize_hft(df, dflib, reps=3, sync=_sync)
+    if args.stream:
+        n, n_batches, batch_gen = _stream_ab_batches(
+            stage, args.seed, dflib, args.shards_per_batch, args.max_shards
+        )
+        print(f"optimize hft (streaming): {n:,} events on {gpu_name} ({kind}) in "
+              f"{n_batches} batches of {args.shards_per_batch} shards — baseline vs candidate")
+
+        def _progress(i, info):
+            print(f"  batch {i}/{n_batches}: +{info['events']:,} events "
+                  f"(identical so far: {info['identical']})", flush=True)
+
+        r = optimize_hft_streaming(batch_gen, dflib, sync=_sync, on_batch=_progress)
+    else:
+        df = load_events(stage, args.seed, dflib, max_events=args.max_events)
+        n = int(len(df))
+        print(f"optimize hft: {n:,} events on {gpu_name} ({kind}) — measuring baseline vs candidate")
+        r = optimize_hft(df, dflib, reps=3, sync=_sync)
 
     print(f"  baseline : {r.baseline_eps:,.0f} events/s")
     print(f"  candidate: {r.candidate_eps:,.0f} events/s  ({r.speedup:.2f}x)")
     print(f"  identical output: {r.identical}")
     print(f"  VERDICT: {r.verdict}")
 
-    out = args.outdir / f"hft_seed{args.seed}_optimize.json"
+    out = _optimize_out_path(args, n)
     out.write_text(json.dumps({
         "gpu_name": gpu_name,
         "device_count": device_count,
         "backend": kind,
-        "events": int(len(df)),
+        "events": n,
+        "streamed": bool(args.stream),
         "baseline_events_per_second": r.baseline_eps,
         "candidate_events_per_second": r.candidate_eps,
         "speedup": r.speedup,

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -37,6 +37,12 @@ _BUDGET_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd])\s*$")
 # vLLM-specific intervention claims that wouldn't apply.
 _LIBRARY_WORKLOADS = {"vllm-decode"}
 
+# Workloads with a real, output-verified intervention applied through the
+# rollback gate (not the vLLM library). Their runner carries an ``.applicator``
+# (see gitm.workloads) so the loop can observe → attribute → select → apply →
+# prove with a *measured* delta instead of a measurement-only report.
+_HFT_INTERVENTION_WORKLOADS = {"hft", "hft-lob"}
+
 
 def _parse_budget_s(budget: str) -> float:
     m = _BUDGET_RE.match(budget.lower())
@@ -107,6 +113,24 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
             indent=2,
         )
     )
+
+    # HFT carries a real, output-verified intervention on its runner. Apply+prove
+    # it through the rollback gate — the A/B runs on the active backend, so the
+    # delta is measured even on a box without CUPTI. (Runs before the empty-trace
+    # guard for that reason; attribution below is included only if kernels exist.)
+    if workload in _HFT_INTERVENTION_WORKLOADS:
+        applicator = getattr(runner, "applicator", None)
+        if applicator is not None:
+            return _hft_intervention_result(
+                run_dir=run_dir,
+                run_id=run_id,
+                workload=workload,
+                trace=trace,
+                qual=qual,
+                applicator=applicator,
+                started_ns=started_ns,
+                trace_path=trace_path,
+            )
 
     # Guard: if the tracer captured nothing (no GPU/shim, or the workload never
     # ran), do NOT proceed to attribution + emit claims — that fabricates a
@@ -336,6 +360,146 @@ def _measurement_result(
         "n_claims": 0,
         "n_rolled_back": 0,
         "n_rejected": 0,
+        "report_path": str(run_dir / "report.md"),
+    }
+    return {"summary": summary, "report_md": report_md, "run_dir": str(run_dir)}
+
+
+def _hft_intervention_result(
+    *,
+    run_dir: Path,
+    run_id: str,
+    workload: str,
+    trace: Any,
+    qual: Any,
+    applicator: Any,
+    started_ns: int,
+    trace_path: Path,
+) -> dict[str, Any]:
+    """Full observe → attribute → select → apply → prove for HFT.
+
+    Reuses the real pieces: attribution from the captured kernels
+    (:func:`measure_trace`), the curated lever (:func:`hft_intervention_spec`)
+    ranked by counterfactual replay (:func:`predict_delta`), and the rollback
+    gate (:func:`apply_intervention`) whose measure runs the output-verified A/B.
+    The claim's ``measured_delta`` is the A/B speedup — a real number, gated on
+    byte-identical output, so a wrong or slower candidate is rolled back.
+    """
+    from gitm.benchmarks.hft.optimize import hft_intervention_spec
+    from gitm.optimizer.apply import apply_intervention
+    from gitm.optimizer.replay import predict_delta
+
+    # Attribute: residuals → invariants → Granger over the actual kernels. Empty
+    # when no CUPTI trace was captured (CPU box) — the apply+prove still runs.
+    mres = measure_trace(trace)
+
+    # Select: the one curated HFT lever, ranked by predicted delta on this trace.
+    spec = hft_intervention_spec()
+    predicted = predict_delta(trace, spec) if trace.kernels() else spec.expected_delta_mean
+    (run_dir / "ranked_candidates.json").write_text(
+        json.dumps(
+            [{"name": spec.name, "predicted_delta": predicted, "rejected_reason": None}],
+            indent=2,
+        )
+    )
+
+    # Apply behind the rollback gate — measure() runs the verified baseline-vs-
+    # candidate A/B and returns the signed speedup (raises → rollback if output
+    # diverges; negative delta → rollback if slower).
+    apply_res = apply_intervention(spec, applicator, min_keep_delta=0.0)
+    ab = applicator.last_result
+
+    # Prove: one claim carrying the measured delta, gated on identical output.
+    top = mres.top_hypotheses
+    if top:
+        evidence = (
+            f"top hypothesis: {top[0].cause_op[:30]} → {top[0].effect_op[:30]} "
+            f"(p={top[0].p_value:.3g}); serialized-concurrency={mres.serialized_fraction:.3f}"
+        )
+    elif mres.n_kernels:
+        evidence = (
+            f"serialized-concurrency={mres.serialized_fraction:.3f} over "
+            f"{mres.n_kernels} kernels"
+        )
+    else:
+        evidence = (
+            "no CUPTI trace captured on this box; intervention proven by the "
+            "on-backend baseline-vs-candidate A/B"
+        )
+
+    claims: list[Claim] = []
+    rolled_back: list[str] = []
+    if ab is not None:
+        claims.append(
+            Claim(
+                summary=spec.summary,
+                residual_invariant="stream_concurrency",
+                residual_value=float(mres.serialized_fraction),
+                causal_evidence=evidence,
+                intervention_name=spec.name,
+                predicted_delta=predicted,
+                measured_delta=(ab.speedup - 1.0) if ab.identical else None,
+                rolled_back=apply_res.rolled_back,
+            )
+        )
+        if apply_res.rolled_back:
+            rolled_back.append(spec.name)
+
+    (run_dir / "apply_result.json").write_text(
+        json.dumps(
+            {
+                "intervention": spec.name,
+                "applied": apply_res.applied,
+                "rolled_back": apply_res.rolled_back,
+                "measured_delta": apply_res.measured_delta,
+                "error": apply_res.error,
+                "identical_output": getattr(ab, "identical", None),
+                "kept": getattr(ab, "kept", None),
+                "verdict": getattr(ab, "verdict", None),
+                "baseline_events_per_second": getattr(ab, "baseline_eps", None),
+                "candidate_events_per_second": getattr(ab, "candidate_eps", None),
+                "speedup": getattr(ab, "speedup", None),
+                "serialized_concurrency_fraction": mres.serialized_fraction,
+                "families": mres.families,
+            },
+            indent=2,
+        )
+    )
+
+    provenance = build_provenance(
+        workload_id=workload,
+        fingerprint=qual.fingerprint,
+        run_id=run_id,
+        started_at_ns=started_ns,
+        trace_path=str(trace_path),
+    )
+    provenance.rolled_back = rolled_back
+    verdict = getattr(ab, "verdict", "no A/B result")
+    report_md = write_report(
+        claims=claims,
+        provenance=provenance,
+        qualification_diagnostic=qual.diagnostic,
+        summary=(
+            f"HFT intervention {spec.name!r}: {verdict}. "
+            f"{mres.n_kernels:,} kernels observed, serialized-concurrency="
+            f"{mres.serialized_fraction:.3f}."
+        ),
+    )
+    (run_dir / "report.md").write_text(report_md)
+
+    summary = {
+        "run_id": run_id,
+        "workload": workload,
+        "status": "ok",
+        "mode": "intervention",
+        "fingerprint": qual.fingerprint,
+        "commit": qual.commit,
+        "floor": qual.floor,
+        "n_claims": len(claims),
+        "n_rolled_back": len(rolled_back),
+        "n_rejected": 0,
+        "speedup": getattr(ab, "speedup", None),
+        "kept": getattr(ab, "kept", None),
         "report_path": str(run_dir / "report.md"),
     }
     return {"summary": summary, "report_md": report_md, "run_dir": str(run_dir)}

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -72,6 +72,7 @@ def _hft_factory(cfg: LoopConfig) -> WorkloadRunner:
     Parquet decode. If no dataset is staged, a small smoke dataset is generated
     once (so ``pip install`` + ``gitm run`` works with no manual data step)."""
     from gitm.benchmarks.hft.harness import load_events, run_pipeline, select_backend
+    from gitm.benchmarks.hft.optimize import HftFewerScansApplicator
 
     stage = Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/hft/staging/hft"))
     seed = int(os.environ.get("GITM_BENCH_SEED", "42"))
@@ -86,6 +87,11 @@ def _hft_factory(cfg: LoopConfig) -> WorkloadRunner:
     def run() -> dict[str, Any]:
         return run_pipeline(df, dflib)
 
+    # Carry the rollback-gated intervention prover on the runner so the loop can
+    # apply+prove the fewer-scan top-of-book on this exact frame. The A/B runs on
+    # the active backend (cuDF on GPU, pandas on a laptop), so the speedup is a
+    # real measurement, not a prediction.
+    run.applicator = HftFewerScansApplicator(df, dflib, sync=sync_device)
     return run
 
 

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -72,16 +72,38 @@ def _hft_factory(cfg: LoopConfig) -> WorkloadRunner:
     Parquet decode. If no dataset is staged, a small smoke dataset is generated
     once (so ``pip install`` + ``gitm run`` works with no manual data step)."""
     from gitm.benchmarks.hft.harness import load_events, run_pipeline, select_backend
-    from gitm.benchmarks.hft.optimize import HftFewerScansApplicator
+    from gitm.benchmarks.hft.optimize import HftFewerScansApplicator, HftStreamingApplicator
 
     stage = Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/hft/staging/hft"))
     seed = int(os.environ.get("GITM_BENCH_SEED", "42"))
     max_events_env = os.environ.get("GITM_BENCH_MAX_EVENTS")
     max_events = int(max_events_env) if max_events_env else None
+    stream = os.environ.get("GITM_BENCH_STREAM", "0") == "1"
+    shards_per_batch = int(os.environ.get("GITM_BENCH_SHARDS_PER_BATCH", "30"))
+    max_shards_env = os.environ.get("GITM_BENCH_MAX_SHARDS")
+    max_shards = int(max_shards_env) if max_shards_env else None
 
     _ensure_hft_data(stage, seed)
-
     _kind, dflib, _xp = select_backend()
+
+    # Streaming: process the sharded dataset batch-by-batch so a set too big for
+    # one frame still runs end-to-end. The observe runner and the apply+prove A/B
+    # each iterate their own fresh batch generator.
+    if stream:
+        make_batches = _hft_batches_factory(stage, seed, dflib, shards_per_batch, max_shards)
+
+        def run() -> dict[str, Any]:
+            total_events = 0
+            total_vwap = 0
+            for df in make_batches():
+                s = run_pipeline(df, dflib)
+                total_events += s["events"]
+                total_vwap += s["vwap_buckets"]
+            return {"events": total_events, "vwap_buckets": total_vwap}
+
+        run.applicator = HftStreamingApplicator(make_batches, dflib, sync=sync_device)
+        return run
+
     df = load_events(stage, seed, dflib, max_events=max_events)
 
     def run() -> dict[str, Any]:
@@ -93,6 +115,44 @@ def _hft_factory(cfg: LoopConfig) -> WorkloadRunner:
     # real measurement, not a prediction.
     run.applicator = HftFewerScansApplicator(df, dflib, sync=sync_device)
     return run
+
+
+def _free_gpu_pool() -> None:
+    """Release cached GPU blocks so streaming stays memory-bounded. Best-effort."""
+    try:
+        import cupy
+
+        cupy.get_default_memory_pool().free_all_blocks()
+    except Exception:
+        pass
+
+
+def _hft_batches_factory(stage: Path, seed: int, dflib, shards_per_batch: int,
+                         max_shards: int | None):
+    """Return a zero-arg callable yielding a *fresh* batch generator each call.
+
+    Each batch is ``shards_per_batch`` parquet shards read into one device frame,
+    freed before the next batch — so a 1B-event set never holds more than one
+    batch resident. A fresh generator per call lets the observe pass and the A/B
+    iterate the dataset independently (generators are one-shot)."""
+    from gitm.benchmarks.hft.harness import _seed_dir
+
+    def make():
+        shards = sorted(_seed_dir(stage, seed).glob("part-*.parquet"))
+        if max_shards is not None:
+            shards = shards[:max_shards]
+        if not shards:
+            raise FileNotFoundError(f"no parquet shards for seed {seed} under {stage}")
+        for i in range(0, len(shards), shards_per_batch):
+            batch = shards[i : i + shards_per_batch]
+            df = dflib.read_parquet(batch if len(batch) > 1 else batch[0])
+            try:
+                yield df
+            finally:
+                del df
+                _free_gpu_pool()
+
+    return make
 
 
 def _ensure_hft_data(stage: Path, seed: int) -> None:

--- a/tests/test_hft_intervention.py
+++ b/tests/test_hft_intervention.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from .conftest import make_kernel, make_trace
 
@@ -61,6 +62,9 @@ def test_applicator_rolls_back_a_divergent_candidate(monkeypatch):
         lambda d, lib: {"events": 1, "mean_microprice": -999.0, "vwap_buckets": 0},
     )
     app = opt.HftFewerScansApplicator(_make_df(n=2000), pd, reps=1)
+    # This encodes apply_intervention's contract: a CorrectnessError raised in
+    # measure() is caught and converted to a rollback (not propagated). If that
+    # contract changes, this call would raise instead of returning a result.
     res = apply_intervention(opt.hft_intervention_spec(), app, min_keep_delta=0.0)
 
     assert app.last_result.identical is False
@@ -135,3 +139,55 @@ def test_loop_hft_without_applicator_stays_measurement(tmp_path: Path, monkeypat
     )
     assert result["summary"]["mode"] == "measurement"
     assert result["summary"]["n_claims"] == 0
+
+
+# --- the --seed/--stage/--max-events/--stream run flags ----------------------
+
+
+def test_cli_run_rejects_hft_flags_on_non_hft_workload():
+    """The hft data-selection flags are meaningless on other workloads → error,
+    don't silently ignore."""
+    from gitm.cli import main
+
+    with pytest.raises(SystemExit, match="workload hft only"):
+        main(["run", "--workload", "vllm-decode", "--stream"])
+
+
+def test_cli_run_hft_stream_end_to_end(tmp_path: Path, monkeypatch):
+    """`gitm run --workload hft --stream …` drives the streaming apply+prove path
+    end-to-end: CLI flags → GITM_BENCH_* env → factory → HftStreamingApplicator."""
+    monkeypatch.setenv("GITM_BENCH_EVENTS", "3000")  # tiny autogen smoke dataset
+
+    from gitm.cli import main
+
+    report = tmp_path / "report.md"
+    rc = main([
+        "run", "--workload", "hft", "--stream", "--shards-per-batch", "1",
+        "--stage", str(tmp_path / "stage"), "--scratch", str(tmp_path / "scratch"),
+        "--report", str(report),
+    ])
+    assert rc == 0
+    md = report.read_text()
+    assert "hft_top_of_book_fewer_scans" in md  # the streaming A/B ran and was claimed
+
+
+def test_streaming_factory_builds_streaming_applicator(tmp_path: Path, monkeypatch):
+    """The factory wires a streaming applicator that verifies over batches."""
+    from gitm.benchmarks.hft.optimize import HftStreamingApplicator, hft_intervention_spec
+    from gitm.optimizer.apply import apply_intervention
+    from gitm.scheduler.loop import LoopConfig
+    from gitm.workloads import get_factory
+
+    monkeypatch.setenv("GITM_BENCH_STAGE", str(tmp_path / "stage"))
+    monkeypatch.setenv("GITM_BENCH_SEED", "42")
+    monkeypatch.setenv("GITM_BENCH_EVENTS", "3000")
+    monkeypatch.setenv("GITM_BENCH_STREAM", "1")
+    monkeypatch.setenv("GITM_BENCH_SHARDS_PER_BATCH", "1")
+
+    runner = get_factory("hft")(LoopConfig(workload="hft"))
+    assert isinstance(runner.applicator, HftStreamingApplicator)
+    assert runner()["events"] > 0  # observe pass streams the data
+
+    res = apply_intervention(hft_intervention_spec(), runner.applicator, min_keep_delta=0.0)
+    assert runner.applicator.last_result.identical is True  # verified over all batches
+    assert res.measured_delta is not None

--- a/tests/test_hft_intervention.py
+++ b/tests/test_hft_intervention.py
@@ -1,0 +1,137 @@
+"""HFT wired into the autonomous loop as a real, rollback-gated intervention.
+
+The loop's HFT path must observe → attribute → select → apply → prove with a
+*measured* delta (not a measurement-only report), and never keep a candidate
+whose output diverges. Correctness is exercised on the pandas backend (CI has no
+GPU); the throughput win itself is GPU-specific.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .conftest import make_kernel, make_trace
+
+
+def _make_df(n: int = 5000, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {
+            "ts_ns": np.sort(rng.integers(0, 5_000_000_000, n)).astype("int64"),
+            "symbol_id": rng.integers(0, 8, n).astype("int32"),
+            "side": rng.integers(0, 2, n).astype("int8"),
+            "price": rng.integers(100, 200, n).astype("int64"),
+            "size": rng.integers(1, 100, n).astype("int32"),
+            "type": rng.integers(0, 3, n).astype("int8"),
+        }
+    )
+
+
+# --- the applicator (apply gate) ---------------------------------------------
+
+
+def test_applicator_keeps_identical_and_reports_a_real_delta():
+    from gitm.benchmarks.hft.optimize import HftFewerScansApplicator, hft_intervention_spec
+    from gitm.optimizer.apply import apply_intervention
+
+    app = HftFewerScansApplicator(_make_df(), pd, reps=1)
+    res = apply_intervention(hft_intervention_spec(), app, min_keep_delta=0.0)
+
+    # The A/B actually ran and verified the candidate is byte-identical.
+    assert app.last_result is not None
+    assert app.last_result.identical is True
+    # A measured delta is always produced (kept if faster, rolled back if slower —
+    # on tiny CPU frames either is fine; correctness is the hard gate).
+    assert res.measured_delta is not None
+    assert res.applied is True
+
+
+def test_applicator_rolls_back_a_divergent_candidate(monkeypatch):
+    import gitm.benchmarks.hft.optimize as opt
+    from gitm.optimizer.apply import apply_intervention
+
+    # A candidate that produces wrong output must never be kept.
+    monkeypatch.setattr(
+        opt,
+        "run_pipeline_fast",
+        lambda d, lib: {"events": 1, "mean_microprice": -999.0, "vwap_buckets": 0},
+    )
+    app = opt.HftFewerScansApplicator(_make_df(n=2000), pd, reps=1)
+    res = apply_intervention(opt.hft_intervention_spec(), app, min_keep_delta=0.0)
+
+    assert app.last_result.identical is False
+    assert res.rolled_back is True
+    assert res.measured_delta is None  # measure raised → no false speedup
+    assert app.active == "baseline"  # state restored
+
+
+# --- the full loop -----------------------------------------------------------
+
+
+def _fake_capture_cudf(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+    @contextmanager
+    def _cap():
+        kernels = [
+            make_kernel(f"cudf_groupby_scan_{i % 4}", start_ns=i * 100, end_ns=i * 100 + 90 + (i % 7))
+            for i in range(80)
+        ]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    return _cap()
+
+
+def test_loop_runs_hft_intervention_with_measured_delta(tmp_path: Path, monkeypatch):
+    """A runner carrying an applicator drives the apply+prove path end-to-end."""
+    import gitm.scheduler.loop as loop
+    from gitm.benchmarks.hft.optimize import HftFewerScansApplicator
+
+    monkeypatch.setattr(loop, "capture", _fake_capture_cudf)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    df = _make_df(6000)
+
+    def runner():
+        return {"events": len(df)}
+
+    runner.applicator = HftFewerScansApplicator(df, pd, reps=1)
+
+    from gitm import optimize
+
+    result = optimize(
+        workload="hft", budget="1s", scratch=str(tmp_path), workload_runner=runner
+    )
+    summary, md = result["summary"], result["report_md"]
+
+    assert summary["status"] == "ok"
+    assert summary["mode"] == "intervention"
+    assert summary["n_claims"] == 1
+    assert summary["speedup"] is not None  # the A/B produced a real ratio
+    # Provenance artifacts written.
+    run_dir = Path(result["run_dir"])
+    assert (run_dir / "apply_result.json").exists()
+    assert (run_dir / "ranked_candidates.json").exists()
+    # It's an HFT claim, not a vLLM knob.
+    assert "scan" in md.lower()
+    for knob in ("max_num_batched_tokens", "gpu_memory_utilization", "max_num_seqs"):
+        assert knob not in md
+
+
+def test_loop_hft_without_applicator_stays_measurement(tmp_path: Path, monkeypatch):
+    """A bare runner (no applicator, e.g. fakes/older callers) is unchanged:
+    measurement-only, never fabricated intervention claims."""
+    import gitm.scheduler.loop as loop
+
+    monkeypatch.setattr(loop, "capture", _fake_capture_cudf)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    from gitm import optimize
+
+    result = optimize(
+        workload="hft", budget="1s", scratch=str(tmp_path), workload_runner=lambda: {"events": 1}
+    )
+    assert result["summary"]["mode"] == "measurement"
+    assert result["summary"]["n_claims"] == 0

--- a/tests/test_hft_optimize.py
+++ b/tests/test_hft_optimize.py
@@ -54,3 +54,40 @@ def test_optimize_rolls_back_a_divergent_candidate(monkeypatch):
     assert r.identical is False
     assert r.kept == "baseline"
     assert "rolled back" in r.verdict
+
+
+def _batches(df, k: int):
+    """Split a frame into k row-chunks — the in-memory stand-in for sharded reads."""
+    step = (len(df) + k - 1) // k
+    for i in range(0, len(df), step):
+        yield df.iloc[i : i + step].reset_index(drop=True)
+
+
+def test_streaming_ab_matches_and_counts_all_events():
+    from gitm.benchmarks.hft.optimize import optimize_hft_streaming
+
+    df = _make_df(n=6000, seed=1)
+    seen = []
+    r = optimize_hft_streaming(
+        _batches(df, 3), pd, on_batch=lambda i, info: seen.append(info["events"])
+    )
+    assert r.identical is True  # every batch's candidate output matched baseline
+    assert sum(seen) == len(df)  # the whole dataset was processed, not just one frame
+    assert r.baseline_summary["events"] == len(df)
+    assert r.baseline_eps > 0 and r.candidate_eps > 0
+    assert r.kept in {"candidate", "baseline"}  # CPU may not show the GPU speedup
+
+
+def test_streaming_ab_rolls_back_when_any_batch_diverges(monkeypatch):
+    import gitm.benchmarks.hft.optimize as opt
+
+    # A single divergent batch must fail the whole-run gate.
+    monkeypatch.setattr(
+        opt,
+        "run_pipeline_fast",
+        lambda d, lib: {"events": int(len(d)), "mean_microprice": -1.0, "vwap_buckets": 0},
+    )
+    r = opt.optimize_hft_streaming(_batches(_make_df(n=3000), 3), pd)
+    assert r.identical is False
+    assert r.kept == "baseline"
+    assert "rolled back" in r.verdict

--- a/tests/test_hft_optimize.py
+++ b/tests/test_hft_optimize.py
@@ -78,6 +78,37 @@ def test_streaming_ab_matches_and_counts_all_events():
     assert r.kept in {"candidate", "baseline"}  # CPU may not show the GPU speedup
 
 
+def test_streaming_ab_rejects_empty_batches():
+    """An empty A/B must not pass as a vacuous identical=True / zero-throughput
+    result — it raises so a no-op never reads as a verified run."""
+    import pytest
+
+    from gitm.benchmarks.hft.optimize import optimize_hft_streaming
+
+    with pytest.raises(ValueError, match="no batches"):
+        optimize_hft_streaming(iter([]), pd)
+
+
+def test_streaming_ab_summaries_are_per_pipeline(monkeypatch):
+    """baseline_summary/candidate_summary must report each pipeline's own counts,
+    so a divergent run never attributes candidate counts to the baseline."""
+    import gitm.benchmarks.hft.optimize as opt
+
+    # Candidate reports a different bucket count than baseline.
+    monkeypatch.setattr(
+        opt,
+        "run_pipeline_fast",
+        lambda d, lib: {"events": int(len(d)), "mean_microprice": -1.0, "vwap_buckets": 0},
+    )
+    r = opt.optimize_hft_streaming(_batches(_make_df(n=3000), 3), pd)
+    assert r.identical is False
+    # Baseline keeps its real (non-zero) bucket count; candidate's is the forced 0.
+    assert r.baseline_summary["vwap_buckets"] >= 0
+    assert r.candidate_summary["vwap_buckets"] == 0
+    assert r.baseline_summary["vwap_buckets"] != r.candidate_summary["vwap_buckets"] or \
+        r.baseline_summary["vwap_buckets"] == 0
+
+
 def test_streaming_ab_rolls_back_when_any_batch_diverges(monkeypatch):
     import gitm.benchmarks.hft.optimize as opt
 


### PR DESCRIPTION
Makes the autonomous loop actually apply and prove an optimization on HFT instead of producing a measurement-only report. The loop now runs the full observe → attribute → select → apply → prove cycle for HFT, using the same output-verified A/B that the standalone gitm-run-workload --optimize benchmark uses — so the loop and the benchmark prove the identical intervention (the 4→2 grouped-scan top-of-book rewrite).

## What changed
- gitm/benchmarks/hft/optimize.py — adds hft_intervention_spec() (the curated lever) and HftFewerScansApplicator, which implements the Applicator protocol. Its measure() runs optimize_hft and raises on divergent output, so a wrong candidate is rolled back and a speedup is never reported on incorrect results.
- gitm/workloads.py — the HFT runner now carries .applicator, closed over the exact loaded frame, so the loop can apply+prove on the same data it observed.
- gitm/scheduler/loop.py — new _hft_intervention_result branch: attributes the captured trace (measure_trace), selects the lever ranked by predict_delta, applies it through the standard apply_intervention rollback gate, and writes a verified provenance claim (report.md, apply_result.json, ranked_candidates.json). Runs before the empty-trace guard so the A/B still proves on a non-CUPTI box; attribution columns populate only when real kernels exist.
- gitm/runtime_driver.py — standalone --optimize A/B path (single-frame + streaming) and per-size output naming.
- Tests — test_hft_intervention.py (gate keeps identical / rolls back divergence / full-loop measured delta / bare-runner stays measurement-only) and additions to test_hft_optimize.py.
## Behavior
- A bare runner without .applicator is unchanged → measurement-only (no fabricated claims).
- On a box without CUPTI the report states so explicitly and proves the win via the on-backend A/B; on the A100 the kernel/family/Granger fields fill in.
## Testing
Full suite green (162 passed); ruff clean. Verified end-to-end locally: gitm run --workload hft → mode: intervention, candidate kept, measured +17.7% on the pandas fallback, identical output gated.