### PR TITLE
Add openfold/alphafold workload: observe AF2 inference under the runtime

### DIFF
--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -226,6 +226,83 @@ def _edge_factory(cfg: LoopConfig) -> WorkloadRunner:
     return run
 
 
+@register("openfold", "alphafold", "af2")
+def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
+    """AlphaFold2 inference via OpenFold (the biotech benchmark), wired for the loop.
+
+    Builds the real OpenFold runner and runs warmup folds *outside* the capture
+    window; the returned runner folds ``GITM_BENCH_PROTEINS`` proteins (length
+    <= ``GITM_BENCH_MAX_LEN`` that have precomputed MSAs under ``$STAGE/msas``),
+    so the trace is the Evoformer + structure-module compute — not MSA load or
+    first-call autotune.
+
+    **Inference only** — MSAs must be precomputed; this never runs mmseqs2, so
+    the GPU does only the work the GPU is for. No intervention library applies to
+    AF2 yet, so the loop emits an honest *measurement* report (the real kernels),
+    the AF2 analog of the hft/edge measurement run — it does not fabricate a
+    speedup. Weights come from ``OPENFOLD_WEIGHTS``; GPU-only, degrades to a
+    no-data report where OpenFold/torch/data are absent.
+
+    Env:
+        GITM_BENCH_STAGE     staged dir with proteins_50k.fasta + msas/
+        GITM_BENCH_SEED      inference seed (default 42)
+        GITM_BENCH_PROTEINS  proteins to fold under capture (default 8)
+        GITM_BENCH_MAX_LEN   max residue length (default 384)
+        GITM_BENCH_WARMUP    untimed warmup folds before capture (default 2)
+    """
+    import statistics
+
+    from benchmarks.biotech.fetch import read_fasta
+    from benchmarks.biotech.harness import _msa_path, load_openfold_runner
+
+    stage = Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/biotech/staging/biotech"))
+    seed = int(os.environ.get("GITM_BENCH_SEED", "42"))
+    n_proteins = int(os.environ.get("GITM_BENCH_PROTEINS", "8"))
+    max_len = int(os.environ.get("GITM_BENCH_MAX_LEN", "384"))
+    warmup = int(os.environ.get("GITM_BENCH_WARMUP", "2"))
+
+    fasta = stage / "proteins_50k.fasta"
+    if not fasta.exists():
+        raise FileNotFoundError(
+            f"missing {fasta} — stage the biotech dataset (proteins_50k.fasta + msas/) "
+            "or point GITM_BENCH_STAGE at one."
+        )
+    # Filter to proteins that are both short enough AND have precomputed MSAs,
+    # then take the first n — robust whether the stage is the full 50k set or a
+    # smoke subset (we never compute MSAs here).
+    eligible = [
+        r for r in read_fasta(fasta)
+        if len(r.seq) <= max_len and _msa_path(stage, r) is not None
+    ]
+    proteins = eligible[:n_proteins]
+    if not proteins:
+        raise FileNotFoundError(
+            f"no proteins (len<={max_len}) with precomputed MSAs under {stage}/msas"
+        )
+
+    runner = load_openfold_runner(seed)
+
+    # Warmup outside the capture window: first-call kernel autotune + allocator
+    # growth must not pollute the trace.
+    for r in proteins[: min(warmup, len(proteins))]:
+        runner.predict(r, _msa_path(stage, r))
+    sync_device()
+
+    def run() -> dict[str, Any]:
+        plddts: list[float] = []
+        for r in proteins:
+            out = runner.predict(r, _msa_path(stage, r))
+            if "plddt" in out:
+                plddts.append(float(out["plddt"]))
+        return {
+            "structures": len(proteins),
+            "events": len(proteins),  # generic count for the loop's throughput line
+            "median_plddt": statistics.median(plddts) if plddts else None,
+        }
+
+    return run
+
+
 def sync_device() -> None:
     """Block until queued GPU work completes, so all kernels land in the trace
     before capture stops. Best-effort — a no-op without CuPy/torch."""

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -267,14 +267,17 @@ def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
             f"missing {fasta} — stage the biotech dataset (proteins_50k.fasta + msas/) "
             "or point GITM_BENCH_STAGE at one."
         )
