### PR TITLE
edge: fp16 apply→prove intervention (kitti/nuscenes) + full-loop wiring

### DIFF
--- a/benchmarks/edge/harness.py
+++ b/benchmarks/edge/harness.py
@@ -146,10 +146,25 @@ def load_openpcdet_runner(*, config_hash: str | None = None) -> _OpenPCDetRunner
             "  pip install -e /workspace/edge/OpenPCDet"
         ) from exc
 
-    cfg_path = os.environ.get("OPENPCDET_CFG", _OPENPCDET_DEFAULT_CFG)
+    cfg_path = Path(os.environ.get("OPENPCDET_CFG", _OPENPCDET_DEFAULT_CFG))
     ckpt_path = os.environ.get("OPENPCDET_CKPT", _OPENPCDET_DEFAULT_CKPT)
 
-    cfg_from_yaml_file(str(cfg_path), cfg)
+    # OpenPCDet resolves _BASE_CONFIG_ entries (e.g.
+    # cfgs/dataset_configs/kitti_dataset.yaml) relative to the tools/ dir that
+    # holds the top-level cfgs/ folder, not relative to the config file. chdir
+    # there for the load, then restore — mirrors gitm.benchmarks.kitti.workunit
+    # so the harness works regardless of the caller's CWD.
+    resolved_parts = cfg_path.resolve().parts
+    if "cfgs" in resolved_parts:
+        tools_dir = Path(*resolved_parts[: resolved_parts.index("cfgs")])
+    else:
+        tools_dir = cfg_path.resolve().parent
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(tools_dir)
+        cfg_from_yaml_file(str(cfg_path.resolve()), cfg)
+    finally:
+        os.chdir(prev_cwd)
 
     class _InferenceDataset(DatasetTemplate):
         def __init__(self) -> None:
@@ -173,7 +188,11 @@ def load_openpcdet_runner(*, config_hash: str | None = None) -> _OpenPCDetRunner
         num_class=len(cfg.CLASS_NAMES),
         dataset=dataset,
     )
-    model.load_params_from_file(filename=str(ckpt_path), logger=None, to_cpu=True)
+    # OpenPCDet's load_params_from_file calls logger.info() unconditionally, so
+    # a None logger raises AttributeError — pass a real one.
+    model.load_params_from_file(
+        filename=str(ckpt_path), logger=_logging.getLogger("gitm.edge"), to_cpu=True
+    )
     model.cuda().eval()
 
     return _OpenPCDetRunner(model, dataset, list(cfg.CLASS_NAMES))

