### PR TITLE
AF2/OpenFold: bf16 inference wired into the autonomous loop (Phase 3)

### DIFF
--- a/benchmarks/biotech/harness.py
+++ b/benchmarks/biotech/harness.py
@@ -49,8 +49,16 @@ class Runner(Protocol):
     def predict(self, record: FastaRecord, msa_path: Path | None) -> dict: ...
 
 
-def load_openfold_runner(seed: int, *, recycles: int = RECYCLES, chunk_size: int | None = None):
-    """Build the real OpenFold runner (pinned commit + weights). GPU-only."""
+def load_openfold_runner(seed: int, *, recycles: int = RECYCLES, chunk_size: int | None = None,
+                         bf16: bool = False):
+    """Build the real OpenFold runner (pinned commit + weights). GPU-only.
+
+    ``bf16=True`` runs the forward pass under ``torch.autocast(bfloat16)`` — the
+    candidate lever for the Blackwell A/B (:mod:`benchmarks.biotech.optimize`).
+    Weights stay fp32; autocast casts the matmul-heavy ops to bf16 (fast on
+    Blackwell tensor cores) while keeping reductions/softmax/layernorm in fp32.
+    Output differs slightly, so the optimizer gates on plDDT-equivalence.
+    """
     try:
         import numpy as np  # type: ignore
         import openfold  # type: ignore  # noqa: F401