-    # Filter to proteins that are both short enough AND have precomputed MSAs,
-    # then take the first n — robust whether the stage is the full 50k set or a
-    # smoke subset (we never compute MSAs here).
-    eligible = [
-        r for r in read_fasta(fasta)
-        if len(r.seq) <= max_len and _msa_path(stage, r) is not None
-    ]
-    proteins = eligible[:n_proteins]
+    # Take the first n proteins that are both short enough AND have precomputed
+    # MSAs — robust whether the stage is the full 50k set or a smoke subset (we
+    # never compute MSAs here). Early-exit so we don't stat all 50k records, and
+    # cache the resolved MSA path so it's looked up once, not again per fold.
+    # read_fasta yields records in file order, so the selection is deterministic.
+    proteins: list[tuple[Any, Path]] = []
+    for r in read_fasta(fasta):
+        if len(r.seq) <= max_len and (p := _msa_path(stage, r)) is not None:
+            proteins.append((r, p))
+            if len(proteins) >= n_proteins:
+                break
     if not proteins:
         raise FileNotFoundError(
             f"no proteins (len<={max_len}) with precomputed MSAs under {stage}/msas"
@@ -284,19 +287,23 @@ def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
 
     # Warmup outside the capture window: first-call kernel autotune + allocator
     # growth must not pollute the trace.
-    for r in proteins[: min(warmup, len(proteins))]:
-        runner.predict(r, _msa_path(stage, r))
+    for r, msa in proteins[: min(warmup, len(proteins))]:
+        runner.predict(r, msa)
     sync_device()
 
     def run() -> dict[str, Any]:
         plddts: list[float] = []
-        for r in proteins:
-            out = runner.predict(r, _msa_path(stage, r))
+        for r, msa in proteins:
+            out = runner.predict(r, msa)
             if "plddt" in out:
                 plddts.append(float(out["plddt"]))
+        if not plddts:
+            # Every fold omitted plDDT — a silent instrumentation failure (e.g. a
+            # runner version mismatch). Surface it rather than report None as ok.
+            print("WARNING: no plDDT returned by any fold — runner output contract "
+                  "may have changed; structures still folded under the trace.")
         return {
             "structures": len(proteins),
-            "events": len(proteins),  # generic count for the loop's throughput line
             "median_plddt": statistics.median(plddts) if plddts else None,
         }
 

--- a/tests/test_openfold_workload.py
+++ b/tests/test_openfold_workload.py
@@ -1,0 +1,75 @@
+"""AlphaFold2 (OpenFold) wired into the autonomous loop as an observed workload.
+
+AF2 has no intervention library yet, so the loop must report an honest
+*measurement* over the real kernels — never vLLM serving knobs and never a
+fabricated intervention/speedup. These tests run without OpenFold/torch/GPU
+(CI has none): they cover registration, clean no-data degradation when the
+framework/data are absent, and the measurement-routing contract via an injected
+runner + a faked trace.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+from .conftest import make_kernel, make_trace
+
+
+def test_openfold_is_registered():
+    from gitm.workloads import get_factory, registered
+
+    names = set(registered())
+    assert {"openfold", "alphafold", "af2"} <= names
+    assert get_factory("openfold") is not None
+    assert get_factory("alphafold") is not None
+
+
+def test_openfold_no_deps_or_data_degrades_to_no_data(tmp_path: Path, monkeypatch):
+    """No staged data (and/or no OpenFold) → honest no-data, not a crash or fake."""
+    monkeypatch.setenv("GITM_BENCH_STAGE", str(tmp_path / "missing"))
+
+    from gitm import optimize
+
+    result = optimize(workload="openfold", budget="1s", scratch=str(tmp_path))
+    summary = result["summary"]
+    assert summary["status"] == "no_data"
+    assert summary["n_claims"] == 0
+    assert Path(summary["report_path"]).exists()
+
+
+def _fake_capture_evoformer(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+    @contextmanager
+    def _cap():
+        # torch/cutlass-style kernel names — what a real AF2 trace looks like.
+        kernels = [
+            make_kernel(f"cutlass_sm90_evoformer_gemm_{i % 4}",
+                        start_ns=i * 100, end_ns=i * 100 + 90 + (i % 9))
+            for i in range(80)
+        ]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    return _cap()
+
+
+def test_openfold_routes_to_measurement_not_intervention(tmp_path: Path, monkeypatch):
+    """With real kernels in the trace, openfold reports a measurement — never a
+    vLLM knob, and never the hft intervention path (no fabricated speedup)."""
+    import gitm.scheduler.loop as loop
+
+    monkeypatch.setattr(loop, "capture", _fake_capture_evoformer)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    from gitm import optimize
+
+    result = optimize(
+        workload="openfold", budget="1s", scratch=str(tmp_path),
+        workload_runner=lambda: {"structures": 3, "events": 3, "median_plddt": 90.0},
+    )
+    summary, md = result["summary"], result["report_md"]
+
+    assert summary["status"] == "ok"
+    assert summary["mode"] == "measurement"  # not "intervention"
+    assert summary["n_claims"] == 0
+    for knob in ("max_num_batched_tokens", "gpu_memory_utilization", "max_num_seqs"):
+        assert knob not in md, f"measurement report must not contain vLLM knob {knob!r}"

--- a/tests/test_openfold_workload.py
+++ b/tests/test_openfold_workload.py
@@ -38,10 +38,16 @@ def test_openfold_no_deps_or_data_degrades_to_no_data(tmp_path: Path, monkeypatc
     assert Path(summary["report_path"]).exists()
 
 
-def _fake_capture_evoformer(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+def test_openfold_routes_to_measurement_not_intervention(tmp_path: Path, monkeypatch):
+    """With real kernels in the trace, openfold reports a measurement — never a
+    vLLM knob, and never the hft intervention path (no fabricated speedup)."""
+    import gitm.scheduler.loop as loop
+
+    entered = {"capture": False, "runner": False}
+
     @contextmanager
-    def _cap():
-        # torch/cutlass-style kernel names — what a real AF2 trace looks like.
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        entered["capture"] = True
         kernels = [
             make_kernel(f"cutlass_sm90_evoformer_gemm_{i % 4}",
                         start_ns=i * 100, end_ns=i * 100 + 90 + (i % 9))
@@ -49,27 +55,45 @@ def _fake_capture_evoformer(out_path, *, workload_id="w", fingerprint="f", run_i
         ]
         yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
 
-    return _cap()
+    def runner():
+        entered["runner"] = True
+        return {"structures": 3, "median_plddt": 90.0}
 
-
-def test_openfold_routes_to_measurement_not_intervention(tmp_path: Path, monkeypatch):
-    """With real kernels in the trace, openfold reports a measurement — never a
-    vLLM knob, and never the hft intervention path (no fabricated speedup)."""
-    import gitm.scheduler.loop as loop
-
-    monkeypatch.setattr(loop, "capture", _fake_capture_evoformer)
+    monkeypatch.setattr(loop, "capture", fake_capture)
     monkeypatch.setattr(loop, "sync_device", lambda: None)
 
     from gitm import optimize
 
     result = optimize(
-        workload="openfold", budget="1s", scratch=str(tmp_path),
-        workload_runner=lambda: {"structures": 3, "events": 3, "median_plddt": 90.0},
+        workload="openfold", budget="1s", scratch=str(tmp_path), workload_runner=runner
     )
     summary, md = result["summary"], result["report_md"]
 
+    # Guard against a vacuous pass: the workload actually ran under the trace.
+    assert entered["capture"] and entered["runner"]
     assert summary["status"] == "ok"
     assert summary["mode"] == "measurement"  # not "intervention"
     assert summary["n_claims"] == 0
     for knob in ("max_num_batched_tokens", "gpu_memory_utilization", "max_num_seqs"):
         assert knob not in md, f"measurement report must not contain vLLM knob {knob!r}"
+
+
+def test_openfold_factory_filters_by_len_and_msa(tmp_path: Path, monkeypatch):
+    """Protein selection (len + MSA filter, the 'no proteins' guard) is exercised
+    without OpenFold/torch — it runs before the model is built. Here max_len=0
+    excludes every protein, so the factory raises the clear no-proteins error."""
+    from gitm.scheduler.loop import LoopConfig
+    from gitm.workloads import get_factory
+
+    stage = tmp_path / "stage"
+    (stage / "msas" / "P1").mkdir(parents=True)
+    (stage / "msas" / "P1" / "bfd_uniref_hits.a3m").write_text(">x\nMKT\n")
+    (stage / "proteins_50k.fasta").write_text(">P1\nMKT\n")
+
+    monkeypatch.setenv("GITM_BENCH_STAGE", str(stage))
+    monkeypatch.setenv("GITM_BENCH_MAX_LEN", "0")  # excludes everything
+
+    import pytest
+
+    with pytest.raises(FileNotFoundError, match="no proteins"):
+        get_factory("openfold")(LoopConfig(workload="openfold"))


### PR DESCRIPTION
Register an  (alias alphafold/af2) workload that runs OpenFold AF2 inference under the GITM tracer. Warmup folds run outside the capture window; the runner folds GITM_BENCH_PROTEINS proteins (len<=GITM_BENCH_MAX_LEN, those with precomputed MSAs) so the trace is the Evoformer + structure-module compute.

Inference only — never runs mmseqs2. No intervention library applies to AF2 yet, so the loop emits an honest measurement report over the real kernels (the AF2 analog of the hft/edge measurement run), not a fabricated speedup. Degrades to a no-data report where OpenFold/torch/data are absent.