--- a/benchmarks/edge/run_edge_speeds.sh
+++ b/benchmarks/edge/run_edge_speeds.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Edge speed run — OpenPCDet PointPillars fps over the warm window, 3 seeds.
+# Produces the frames_per_second numbers + 2%-agreement check from spec.md §3.
+#
+# Run ON THE GPU POD (needs torch + pcdet + CUDA + the staged edge dataset).
+#   bash run_edge_speeds.sh            # full 5000-frame warm window
+#   WARM=500 bash run_edge_speeds.sh   # quick sighter first
+#
+# Run it with `bash`, NOT `source`/`.` — see the guard below.
+
+# Guard: if this file is sourced (`. script` / `source script`) instead of run
+# (`bash script`), a failed preflight's `exit` runs in your LOGIN shell and
+# drops your SSH session. Detect sourcing and re-exec in a child bash so `exit`
+# only ends the script, never your pod session.
+if (return 0 2>/dev/null); then
+  _self="${BASH_SOURCE[0]:-}"
+  if [ -n "$_self" ]; then
+    bash "$_self" "$@"; return $?
+  fi
+  echo "Don't source this script — run it:  bash run_edge_speeds.sh" >&2
+  return 1
+fi
+
+set -euo pipefail
+
+# Run from this script's own directory so `harness.py` / `build_manifest.py`
+# resolve no matter where the caller invokes it from (e.g. repo root).
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Data is staged under /workspace/edge/data on the pod (manifest + checkpoints
+# both live there). Override any of these via the environment.
+STAGE="${GITM_BENCH_STAGE:-/workspace/edge/data}"
+WARM="${WARM:-5000}"
+export OPENPCDET_CFG="${OPENPCDET_CFG:-/workspace/edge/OpenPCDet/tools/cfgs/kitti_models/pointpillar.yaml}"
+export OPENPCDET_CKPT="${OPENPCDET_CKPT:-/workspace/edge/data/checkpoints/kitti/pointpillar_7728.pth}"
+export GITM_BENCH_STAGE="$STAGE"
+
+echo "stage=$STAGE  warm=$WARM"
+echo "cfg=$OPENPCDET_CFG"
+echo "ckpt=$OPENPCDET_CKPT"
+
+# Preflight: the things that most often blow up a pod run.
+[ -f "$STAGE/manifest.jsonl" ] || { echo "MISSING $STAGE/manifest.jsonl — build it: GITM_DATA_ROOT=$STAGE python build_manifest.py (or make keyframes)"; exit 1; }
+[ -f "$OPENPCDET_CKPT" ] || { echo "MISSING checkpoint $OPENPCDET_CKPT"; exit 1; }
+[ -f "$OPENPCDET_CFG" ] || { echo "MISSING config $OPENPCDET_CFG"; exit 1; }
+echo "manifest rows: $(wc -l < "$STAGE/manifest.jsonl")"
+
+declare -a FPS
+for seed in 42 43 44; do
+  echo "=== seed $seed ==="
+  out="$(python harness.py --seed "$seed" --warm-frames "$WARM")"
+  echo "$out" | grep '^\[edge harness'
+  fps="$(echo "$out" | tail -1 | python -c 'import sys,json; print(json.load(sys.stdin)["metric_value"])')"
+  FPS+=("$fps")
+done
+
+python - "${FPS[@]}" <<'PY'
+import sys
+v=[float(x) for x in sys.argv[1:]]
+mean=sum(v)/len(v)
+spread=(max(v)-min(v))/mean if mean else 0
+print("\n==== EDGE SPEED SUMMARY ====")
+for s,f in zip((42,43,44), v): print(f"  seed {s}: {f:8.1f} fps")
+print(f"  mean   : {mean:8.1f} fps")
+print(f"  spread : {spread*100:6.2f}%  ({'PASS' if spread<=0.02 else 'FAIL'} vs 2% tolerance)")
+PY

--- a/gitm/benchmarks/edge/optimize.py
+++ b/gitm/benchmarks/edge/optimize.py
@@ -1,0 +1,226 @@
+"""The 'act' half for edge (3D LiDAR detection) — an output-gated, rollback-gated
+optimization, mirroring gitm.benchmarks.hft.optimize.
+
+The baseline runs PointPillars/CenterPoint inference in fp32. The candidate runs
+the same model under fp16 autocast: the conv backbone + BEV head do far less
+memory traffic, the realizable gain on a memory-bound perception net. We prove
+it the GITM way:
+
+    measure fp32 baseline → apply fp16 candidate → verify detections EQUIVALENT
+    → compare speed → keep the candidate only if it is BOTH equivalent and
+    faster, else roll back.
+
+Unlike HFT (integer/float reductions → byte-identical), NN inference across a
+precision change is never bit-exact, so "equivalent" is a tolerance gate: same
+detection count and the same sorted confidence scores within ``score_atol``. If
+fp16 drops/adds a detection or shifts scores beyond tolerance, the correctness
+gate keeps fp32 — no speedup is ever reported on top of degraded detections.
+
+The A/B is injectable (``run_mode``) so the wiring/gate is testable on a laptop
+with a fake; the real run_mode (built in gitm.workloads) drives the OpenPCDet
+WorkUnit on the GPU.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from gitm.kernels.spec import Applicability, InterventionSpec, SafetyGate
+
+# A run_mode runs N frames in a given precision and returns a summary dict:
+#   {"n_frames": int, "n_detections": int, "scores": sorted-desc list[float]}
+RunMode = Callable[[str], dict]
+
+
+def detections_equivalent(a: dict, b: dict, *, score_atol: float = 0.02) -> bool:
+    """True iff two detection summaries match within tolerance.
+
+    Gate: identical detection count, the score list length matches that count
+    (catches a malformed summary), and each confidence score agrees within
+    ``score_atol``. Scores are sorted here defensively, so callers need not
+    pre-sort. This is the perception analogue of HFT's byte-identical signature —
+    strict enough that a real regression (dropped object, shifted confidence)
+    trips it, loose enough to tolerate fp16 rounding.
+    """
+    na, nb = int(a.get("n_detections", -1)), int(b.get("n_detections", -2))
+    if na != nb:
+        return False
+    sa = sorted((float(x) for x in a.get("scores", [])), reverse=True)
+    sb = sorted((float(x) for x in b.get("scores", [])), reverse=True)
+    # A well-formed summary carries one score per detection; mismatch = malformed.
+    if len(sa) != na or len(sb) != nb:
+        return False
+    # lengths are equal here (both == na); strict=True surfaces any future drift.
+    return all(abs(x - y) <= score_atol for x, y in zip(sa, sb, strict=True))
+
+
+@dataclass
+class EdgeABResult:
+    baseline_eps: float       # frames/sec, fp32
+    candidate_eps: float      # frames/sec, fp16
+    speedup: float            # candidate / baseline (e.g. 1.6 = 60% faster)
+    identical: bool           # detections equivalent within tolerance
+    kept: str                 # "candidate" | "baseline"
+    baseline_summary: dict = field(default_factory=dict)
+    candidate_summary: dict = field(default_factory=dict)
+
+    @property
+    def verdict(self) -> str:
+        if not self.identical:
+            return "rolled back — fp16 detections differ from fp32 beyond tolerance"
+        if self.kept == "candidate":
+            return f"kept candidate — verified +{(self.speedup - 1) * 100:.1f}% faster, detections equivalent"
+        return "kept baseline — fp16 not faster"
+
+
+def optimize_edge(
+    run_mode: RunMode,
+    *,
+    reps: int = 2,
+    sync: Callable[[], None] | None = None,
+    score_atol: float = 0.02,
+) -> EdgeABResult:
+    """Run the measure→apply→prove A/B and return a gated verdict.
+
+    ``run_mode(mode)`` runs the frames in ``"fp32"`` or ``"fp16"`` — a single
+    callable dispatched by mode (the two precisions are the same code path on a
+    different autocast context, not two distinct functions). Each precision is
+    run ``reps`` times; the best (lowest) wall time is used to reduce launch
+    jitter. ``sync`` is invoked after each run so GPU timing is honest (pass a
+    device sync; default no-op for CPU/fake).
+    """
+    sync = sync or (lambda: None)
+
+    def _timed(mode: str) -> tuple[dict, float]:
+        best = float("inf")
+        summary: dict = {}
+        for _ in range(max(1, reps)):
+            t0 = time.perf_counter()
+            summary = run_mode(mode)
+            sync()
+            best = min(best, time.perf_counter() - t0)
+        n = max(int(summary.get("n_frames", 0)), 0)
+        return summary, n / max(best, 1e-9)
+
+    base_summary, base_eps = _timed("fp32")
+    cand_summary, cand_eps = _timed("fp16")
+
+    identical = detections_equivalent(base_summary, cand_summary, score_atol=score_atol)
+    speedup = cand_eps / base_eps if base_eps else 0.0
+    kept = "candidate" if (identical and cand_eps > base_eps) else "baseline"
+
+    return EdgeABResult(
+        baseline_eps=base_eps,
+        candidate_eps=cand_eps,
+        speedup=speedup,
+        identical=identical,
+        kept=kept,
+        baseline_summary=base_summary,
+        candidate_summary=cand_summary,
+    )
+
+
+# --- the intervention, wired for the autonomous loop -------------------------
+
+
+class DetectionDivergenceError(RuntimeError):
+    """fp16 detections diverged from fp32 beyond tolerance.
+
+    Raised inside :meth:`EdgeFp16Applicator.measure` so the apply gate rolls
+    back: a speedup is *never* kept on top of degraded detections.
+    """
+
+
+def edge_intervention_spec() -> InterventionSpec:
+    """The curated edge lever: fp16 autocast inference for 3D detection.
+
+    Detection-equivalence is enforced at apply time (inside the A/B), so the
+    expected-delta range here is only used for *ranking* — the real number comes
+    from the rollback-gated measure.
+    """
+    return InterventionSpec(
+        name="edge_fp16_autocast",
+        summary="Run PointPillars/CenterPoint inference under fp16 autocast "
+        "instead of fp32 — halves memory traffic on the conv backbone + BEV "
+        "head. Kept only if detections stay equivalent (count + sorted scores "
+        "within tolerance) and it is faster.",
+        knob="edge.inference_dtype",
+        value="fp16",
+        applies_to_kernels=[
+            "conv", "bev", "backbone", "pillar", "voxel", "scatter", "nms", "gemm",
+        ],
+        expected_delta_mean=0.40,
+        expected_delta_lo=0.0,
+        expected_delta_hi=1.00,
+        source="gitm/benchmarks/edge/optimize.py — fp16 autocast A/B, "
+        "detection-equivalence gated against the fp32 baseline.",
+        applicability=Applicability(workloads=["edge", "kitti", "nuscenes"]),
+        safety=SafetyGate(
+            tier="moderate",
+            requires_rollback_window_s=0,
+            forbid_if_oom_history=False,
+            notes="Precision change; detection-equivalence is gated before any "
+            "speedup is kept, so a degraded run rolls back to fp32.",
+        ),
+        review=None,
+    )
+
+
+class EdgeFp16Applicator:
+    """Apply fp16 autocast inference through the standard rollback gate.
+
+    The 'live state' is the active inference precision. :meth:`measure` runs the
+    real fp32-vs-fp16 A/B (:func:`optimize_edge`): it raises
+    :class:`DetectionDivergenceError` when the candidate's detections are not
+    equivalent (forcing a rollback), otherwise returns the signed speedup delta
+    so the gate keeps fp16 only when it is genuinely faster. The full
+    :class:`EdgeABResult` is stashed on :attr:`last_result` for the report.
+
+    ``run_mode(mode)`` runs the workload's frames in ``"fp32"`` or ``"fp16"`` and
+    returns a summary dict — injected so this is testable without a GPU.
+
+    Implements the :class:`gitm.optimizer.apply.Applicator` protocol structurally,
+    and carries its own :attr:`spec` so the generalized loop can read it.
+    """
+
+    def __init__(
+        self,
+        run_mode: RunMode,
+        *,
+        reps: int = 2,
+        sync: Callable[[], None] | None = None,
+        score_atol: float = 0.02,
+        spec: InterventionSpec | None = None,
+    ):
+        self._run_mode = run_mode
+        self._reps = reps
+        self._sync = sync
+        self._score_atol = score_atol
+        self.active = "fp32"
+        self.last_result: EdgeABResult | None = None
+        self.spec = spec or edge_intervention_spec()
+
+    def snapshot(self) -> str:
+        return self.active
+
+    def apply(self, spec: InterventionSpec) -> None:
+        self.active = "fp16"
+
+    def restore(self, snapshot: str) -> None:
+        self.active = snapshot
+
+    def measure(self, spec: InterventionSpec) -> float:
+        r = optimize_edge(
+            self._run_mode,
+            reps=self._reps,
+            sync=self._sync,
+            score_atol=self._score_atol,
+        )
+        self.last_result = r
+        if not r.identical:
+            raise DetectionDivergenceError(
+                "fp16 detections differ from fp32 beyond tolerance — rolling back"
+            )
+        return r.speedup - 1.0

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -47,6 +47,11 @@ _HFT_INTERVENTION_WORKLOADS = {"hft", "hft-lob"}
 # through the same rollback gate. Its runner carries an ``.applicator``.
 _OPENFOLD_INTERVENTION_WORKLOADS = {"openfold", "alphafold", "af2"}
 
+# Edge (3D LiDAR detection) has a real, detection-equivalence-gated intervention
+# (fp16 autocast inference) applied through the same rollback gate. Its runner
+# carries an ``.applicator``.
+_EDGE_INTERVENTION_WORKLOADS = {"edge", "kitti", "nuscenes"}
+
 
 def _parse_budget_s(budget: str) -> float:
     m = _BUDGET_RE.match(budget.lower())
@@ -144,6 +149,24 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         applicator = getattr(runner, "applicator", None)
         if applicator is not None:
             return _openfold_intervention_result(
+                run_dir=run_dir,
+                run_id=run_id,
+                workload=workload,
+                trace=trace,
+                qual=qual,
+                applicator=applicator,
+                started_ns=started_ns,
+                trace_path=trace_path,
+            )
+
+    # Edge (kitti/nuscenes) carries the fp16 intervention on its runner. Same
+    # pattern as HFT/AF2: apply+prove through the rollback gate (measure() runs
+    # the fp32-vs-fp16 A/B, gated on detection-equivalence). Before the empty-
+    # trace guard so the A/B still runs on a box without CUPTI.
+    if workload in _EDGE_INTERVENTION_WORKLOADS:
+        applicator = getattr(runner, "applicator", None)
+        if applicator is not None:
+            return _edge_intervention_result(
                 run_dir=run_dir,
                 run_id=run_id,
                 workload=workload,
@@ -638,6 +661,141 @@ def _openfold_intervention_result(
         qualification_diagnostic=qual.diagnostic,
         summary=(
             f"AF2 intervention {spec.name!r}: {verdict}. "
+            f"{mres.n_kernels:,} kernels observed, serialized-concurrency="
+            f"{mres.serialized_fraction:.3f}."
+        ),
+    )
+    (run_dir / "report.md").write_text(report_md)
+
+    summary = {
+        "run_id": run_id,
+        "workload": workload,
+        "status": "ok",
+        "mode": "intervention",
+        "fingerprint": qual.fingerprint,
+        "commit": qual.commit,
+        "floor": qual.floor,
+        "n_claims": len(claims),
+        "n_rolled_back": len(rolled_back),
+        "n_rejected": 0,
+        "speedup": getattr(ab, "speedup", None),
+        "kept": getattr(ab, "kept", None),
+        "report_path": str(run_dir / "report.md"),
+    }
+    return {"summary": summary, "report_md": report_md, "run_dir": str(run_dir)}
+
+
+def _edge_intervention_result(
+    *,
+    run_dir: Path,
+    run_id: str,
+    workload: str,
+    trace: Any,
+    qual: Any,
+    applicator: Any,
+    started_ns: int,
+    trace_path: Path,
+) -> dict[str, Any]:
+    """Full observe → attribute → select → apply → prove for edge (kitti/nuscenes).
+
+    Mirrors :func:`_hft_intervention_result`/:func:`_openfold_intervention_result`
+    but the gate is detection-equivalence (count + sorted scores within
+    tolerance), not byte-identical output: the applicator's measure() runs the
+    fp32-vs-fp16 A/B and keeps fp16 only if detections stay equivalent AND it is
+    faster, else rolls back to fp32. The claim's ``measured_delta`` is the
+    measured speedup, so a detection regression is never reported as a win.
+    """
+    from gitm.benchmarks.edge.optimize import edge_intervention_spec
+    from gitm.optimizer.apply import apply_intervention
+    from gitm.optimizer.replay import predict_delta
+
+    mres = measure_trace(trace)
+
+    # The applicator carries its own spec; fall back to the module factory.
+    spec = getattr(applicator, "spec", None) or edge_intervention_spec()
+    predicted = predict_delta(trace, spec) if trace.kernels() else spec.expected_delta_mean
+    (run_dir / "ranked_candidates.json").write_text(
+        json.dumps(
+            [{"name": spec.name, "predicted_delta": predicted, "rejected_reason": None}],
+            indent=2,
+        )
+    )
+
+    apply_res = apply_intervention(spec, applicator, min_keep_delta=0.0)
+    ab = applicator.last_result  # EdgeABResult
+
+    top = mres.top_hypotheses
+    if top:
+        evidence = (
+            f"top hypothesis: {top[0].cause_op[:30]} → {top[0].effect_op[:30]} "
+            f"(p={top[0].p_value:.3g}); serialized-concurrency={mres.serialized_fraction:.3f}"
+        )
+    elif mres.n_kernels:
+        evidence = (
+            f"serialized-concurrency={mres.serialized_fraction:.3f} over "
+            f"{mres.n_kernels} kernels"
+        )
+    else:
+        evidence = (
+            "no CUPTI trace captured on this box; intervention proven by the "
+            "on-backend fp32-vs-fp16 A/B"
+        )
+
+    claims: list[Claim] = []
+    rolled_back: list[str] = []
+    if ab is not None:
+        claims.append(
+            Claim(
+                summary=spec.summary,
+                residual_invariant="kernel_time",
+                residual_value=float(mres.serialized_fraction),
+                causal_evidence=evidence,
+                intervention_name=spec.name,
+                # detection-equivalence is the edge correctness gate.
+                measured_delta=(ab.speedup - 1.0) if ab.identical else None,
+                predicted_delta=predicted,
+                rolled_back=apply_res.rolled_back,
+            )
+        )
+        if apply_res.rolled_back:
+            rolled_back.append(spec.name)
+
+    (run_dir / "apply_result.json").write_text(
+        json.dumps(
+            {
+                "intervention": spec.name,
+                "applied": apply_res.applied,
+                "rolled_back": apply_res.rolled_back,
+                "measured_delta": apply_res.measured_delta,
+                "error": apply_res.error,
+                "detections_equivalent": getattr(ab, "identical", None),
+                "kept": getattr(ab, "kept", None),
+                "verdict": getattr(ab, "verdict", None),
+                "baseline_frames_per_second": getattr(ab, "baseline_eps", None),
+                "candidate_frames_per_second": getattr(ab, "candidate_eps", None),
+                "speedup": getattr(ab, "speedup", None),
+                "serialized_concurrency_fraction": mres.serialized_fraction,
+                "families": mres.families,
+            },
+            indent=2,
+        )
+    )
+
+    provenance = build_provenance(
+        workload_id=workload,
+        fingerprint=qual.fingerprint,
+        run_id=run_id,
+        started_at_ns=started_ns,
+        trace_path=str(trace_path),
+    )
+    provenance.rolled_back = rolled_back
+    verdict = getattr(ab, "verdict", "no A/B result")
+    report_md = write_report(
+        claims=claims,
+        provenance=provenance,
+        qualification_diagnostic=qual.diagnostic,
+        summary=(
+            f"edge intervention {spec.name!r}: {verdict}. "
             f"{mres.n_kernels:,} kernels observed, serialized-concurrency="
             f"{mres.serialized_fraction:.3f}."
         ),

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -188,18 +188,111 @@ def _ensure_hft_data(stage: Path, seed: int) -> None:
     )
 
 
-@register("edge")
-def _edge_factory(cfg: LoopConfig) -> WorkloadRunner:
+# Per-workload OpenPCDet config + checkpoint defaults under the standard pod
+# layout (/workspace/edge/...). GITM_EDGE_CFG / GITM_EDGE_CKPT override either.
+_EDGE_MODEL_DEFAULTS = {
+    "kitti": (
+        "/workspace/edge/OpenPCDet/tools/cfgs/kitti_models/pointpillar.yaml",
+        "/workspace/edge/data/checkpoints/kitti/pointpillar_7728.pth",
+    ),
+    "nuscenes": (
+        "/workspace/edge/OpenPCDet/tools/cfgs/nuscenes_models/cbgs_dyn_pp_centerpoint.yaml",
+        "/workspace/edge/OpenPCDet/checkpoints/cbgs_pp_centerpoint_nds6070.pth",
+    ),
+}
+
+
+def _resolve_model(workload: str) -> tuple[Path, Path]:
+    """Resolve (cfg, ckpt) for an edge workload from env overrides + defaults.
+
+    Fails loud with the resolved path if either is missing, so a wrong default
+    or a forgotten env var yields an actionable message instead of a KeyError or
+    an opaque error deep inside OpenPCDet.
+    """
+    if workload not in _EDGE_MODEL_DEFAULTS:
+        raise KeyError(
+            f"no edge model defaults for {workload!r}; "
+            f"known: {sorted(_EDGE_MODEL_DEFAULTS)}"
+        )
+    default_cfg, default_ckpt = _EDGE_MODEL_DEFAULTS[workload]
+    cfg_path = Path(os.environ.get("GITM_EDGE_CFG", default_cfg))
+    ckpt_path = Path(os.environ.get("GITM_EDGE_CKPT", default_ckpt))
+    for env_name, p in (("GITM_EDGE_CFG", cfg_path), ("GITM_EDGE_CKPT", ckpt_path)):
+        if not p.exists():
+            raise FileNotFoundError(
+                f"{workload} workload: {env_name} resolves to {p}, which does not "
+                f"exist. Point {env_name} at the OpenPCDet path on this box."
+            )
+    return cfg_path, ckpt_path
+
+
+def _make_edge_run_mode(unit: Any, items: list) -> Callable[[str], dict[str, Any]]:
+    """Build the fp32/fp16 ``run_mode`` closure for the edge fp16 A/B.
+
+    Runs ``items`` through ``unit.run`` in fp32, or under fp16 autocast when
+    called with ``"fp16"``, and returns a detection summary the A/B gate compares
+    (count + sorted confidence scores). Same model + weights either way — only
+    the autocast context differs — so the only legitimate difference is fp16
+    rounding, which the gate tolerates within ``score_atol``.
+    """
+    import contextlib
+
+    import torch
+
+    def run_mode(mode: str) -> dict[str, Any]:
+        ctx = (
+            torch.autocast(device_type="cuda", dtype=torch.float16)
+            if mode == "fp16"
+            else contextlib.nullcontext()
+        )
+        # unit.run() already syncs per frame (it does .cpu() on the outputs), and
+        # optimize_edge's _timed syncs after each rep — so no extra sync here. The
+        # gate (detections_equivalent) sorts, so scores stay in collection order.
+        n_det = 0
+        scores: list[float] = []
+        with torch.no_grad(), ctx:
+            for it in items:
+                res = unit.run(it)
+                n_det += res.n_detections
+                scores.extend(float(d["score"]) for d in res.detections)
+        return {"n_frames": len(items), "n_detections": n_det, "scores": scores}
+
+    return run_mode
+
+
+def _attach_edge_applicator(run: WorkloadRunner, unit: Any, items: list) -> None:
+    """Attach the fp16-autocast applicator so the loop runs apply→prove on edge.
+
+    The A/B is capped to a small frame count (GITM_EDGE_AB_FRAMES, default 30) so
+    the rollback-gated measure is fast regardless of the observe-phase frame count.
+    With no frames there is no A/B to run, so no applicator is attached and the
+    loop falls back to a measurement-only report rather than a noise verdict over
+    an empty comparison.
+    """
+    if not items:
+        return
+    from gitm.benchmarks.edge.optimize import EdgeFp16Applicator
+
+    ab_n = int(os.environ.get("GITM_EDGE_AB_FRAMES", "30"))
+    ab_items = items[:ab_n]
+    run.applicator = EdgeFp16Applicator(
+        _make_edge_run_mode(unit, ab_items), sync=sync_device
+    )
+
+
+@register("edge", "nuscenes")
+def _nuscenes_factory(cfg: LoopConfig) -> WorkloadRunner:
     """nuScenes CenterPoint-PointPillar. Warmup (context init, cudnn autotune)
-    runs here, outside the capture window; the runner replays the frames."""
+    runs here, outside the capture window; the runner replays the frames. Carries
+    the fp16 applicator so the loop runs the full apply→prove."""
     import random
+    import time
 
     import torch
 
     from gitm.benchmarks.edge.workunit import NuScenesWorkUnit
 
-    cfg_path = Path(os.environ["GITM_EDGE_CFG"])
-    ckpt_path = Path(os.environ["GITM_EDGE_CKPT"])
+    cfg_path, ckpt_path = _resolve_model("nuscenes")
     data_root = os.environ.get("GITM_EDGE_DATA_ROOT", "/workspace/edge/OpenPCDet/data/nuscenes")
     n_frames = int(os.environ.get("GITM_EDGE_FRAMES", "500"))
     max_sweeps = int(os.environ.get("GITM_EDGE_MAX_SWEEPS", "10"))
@@ -219,10 +312,66 @@ def _edge_factory(cfg: LoopConfig) -> WorkloadRunner:
 
     def run() -> dict[str, Any]:
         total_dets = 0
+        t0 = time.perf_counter()
         for idx in run_indices:
             total_dets += unit.run(idx).n_detections
-        return {"frames": len(run_indices), "detections": total_dets}
+        elapsed = max(time.perf_counter() - t0, 1e-9)
+        return {
+            "frames": len(run_indices),
+            "detections": total_dets,
+            "elapsed_s": elapsed,
+            "fps": len(run_indices) / elapsed,
+        }
 
+    _attach_edge_applicator(run, unit, run_indices)
+    return run
+
+
+@register("kitti")
+def _kitti_factory(cfg: LoopConfig) -> WorkloadRunner:
+    """KITTI PointPillars. Unlike nuScenes, the KITTI WorkUnit is iterated by
+    .bin file path (no dataset index), so frames come from the canonical velodyne
+    enumerator. Carries the fp16 applicator for the full apply→prove loop."""
+    import random
+    import time
+
+    import torch
+
+    from gitm.benchmarks.kitti.baseline import _load_frame_paths
+    from gitm.benchmarks.kitti.workunit import WorkUnit
+
+    cfg_path, ckpt_path = _resolve_model("kitti")
+    data_root = Path(
+        os.environ.get("GITM_EDGE_DATA_ROOT")
+        or os.environ.get("GITM_DATA_ROOT", "/workspace/edge")
+    )
+    n_frames = int(os.environ.get("GITM_EDGE_FRAMES", "500"))
+    seed = int(os.environ.get("GITM_BENCH_SEED", "42"))
+
+    unit = WorkUnit.from_checkpoint(cfg_path=cfg_path, ckpt_path=ckpt_path)
+    all_paths = _load_frame_paths(data_root)  # sorted velodyne *.bin; fails loud
+    rng = random.Random(seed)
+    rng.shuffle(all_paths)
+    run_paths = all_paths[:n_frames]
+
+    for p in run_paths[:10]:  # warmup outside capture
+        unit.run(p)
+    torch.cuda.synchronize()
+
+    def run() -> dict[str, Any]:
+        total_dets = 0
+        t0 = time.perf_counter()
+        for p in run_paths:
+            total_dets += unit.run(p).n_detections
+        elapsed = max(time.perf_counter() - t0, 1e-9)
+        return {
+            "frames": len(run_paths),
+            "detections": total_dets,
+            "elapsed_s": elapsed,
+            "fps": len(run_paths) / elapsed,
+        }
+
+    _attach_edge_applicator(run, unit, run_paths)
     return run
 
 

--- a/tests/test_edge_optimize.py
+++ b/tests/test_edge_optimize.py
@@ -1,0 +1,105 @@
+"""Edge fp16 intervention: the apply→prove A/B and its correctness gate.
+
+GPU-free — the A/B is driven by an injected fake run_mode, exactly the seam the
+real OpenPCDet runner plugs into on the pod. Mirrors tests/test_hft_intervention
+in spirit: prove the gate keeps a faster-and-equivalent candidate and rolls back
+a divergent one.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from gitm.benchmarks.edge.optimize import (
+    DetectionDivergenceError,
+    EdgeFp16Applicator,
+    detections_equivalent,
+    edge_intervention_spec,
+    optimize_edge,
+)
+
+
+def _fake_run_mode(*, fp16_count: int, fp32_count: int = 5,
+                   fp16_sleep: float = 0.001, fp32_sleep: float = 0.012):
+    """fp32 is the slow baseline; fp16 is faster. fp16_count controls whether the
+    candidate's detections stay equivalent (== fp32_count) or diverge."""
+    def run_mode(mode: str) -> dict:
+        if mode == "fp16":
+            time.sleep(fp16_sleep)
+            n = fp16_count
+        else:
+            time.sleep(fp32_sleep)
+            n = fp32_count
+        return {"n_frames": 8, "n_detections": n, "scores": [0.9] * n}
+    return run_mode
+
+
+def test_detections_equivalent_gate():
+    base = {"n_detections": 3, "scores": [0.9, 0.8, 0.7]}
+    assert detections_equivalent(base, {"n_detections": 3, "scores": [0.91, 0.79, 0.71]})
+    # count mismatch → not equivalent
+    assert not detections_equivalent(base, {"n_detections": 2, "scores": [0.9, 0.8]})
+    # score drift beyond tolerance → not equivalent
+    assert not detections_equivalent(base, {"n_detections": 3, "scores": [0.5, 0.8, 0.7]})
+
+
+def test_spec_applies_to_edge_workloads():
+    spec = edge_intervention_spec()
+    assert spec.name == "edge_fp16_autocast"
+    assert set(spec.applicability.workloads) >= {"edge", "kitti", "nuscenes"}
+
+
+def test_optimize_edge_keeps_faster_equivalent_candidate():
+    rm = _fake_run_mode(fp16_count=5)  # equivalent to fp32 + faster
+    r = optimize_edge(rm, reps=1)
+    assert r.identical
+    assert r.speedup > 1.0
+    assert r.kept == "candidate"
+    assert "faster" in r.verdict
+
+
+def test_applicator_measure_returns_positive_delta_when_equivalent():
+    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=5), reps=1)
+    snap = app.snapshot()
+    app.apply(app.spec)
+    delta = app.measure(app.spec)
+    assert delta > 0
+    assert app.last_result is not None and app.last_result.identical
+    app.restore(snap)
+    assert app.active == "fp32"
+
+
+def test_applicator_rolls_back_on_detection_divergence():
+    # fp16 drops a detection → gate must refuse the speedup
+    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=4), reps=1)
+    with pytest.raises(DetectionDivergenceError):
+        app.measure(app.spec)
+
+
+def test_attach_skips_applicator_when_no_frames():
+    """No frames → no A/B → no applicator, so the loop falls back to
+    measurement-only instead of a noise verdict over an empty comparison."""
+    from gitm.workloads import _attach_edge_applicator
+
+    def run() -> dict:
+        return {}
+
+    _attach_edge_applicator(run, object(), [])
+    assert not hasattr(run, "applicator")
+
+
+def test_applicator_runs_through_the_apply_gate():
+    """End-to-end through the real rollback gate: equivalent+faster is kept."""
+    from gitm.optimizer.apply import apply_intervention
+
+    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=5), reps=1)
+    res = apply_intervention(app.spec, app, min_keep_delta=0.0)
+    assert res.applied and not res.rolled_back
+    assert res.measured_delta is not None and res.measured_delta > 0
+
+    # divergent candidate → gate rolls back, no speedup kept
+    app2 = EdgeFp16Applicator(_fake_run_mode(fp16_count=4), reps=1)
+    res2 = apply_intervention(app2.spec, app2, min_keep_delta=0.0)
+    assert res2.rolled_back