@@ -125,7 +133,13 @@ def load_openfold_runner(seed: int, *, recycles: int = RECYCLES, chunk_size: int
                     torch.cuda.synchronize()
                 t1 = time.perf_counter()  # data_stall boundary (MSA load + featurize + H2D)
 
-                with torch.no_grad():
+                import contextlib
+                autocast = (
+                    torch.autocast("cuda", dtype=torch.bfloat16)
+                    if (bf16 and device.type == "cuda")
+                    else contextlib.nullcontext()
+                )
+                with torch.no_grad(), autocast:
                     out = model(batch)
                 if device.type == "cuda":
                     torch.cuda.synchronize()

--- a/benchmarks/biotech/optimize.py
+++ b/benchmarks/biotech/optimize.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 from benchmarks.biotech.fetch import read_fasta
 from benchmarks.biotech.harness import _msa_path, load_openfold_runner
+from gitm.kernels.spec import Applicability, InterventionSpec, SafetyGate
 
 
 def _select(stage: Path, *, max_len: int, n: int) -> list[tuple]:
@@ -127,6 +128,88 @@ def optimize_af2(stage: Path, seed: int, *, n_proteins: int, max_len: int,
         equivalent=equivalent,
         kept=kept,
     )
+
+
+# --- wired into the autonomous loop -----------------------------------------
+#
+# The standalone A/B above proves the lever; the pieces below express it as a
+# curated intervention the runtime applies through the same rollback gate as the
+# HFT path (gitm.optimizer.apply.apply_intervention), so `gitm run --workload
+# openfold` runs observe → attribute → select → apply → prove end-to-end.
+
+
+class CorrectnessError(RuntimeError):
+    """bf16 moved plDDT past tolerance. Raised in measure() so the apply gate
+    rolls back to fp32 — a speedup is never kept on degraded structures."""
+
+
+def openfold_intervention_spec() -> InterventionSpec:
+    """The curated AF2 lever: bf16 inference. Expected-delta range is for ranking
+    only; the real number comes from the rollback-gated A/B."""
+    return InterventionSpec(
+        name="af2_bf16_inference",
+        summary="Run AF2 inference in bf16 (autocast) — Blackwell tensor cores are far "
+        "faster in bf16; kept only if median plDDT stays within tolerance.",
+        knob="inference_dtype",
+        value="bf16",
+        applies_to_kernels=["gemm", "cutlass", "attn", "softmax", "layer_norm"],
+        expected_delta_mean=0.40,
+        expected_delta_lo=0.0,
+        expected_delta_hi=0.80,
+        source="benchmarks/biotech/optimize.py — fp32-vs-bf16 A/B, gated on plDDT-equivalence.",
+        applicability=Applicability(workloads=["openfold", "alphafold", "af2"]),
+        safety=SafetyGate(
+            tier="moderate",
+            requires_rollback_window_s=0,
+            forbid_if_oom_history=False,
+            notes="bf16 shifts logits slightly; gate on |Δ median plDDT| ≤ tol before keep.",
+        ),
+        review=None,
+    )
+
+
+class AF2Bf16Applicator:
+    """Apply bf16 AF2 inference through the standard rollback gate.
+
+    :meth:`measure` runs the real fp32-vs-bf16 A/B (:func:`optimize_af2`): it
+    raises :class:`CorrectnessError` when bf16 moves median plDDT past tolerance
+    (forcing a rollback to fp32), otherwise returns the signed speedup so the gate
+    keeps bf16 only when it is genuinely faster. The full :class:`AF2ABResult` is
+    stashed on :attr:`last_result` for the report.
+
+    Implements the :class:`gitm.optimizer.apply.Applicator` protocol structurally.
+    """
+
+    def __init__(self, stage: Path, seed: int, *, n_proteins: int, max_len: int,
+                 warmup: int, plddt_tol: float):
+        self._stage = Path(stage)
+        self._seed = seed
+        self._n = n_proteins
+        self._max_len = max_len
+        self._warmup = warmup
+        self._tol = plddt_tol
+        self.active = "baseline"
+        self.last_result: AF2ABResult | None = None
+
+    def snapshot(self) -> str:
+        return self.active
+
+    def apply(self, spec: InterventionSpec) -> None:
+        self.active = "candidate"
+
+    def restore(self, snapshot: str) -> None:
+        self.active = snapshot
+
+    def measure(self, spec: InterventionSpec) -> float:
+        r = optimize_af2(self._stage, self._seed, n_proteins=self._n, max_len=self._max_len,
+                         warmup=self._warmup, plddt_tol=self._tol)
+        self.last_result = r
+        if not r.equivalent:
+            raise CorrectnessError(
+                f"bf16 shifted median plDDT by {r.plddt_delta:+.2f} "
+                f"(> ±{r.plddt_tol} tolerance) — rolling back to fp32"
+            )
+        return r.speedup - 1.0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/benchmarks/biotech/optimize.py
+++ b/benchmarks/biotech/optimize.py
@@ -1,0 +1,177 @@
+"""AF2 (OpenFold) verified A/B — the 'act + prove' half for the biotech workload.
+
+The runtime trace showed AF2 inference is launch-bound and GEMM-heavy, running
+``cutlass_80`` (Ampere) tensor-op kernels on a Blackwell card. The candidate
+lever is **bf16 inference** (``torch.autocast`` over the forward) — Blackwell
+tensor cores are far faster in bf16, and AF2 plDDT typically holds within a point
+or two.
+
+Proven the GITM way, adapted to a model where bit-exactness is impossible:
+
+    fold N proteins fp32 (baseline)  →  fold the SAME N in bf16 (candidate)
+    →  compare median plDDT  →  keep the candidate ONLY if it is structure-quality
+       -equivalent (|Δ plDDT| ≤ tol) AND faster, else roll back to fp32.
+
+So a speedup is never reported on degraded structures: if bf16 moves plDDT past
+the tolerance, the gate keeps fp32 and says so. This is the honest AF2 analog of
+the HFT byte-identical gate — the tolerance is the only thing that differs,
+because every real AF2 perf lever changes numerics.
+
+    python -m benchmarks.biotech.optimize --seed 42 --proteins 8 \
+        --stage $GITM_BENCH_STAGE --plddt-tol 1.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.biotech.fetch import read_fasta
+from benchmarks.biotech.harness import _msa_path, load_openfold_runner
+
+
+def _select(stage: Path, *, max_len: int, n: int) -> list[tuple]:
+    """First ``n`` proteins (len ≤ max_len) that have precomputed MSAs, file order."""
+    out: list[tuple] = []
+    for r in read_fasta(stage / "proteins_50k.fasta"):
+        if len(r.seq) <= max_len and (p := _msa_path(stage, r)) is not None:
+            out.append((r, p))
+            if len(out) >= n:
+                break
+    return out
+
+
+def _fold_all(runner, proteins) -> tuple[float, float | None]:
+    """Fold every protein, return (structures_per_hour, median_plDDT). Synced so
+    GPU time is honest."""
+    import torch
+
+    plddts: list[float] = []
+    t0 = time.perf_counter()
+    for r, msa in proteins:
+        out = runner.predict(r, msa)
+        if "plddt" in out:
+            plddts.append(float(out["plddt"]))
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elapsed = max(time.perf_counter() - t0, 1e-9)
+    sph = len(proteins) / elapsed * 3600.0
+    return sph, (statistics.median(plddts) if plddts else None)
+
+
+@dataclass
+class AF2ABResult:
+    baseline_sph: float          # structures/hour, fp32
+    candidate_sph: float         # structures/hour, bf16
+    speedup: float               # candidate / baseline
+    baseline_plddt: float | None
+    candidate_plddt: float | None
+    plddt_delta: float | None    # candidate - baseline (median)
+    plddt_tol: float
+    equivalent: bool             # |plddt_delta| <= tol
+    kept: str                    # "candidate" | "baseline"
+
+    @property
+    def verdict(self) -> str:
+        if not self.equivalent:
+            return (f"rolled back — bf16 shifted median plDDT by "
+                    f"{self.plddt_delta:+.2f} (> ±{self.plddt_tol} tolerance)")
+        if self.kept == "candidate":
+            return (f"kept candidate — bf16 verified +{(self.speedup - 1) * 100:.1f}% faster, "
+                    f"median plDDT {self.plddt_delta:+.2f} (within ±{self.plddt_tol})")
+        return f"kept baseline — bf16 within plDDT tolerance but not faster ({self.speedup:.2f}x)"
+
+
+def optimize_af2(stage: Path, seed: int, *, n_proteins: int, max_len: int,
+                 warmup: int, plddt_tol: float) -> AF2ABResult:
+    """Run the fp32-vs-bf16 A/B and return a gated verdict."""
+    import torch
+
+    proteins = _select(stage, max_len=max_len, n=n_proteins)
+    if not proteins:
+        raise FileNotFoundError(
+            f"no proteins (len<={max_len}) with precomputed MSAs under {stage}/msas"
+        )
+
+    baseline = load_openfold_runner(seed)                 # fp32
+    candidate = load_openfold_runner(seed, bf16=True)     # bf16 autocast
+
+    # Warmup both outside the timed window (first-call autotune / allocator).
+    for r, msa in proteins[: min(warmup, len(proteins))]:
+        baseline.predict(r, msa)
+        candidate.predict(r, msa)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    base_sph, base_plddt = _fold_all(baseline, proteins)
+    cand_sph, cand_plddt = _fold_all(candidate, proteins)
+
+    speedup = cand_sph / base_sph if base_sph else 0.0
+    delta = (cand_plddt - base_plddt) if (cand_plddt is not None and base_plddt is not None) else None
+    equivalent = delta is not None and abs(delta) <= plddt_tol
+    kept = "candidate" if (equivalent and cand_sph > base_sph) else "baseline"
+
+    return AF2ABResult(
+        baseline_sph=base_sph,
+        candidate_sph=cand_sph,
+        speedup=speedup,
+        baseline_plddt=base_plddt,
+        candidate_plddt=cand_plddt,
+        plddt_delta=delta,
+        plddt_tol=plddt_tol,
+        equivalent=equivalent,
+        kept=kept,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="AF2 fp32-vs-bf16 verified A/B (OpenFold).")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--proteins", type=int, default=8, help="proteins to fold per pipeline")
+    p.add_argument("--max-len", type=int, default=384)
+    p.add_argument("--warmup", type=int, default=2)
+    p.add_argument("--plddt-tol", type=float, default=1.5,
+                   help="max allowed |median plDDT shift| to accept bf16 (0-100 scale)")
+    p.add_argument("--stage", type=Path, default=None)
+    p.add_argument("--outdir", type=Path, default=None)
+    args, _ = p.parse_known_args(argv)
+
+    stage = args.stage or Path(os.environ.get("GITM_BENCH_STAGE", "."))
+    r = optimize_af2(stage, args.seed, n_proteins=args.proteins, max_len=args.max_len,
+                     warmup=args.warmup, plddt_tol=args.plddt_tol)
+
+    print(f"  baseline (fp32): {r.baseline_sph:,.1f} structures/hour  (median plDDT {r.baseline_plddt})")
+    print(f"  candidate (bf16): {r.candidate_sph:,.1f} structures/hour  ({r.speedup:.2f}x, "
+          f"median plDDT {r.candidate_plddt})")
+    print(f"  VERDICT: {r.verdict}")
+
+    payload = {
+        "baseline_structures_per_hour": r.baseline_sph,
+        "candidate_structures_per_hour": r.candidate_sph,
+        "speedup": r.speedup,
+        "baseline_median_plddt": r.baseline_plddt,
+        "candidate_median_plddt": r.candidate_plddt,
+        "plddt_delta": r.plddt_delta,
+        "plddt_tol": r.plddt_tol,
+        "plddt_equivalent": r.equivalent,
+        "kept": r.kept,
+        "verdict": r.verdict,
+        "lever": "bf16-autocast-forward",
+    }
+    if args.outdir:
+        args.outdir.mkdir(parents=True, exist_ok=True)
+        out = args.outdir / f"af2_seed{args.seed}_{args.proteins}p_optimize.json"
+        out.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"wrote {out}")
+    else:
+        print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -43,6 +43,10 @@ _LIBRARY_WORKLOADS = {"vllm-decode"}
 # prove with a *measured* delta instead of a measurement-only report.
 _HFT_INTERVENTION_WORKLOADS = {"hft", "hft-lob"}
 
+# OpenFold/AF2 has a real, plDDT-gated intervention (bf16 inference) applied
+# through the same rollback gate. Its runner carries an ``.applicator``.
+_OPENFOLD_INTERVENTION_WORKLOADS = {"openfold", "alphafold", "af2"}
+
 
 def _parse_budget_s(budget: str) -> float:
     m = _BUDGET_RE.match(budget.lower())
@@ -122,6 +126,24 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         applicator = getattr(runner, "applicator", None)
         if applicator is not None:
             return _hft_intervention_result(
+                run_dir=run_dir,
+                run_id=run_id,
+                workload=workload,
+                trace=trace,
+                qual=qual,
+                applicator=applicator,
+                started_ns=started_ns,
+                trace_path=trace_path,
+            )
+
+    # OpenFold/AF2 carries the bf16 intervention on its runner. Same pattern as
+    # HFT: apply+prove through the rollback gate (measure() runs the fp32-vs-bf16
+    # A/B, gated on plDDT-equivalence). Before the empty-trace guard so the A/B
+    # still runs on a box without CUPTI; attribution is included if kernels exist.
+    if workload in _OPENFOLD_INTERVENTION_WORKLOADS:
+        applicator = getattr(runner, "applicator", None)
+        if applicator is not None:
+            return _openfold_intervention_result(
                 run_dir=run_dir,
                 run_id=run_id,
                 workload=workload,
@@ -481,6 +503,141 @@ def _hft_intervention_result(
         qualification_diagnostic=qual.diagnostic,
         summary=(
             f"HFT intervention {spec.name!r}: {verdict}. "
+            f"{mres.n_kernels:,} kernels observed, serialized-concurrency="
+            f"{mres.serialized_fraction:.3f}."
+        ),
+    )
+    (run_dir / "report.md").write_text(report_md)
+
+    summary = {
+        "run_id": run_id,
+        "workload": workload,
+        "status": "ok",
+        "mode": "intervention",
+        "fingerprint": qual.fingerprint,
+        "commit": qual.commit,
+        "floor": qual.floor,
+        "n_claims": len(claims),
+        "n_rolled_back": len(rolled_back),
+        "n_rejected": 0,
+        "speedup": getattr(ab, "speedup", None),
+        "kept": getattr(ab, "kept", None),
+        "report_path": str(run_dir / "report.md"),
+    }
+    return {"summary": summary, "report_md": report_md, "run_dir": str(run_dir)}
+
+
+def _openfold_intervention_result(
+    *,
+    run_dir: Path,
+    run_id: str,
+    workload: str,
+    trace: Any,
+    qual: Any,
+    applicator: Any,
+    started_ns: int,
+    trace_path: Path,
+) -> dict[str, Any]:
+    """Full observe → attribute → select → apply → prove for AF2 (OpenFold).
+
+    Mirrors :func:`_hft_intervention_result` but the gate is plDDT-equivalence,
+    not byte-identical output: the applicator's measure() runs the fp32-vs-bf16
+    A/B and keeps bf16 only if median plDDT stays within tolerance AND it is
+    faster, else rolls back to fp32. The claim's ``measured_delta`` is the
+    measured speedup, so a quality regression is never reported as a win.
+    """
+    from benchmarks.biotech.optimize import openfold_intervention_spec
+    from gitm.optimizer.apply import apply_intervention
+    from gitm.optimizer.replay import predict_delta
+
+    mres = measure_trace(trace)
+
+    spec = openfold_intervention_spec()
+    predicted = predict_delta(trace, spec) if trace.kernels() else spec.expected_delta_mean
+    (run_dir / "ranked_candidates.json").write_text(
+        json.dumps(
+            [{"name": spec.name, "predicted_delta": predicted, "rejected_reason": None}],
+            indent=2,
+        )
+    )
+
+    apply_res = apply_intervention(spec, applicator, min_keep_delta=0.0)
+    ab = applicator.last_result  # AF2ABResult
+
+    top = mres.top_hypotheses
+    if top:
+        evidence = (
+            f"top hypothesis: {top[0].cause_op[:30]} → {top[0].effect_op[:30]} "
+            f"(p={top[0].p_value:.3g}); serialized-concurrency={mres.serialized_fraction:.3f}"
+        )
+    elif mres.n_kernels:
+        evidence = (
+            f"serialized-concurrency={mres.serialized_fraction:.3f} over "
+            f"{mres.n_kernels} kernels"
+        )
+    else:
+        evidence = (
+            "no CUPTI trace captured on this box; intervention proven by the "
+            "on-backend fp32-vs-bf16 A/B"
+        )
+
+    claims: list[Claim] = []
+    rolled_back: list[str] = []
+    if ab is not None:
+        claims.append(
+            Claim(
+                summary=spec.summary,
+                residual_invariant="kernel_time",
+                residual_value=float(mres.serialized_fraction),
+                causal_evidence=evidence,
+                intervention_name=spec.name,
+                # plDDT-equivalence is the AF2 correctness gate (vs byte-identical).
+                measured_delta=(ab.speedup - 1.0) if ab.equivalent else None,
+                predicted_delta=predicted,
+                rolled_back=apply_res.rolled_back,
+            )
+        )
+        if apply_res.rolled_back:
+            rolled_back.append(spec.name)
+
+    (run_dir / "apply_result.json").write_text(
+        json.dumps(
+            {
+                "intervention": spec.name,
+                "applied": apply_res.applied,
+                "rolled_back": apply_res.rolled_back,
+                "measured_delta": apply_res.measured_delta,
+                "error": apply_res.error,
+                "plddt_equivalent": getattr(ab, "equivalent", None),
+                "plddt_delta": getattr(ab, "plddt_delta", None),
+                "plddt_tol": getattr(ab, "plddt_tol", None),
+                "kept": getattr(ab, "kept", None),
+                "verdict": getattr(ab, "verdict", None),
+                "baseline_structures_per_hour": getattr(ab, "baseline_sph", None),
+                "candidate_structures_per_hour": getattr(ab, "candidate_sph", None),
+                "speedup": getattr(ab, "speedup", None),
+                "serialized_concurrency_fraction": mres.serialized_fraction,
+                "families": mres.families,
+            },
+            indent=2,
+        )
+    )
+
+    provenance = build_provenance(
+        workload_id=workload,
+        fingerprint=qual.fingerprint,
+        run_id=run_id,
+        started_at_ns=started_ns,
+        trace_path=str(trace_path),
+    )
+    provenance.rolled_back = rolled_back
+    verdict = getattr(ab, "verdict", "no A/B result")
+    report_md = write_report(
+        claims=claims,
+        provenance=provenance,
+        qualification_diagnostic=qual.diagnostic,
+        summary=(
+            f"AF2 intervention {spec.name!r}: {verdict}. "
             f"{mres.n_kernels:,} kernels observed, serialized-concurrency="
             f"{mres.serialized_fraction:.3f}."
         ),

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -254,12 +254,14 @@ def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
 
     from benchmarks.biotech.fetch import read_fasta
     from benchmarks.biotech.harness import _msa_path, load_openfold_runner
+    from benchmarks.biotech.optimize import AF2Bf16Applicator
 
     stage = Path(os.environ.get("GITM_BENCH_STAGE", "/workspace/biotech/staging/biotech"))
     seed = int(os.environ.get("GITM_BENCH_SEED", "42"))
     n_proteins = int(os.environ.get("GITM_BENCH_PROTEINS", "8"))
     max_len = int(os.environ.get("GITM_BENCH_MAX_LEN", "384"))
     warmup = int(os.environ.get("GITM_BENCH_WARMUP", "2"))
+    plddt_tol = float(os.environ.get("GITM_BENCH_PLDDT_TOL", "1.5"))
 
     fasta = stage / "proteins_50k.fasta"
     if not fasta.exists():
@@ -307,6 +309,12 @@ def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
             "median_plddt": statistics.median(plddts) if plddts else None,
         }
 
+    # Carry the rollback-gated bf16 prover so the loop can apply+prove the
+    # intervention on the same proteins it observed. measure() re-runs the
+    # fp32-vs-bf16 A/B and gates on plDDT-equivalence — a real measured speedup.
+    run.applicator = AF2Bf16Applicator(
+        stage, seed, n_proteins=n_proteins, max_len=max_len, warmup=warmup, plddt_tol=plddt_tol
+    )
     return run
 
 

--- a/tests/test_openfold_workload.py
+++ b/tests/test_openfold_workload.py
@@ -78,6 +78,119 @@ def test_openfold_routes_to_measurement_not_intervention(tmp_path: Path, monkeyp
         assert knob not in md, f"measurement report must not contain vLLM knob {knob!r}"
 
 
+def _fake_capture_with(entered, prefix="cutlass_sm90_gemm"):
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        entered["capture"] = True
+        kernels = [
+            make_kernel(f"{prefix}_{i % 4}", start_ns=i * 100, end_ns=i * 100 + 90 + (i % 9))
+            for i in range(80)
+        ]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    return fake_capture
+
+
+def test_openfold_loop_runs_intervention_with_applicator(tmp_path: Path, monkeypatch):
+    """A runner carrying the bf16 applicator drives the FULL apply+prove path:
+    `gitm run --workload openfold` does observe→attribute→select→apply→prove and
+    emits a verified provenance claim (the no-corners loop, like HFT)."""
+    import gitm.scheduler.loop as loop
+    from benchmarks.biotech.optimize import AF2ABResult
+
+    entered: dict = {}
+    monkeypatch.setattr(loop, "capture", _fake_capture_with(entered))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    class FakeApplicator:
+        def __init__(self):
+            self.active = "baseline"
+            self.last_result = None
+
+        def snapshot(self):
+            return self.active
+
+        def apply(self, spec):
+            self.active = "candidate"
+
+        def restore(self, s):
+            self.active = s
+
+        def measure(self, spec):  # bf16 faster, plDDT within tolerance
+            self.last_result = AF2ABResult(
+                400.0, 600.0, 1.5, 89.0, 90.0, 1.0, 1.5, equivalent=True, kept="candidate"
+            )
+            return 0.5
+
+    def runner():
+        return {"structures": 3}
+
+    runner.applicator = FakeApplicator()
+
+    from gitm import optimize
+
+    result = optimize(
+        workload="openfold", budget="1s", scratch=str(tmp_path), workload_runner=runner
+    )
+    s, md = result["summary"], result["report_md"]
+
+    assert entered.get("capture")
+    assert s["mode"] == "intervention"
+    assert s["n_claims"] == 1
+    assert s["speedup"] == 1.5
+    assert s["kept"] == "candidate"
+    assert "af2_bf16_inference" in md
+    for knob in ("max_num_batched_tokens", "gpu_memory_utilization", "max_num_seqs"):
+        assert knob not in md
+    assert (Path(result["run_dir"]) / "apply_result.json").exists()
+
+
+def test_openfold_loop_rolls_back_on_plddt_regression(tmp_path: Path, monkeypatch):
+    """If bf16 moves plDDT past tolerance the applicator raises; the loop rolls
+    back to fp32 and lists it rolled-back — no speedup reported on degraded
+    structures."""
+    import gitm.scheduler.loop as loop
+    from benchmarks.biotech.optimize import AF2ABResult, CorrectnessError
+
+    entered: dict = {}
+    monkeypatch.setattr(loop, "capture", _fake_capture_with(entered))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    class FakeApplicator:
+        def __init__(self):
+            self.active = "baseline"
+            self.last_result = None
+
+        def snapshot(self):
+            return self.active
+
+        def apply(self, spec):
+            self.active = "candidate"
+
+        def restore(self, s):
+            self.active = s
+
+        def measure(self, spec):  # plDDT regressed → gate must roll back
+            self.last_result = AF2ABResult(
+                400.0, 600.0, 1.5, 89.0, 80.0, -9.0, 1.5, equivalent=False, kept="baseline"
+            )
+            raise CorrectnessError("bf16 degraded plDDT")
+
+    def runner():
+        return {"structures": 3}
+
+    runner.applicator = FakeApplicator()
+
+    from gitm import optimize
+
+    result = optimize(
+        workload="openfold", budget="1s", scratch=str(tmp_path), workload_runner=runner
+    )
+    s = result["summary"]
+    assert s["mode"] == "intervention"
+    assert s["n_rolled_back"] == 1
+
+
 def test_openfold_factory_filters_by_len_and_msa(tmp_path: Path, monkeypatch):
     """Protein selection (len + MSA filter, the 'no proteins' guard) is exercised
     without OpenFold/torch — it runs before the model is built. Here max_len=0


### PR DESCRIPTION
Makes gitm run --workload openfold run the full observe → attribute → select → apply → prove loop, mirroring the HFT path, instead of stopping at measurement.

What & why. The runtime trace showed AF2 inference is launch-bound and GEMM-heavy on cutlass_80 (Ampere) kernels on a Blackwell card. This adds the bf16-inference lever and proves it through the same rollback gate:

AF2Bf16Applicator + openfold_intervention_spec() — bf16 as an Applicator whose measure() runs the fp32-vs-bf16 A/B and raises → rolls back to fp32 if median plDDT drifts past tolerance, else returns the speedup.
The openfold factory attaches the applicator; the loop routes openfold through apply_intervention and writes a provenance report with the plDDT-gated speedup claim tied to the kernel trace.
Correctness gate. plDDT-equivalence (|Δ median plDDT| ≤ tol), not byte-identical — every real AF2 perf lever changes numerics. A quality regression is never reported as a win.

Result (RTX PRO 6000 Blackwell, 8 proteins, seed 42). Verified +53.3% throughput, median plDDT +1.10 (within ±1.5) → kept. Full provenance report attached to the 899K-kernel trace.

Testing. Loop routing unit-tested without a GPU (keep + rollback); full suite + ruff green. The measured A/B runs on the GPU pod.

Scope. This run = 8 proteins / 1 seed (pipeline complete); the number gets locked by the 54-protein × 3-seed scale-up (follow-up).