--- a/tests/test_workload_bootstrap.py
+++ b/tests/test_workload_bootstrap.py
@@ -53,6 +53,28 @@ def test_hft_factory_autostages_and_runs(tmp_path: Path, monkeypatch):
     assert summary["events"] > 0
 
 
+def test_edge_workloads_registered():
+    """kitti and nuscenes must be resolvable workload ids (README advertises
+    them); edge stays as the nuScenes alias for back-compat."""
+    from gitm.workloads import get_factory, registered
+
+    names = registered()
+    for name in ("kitti", "nuscenes", "edge"):
+        assert name in names, f"{name} not registered"
+        assert get_factory(name) is not None
+
+
+def test_resolve_model_fails_loud_on_missing_path(tmp_path: Path, monkeypatch):
+    """A missing cfg/ckpt yields an actionable FileNotFoundError naming the env
+    var and the resolved path — not a KeyError or an opaque OpenPCDet error."""
+    from gitm.workloads import _resolve_model
+
+    monkeypatch.setenv("GITM_EDGE_CFG", str(tmp_path / "nope.yaml"))
+    monkeypatch.setenv("GITM_EDGE_CKPT", str(tmp_path / "nope.pth"))
+    with pytest.raises(FileNotFoundError, match="GITM_EDGE_CFG"):
+        _resolve_model("kitti")
+
+
 def test_autobuild_skipped_without_gpu(monkeypatch):
     import gitm.tracer._cupti as c
 


### PR DESCRIPTION
Brings edge (3D LiDAR detection) into the full observe→attribute→select→apply→ prove loop, mirroring the existing hft and openfold interventions.

- gitm/benchmarks/edge/optimize.py: EdgeFp16Applicator + edge_intervention_spec. A/B runs fp32 vs fp16 autocast, gates on detection-equivalence (count + sorted scores within tolerance), returns the measured speedup; a divergence or a slowdown rolls back. run_mode is injectable so the gate is unit-tested with a fake (no GPU).
- gitm/scheduler/loop.py: add _EDGE_INTERVENTION_WORKLOADS gate + _edge_intervention_result, alongside the hft/openfold gates.
- gitm/workloads.py: register kitti + (edge,nuscenes); resolve cfg/ckpt with pod-correct defaults; attach EdgeFp16Applicator to both runners.
- benchmarks/edge/harness.py: fix two real bugs that blocked any real run — chdir to tools/ so OpenPCDet resolves _BASE_CONFIG_, and pass a real logger to load_params_from_file (None crashed it).
- benchmarks/edge/run_edge_speeds.sh: 3-seed fps runner with pod-correct paths and a source guard.

Baselines measured on RunPod: KITTI PointPillars 9.4 fps, nuScenes CenterPoint-PP 2.6 fps (10 sweeps). Full suite green.