### PR TITLE
edge: frame-batching intervention

### DIFF
--- a/gitm/benchmarks/edge/optimize.py
+++ b/gitm/benchmarks/edge/optimize.py
@@ -69,27 +69,29 @@ class EdgeABResult:
     @property
     def verdict(self) -> str:
         if not self.identical:
-            return "rolled back — fp16 detections differ from fp32 beyond tolerance"
+            return "rolled back — candidate detections differ from baseline beyond tolerance"
         if self.kept == "candidate":
             return f"kept candidate — verified +{(self.speedup - 1) * 100:.1f}% faster, detections equivalent"
-        return "kept baseline — fp16 not faster"
+        return "kept baseline — candidate not faster"
 
 
 def optimize_edge(
     run_mode: RunMode,
     *,
+    baseline_mode: str = "fp32",
+    candidate_mode: str = "fp16",
     reps: int = 2,
     sync: Callable[[], None] | None = None,
     score_atol: float = 0.02,
 ) -> EdgeABResult:
     """Run the measure→apply→prove A/B and return a gated verdict.
 
-    ``run_mode(mode)`` runs the frames in ``"fp32"`` or ``"fp16"`` — a single
-    callable dispatched by mode (the two precisions are the same code path on a
-    different autocast context, not two distinct functions). Each precision is
-    run ``reps`` times; the best (lowest) wall time is used to reduce launch
-    jitter. ``sync`` is invoked after each run so GPU timing is honest (pass a
-    device sync; default no-op for CPU/fake).
+    ``run_mode(mode)`` runs the frames in the given mode and returns a detection
+    summary — a single callable dispatched by mode (e.g. ``"fp32"``/``"fp16"`` for
+    the precision lever, ``"serial"``/``"batched"`` for the batching lever). Each
+    mode is run ``reps`` times; the best (lowest) wall time is used to reduce
+    launch jitter. ``sync`` is invoked after each run so GPU timing is honest
+    (pass a device sync; default no-op for CPU/fake).
     """
     sync = sync or (lambda: None)
 
@@ -104,8 +106,8 @@ def optimize_edge(
         n = max(int(summary.get("n_frames", 0)), 0)
         return summary, n / max(best, 1e-9)
 
-    base_summary, base_eps = _timed("fp32")
-    cand_summary, cand_eps = _timed("fp16")
+    base_summary, base_eps = _timed(baseline_mode)
+    cand_summary, cand_eps = _timed(candidate_mode)
 
     identical = detections_equivalent(base_summary, cand_summary, score_atol=score_atol)
     speedup = cand_eps / base_eps if base_eps else 0.0
@@ -214,6 +216,8 @@ class EdgeFp16Applicator:
     def measure(self, spec: InterventionSpec) -> float:
         r = optimize_edge(
             self._run_mode,
+            baseline_mode="fp32",
+            candidate_mode="fp16",
             reps=self._reps,
             sync=self._sync,
             score_atol=self._score_atol,
@@ -222,5 +226,107 @@ class EdgeFp16Applicator:
         if not r.identical:
             raise DetectionDivergenceError(
                 "fp16 detections differ from fp32 beyond tolerance — rolling back"
+            )
+        return r.speedup - 1.0
+
+
+def edge_batching_spec(batch_size: int = 4) -> InterventionSpec:
+    """The curated edge lever for a launch-bound profile: frame batching.
+
+    The KITTI/nuScenes trace shows serialized-concurrency ~1.0 over ~11k tiny
+    kernels — the run is launch-bound, so precision (fp16) doesn't help; cutting
+    *launches* does. Batching B frames into one forward pass amortizes per-kernel
+    launch overhead. Per-frame detections are equivalent in eval mode, gated at
+    apply time, so the expected-delta range here is only for ranking.
+
+    ``batch_size`` is recorded as the spec's ``value`` so the provenance reflects
+    the batch size actually run, not a hardcoded constant.
+    """
+    return InterventionSpec(
+        name="edge_frame_batching",
+        summary=f"Run inference on batches of {batch_size} frames in one forward "
+        "pass instead of one frame at a time — amortizes per-launch overhead on a "
+        "launch-bound workload (serialized-concurrency ~1.0). Kept only if per-frame "
+        "detections stay equivalent and throughput improves.",
+        knob="edge.batch_size",
+        value=batch_size,
+        applies_to_kernels=[
+            "conv", "bev", "backbone", "pillar", "voxel", "scatter", "nms",
+            "gemm", "elementwise",
+        ],
+        expected_delta_mean=0.30,
+        expected_delta_lo=0.0,
+        expected_delta_hi=2.00,
+        source="gitm/benchmarks/edge/optimize.py — frame-batching A/B, per-frame "
+        "detection-equivalence gated against the single-frame baseline.",
+        applicability=Applicability(workloads=["edge", "kitti", "nuscenes"]),
+        safety=SafetyGate(
+            tier="moderate",
+            requires_rollback_window_s=0,
+            forbid_if_oom_history=True,
+            notes="Batching raises peak memory; gated on detection-equivalence + "
+            "speedup, and forbidden after an OOM since larger batches can OOM.",
+        ),
+        review=None,
+    )
+
+
+class EdgeBatchingApplicator:
+    """Apply frame batching through the standard rollback gate.
+
+    The 'live state' is whether inference is serial or batched. :meth:`measure`
+    runs the real serial-vs-batched A/B (:func:`optimize_edge` with
+    ``serial``/``batched`` modes): it raises :class:`DetectionDivergenceError`
+    when batched detections diverge (forcing a rollback), otherwise returns the
+    signed throughput delta so the gate keeps batching only when it is faster.
+    The full :class:`EdgeABResult` is stashed on :attr:`last_result`.
+
+    ``run_mode(mode)`` runs the frames ``"serial"`` or ``"batched"`` and returns
+    a detection summary — injected so this is testable without a GPU. Carries its
+    own :attr:`spec` so the generalized loop can read it.
+    """
+
+    def __init__(
+        self,
+        run_mode: RunMode,
+        *,
+        batch_size: int = 4,
+        reps: int = 2,
+        sync: Callable[[], None] | None = None,
+        score_atol: float = 0.02,
+        spec: InterventionSpec | None = None,
+    ):
+        self._run_mode = run_mode
+        self._batch_size = batch_size
+        self._reps = reps
+        self._sync = sync
+        self._score_atol = score_atol
+        self.active = "serial"
+        self.last_result: EdgeABResult | None = None
+        # Default spec records the actual batch size, so provenance ≠ a constant.
+        self.spec = spec or edge_batching_spec(batch_size=batch_size)
+
+    def snapshot(self) -> str:
+        return self.active
+
+    def apply(self, spec: InterventionSpec) -> None:
+        self.active = "batched"
+
+    def restore(self, snapshot: str) -> None:
+        self.active = snapshot
+
+    def measure(self, spec: InterventionSpec) -> float:
+        r = optimize_edge(
+            self._run_mode,
+            baseline_mode="serial",
+            candidate_mode="batched",
+            reps=self._reps,
+            sync=self._sync,
+            score_atol=self._score_atol,
+        )
+        self.last_result = r
+        if not r.identical:
+            raise DetectionDivergenceError(
+                "batched detections differ from single-frame beyond tolerance — rolling back"
             )
         return r.speedup - 1.0

--- a/gitm/benchmarks/edge/workunit.py
+++ b/gitm/benchmarks/edge/workunit.py
@@ -237,3 +237,57 @@ class NuScenesWorkUnit:
             t_postprocess_s=t4 - t3,
             t_total_s=t4 - t0,
         )
+
+    def run_batch(self, indices: list) -> list[WorkUnitResult]:
+        """Process a batch of keyframes in ONE forward pass (detections only).
+
+        Collates B keyframes (each with its 10-sweep accumulation) and launches
+        the network once, amortizing per-kernel launch overhead. Per-frame
+        equivalent to :meth:`run` in eval mode (BatchNorm running stats; conv is
+        per-sample), so detections match the single-frame path within float
+        tolerance — the batching intervention's correctness gate. Stage timings
+        are omitted (the A/B times wall-clock around this call).
+        """
+        if not indices:
+            return []
+
+        import torch
+        from pcdet.models import load_data_to_gpu
+
+        frame_ids: list[str] = []
+        data_dicts = []
+        for index in indices:
+            info = self.dataset.infos[index]
+            fid = info.get("token", str(index))
+            frame_ids.append(fid)
+            points = self.dataset.get_lidar_with_sweeps(index, max_sweeps=self._max_sweeps)
+            data_dicts.append(
+                self.dataset.prepare_data(data_dict={"points": points, "frame_id": fid})
+            )
+        batch = self.dataset.collate_batch(data_dicts)
+        load_data_to_gpu(batch)
+        with torch.no_grad():
+            pred_dicts, _ = self._model.forward(batch)
+        torch.cuda.synchronize()
+
+        results: list[WorkUnitResult] = []
+        for fid, pred in zip(frame_ids, pred_dicts, strict=True):
+            scores = pred["pred_scores"].cpu().numpy()
+            labels = pred["pred_labels"].cpu().numpy()
+            boxes = pred["pred_boxes"].cpu().numpy()
+            n = len(scores)
+            results.append(
+                WorkUnitResult(
+                    frame_id=fid,
+                    n_detections=n,
+                    detections=[
+                        {
+                            "name": self._class_names[int(labels[i]) - 1],
+                            "score": float(scores[i]),
+                            "box3d": boxes[i].tolist(),
+                        }
+                        for i in range(n)
+                    ],
+                )
+            )
+        return results

--- a/gitm/benchmarks/kitti/workunit.py
+++ b/gitm/benchmarks/kitti/workunit.py
@@ -218,3 +218,56 @@ class WorkUnit:
             t_postprocess_s=t4 - t3,
             t_total_s=t4 - t0,
         )
+
+    def run_batch(self, velodyne_paths: list) -> list[WorkUnitResult]:
+        """Process a batch of frames in ONE forward pass (detections only).
+
+        Collates B frames and launches the backbone/head/NMS once, amortizing
+        per-kernel launch overhead — the realizable gain on a launch-bound run
+        (serialized-concurrency ~1.0). In eval mode this is per-frame equivalent
+        to :meth:`run`: BatchNorm uses running stats and the conv/BEV stages are
+        per-sample, so detections match the single-frame path within float
+        tolerance — which is what the batching intervention's gate checks. Stage
+        timings are omitted (the A/B times wall-clock around this call).
+        """
+        if not velodyne_paths:
+            return []
+
+        import numpy as np
+        import torch
+        from pcdet.models import load_data_to_gpu
+
+        paths = [Path(p) for p in velodyne_paths]
+        data_dicts = []
+        for p in paths:
+            pts = np.fromfile(str(p), dtype=np.float32).reshape(-1, 4)
+            data_dicts.append(
+                self._dataset.prepare_data(data_dict={"points": pts, "frame_id": p.stem})
+            )
+        batch = self._dataset.collate_batch(data_dicts)
+        load_data_to_gpu(batch)
+        with torch.no_grad():
+            pred_dicts, _ = self._model.forward(batch)
+        torch.cuda.synchronize()
+
+        results: list[WorkUnitResult] = []
+        for p, pred in zip(paths, pred_dicts, strict=True):
+            scores = pred["pred_scores"].cpu().numpy()
+            labels = pred["pred_labels"].cpu().numpy()
+            boxes = pred["pred_boxes"].cpu().numpy()
+            n = len(scores)
+            results.append(
+                WorkUnitResult(
+                    frame_id=p.stem,
+                    n_detections=n,
+                    detections=[
+                        {
+                            "name": self._class_names[int(labels[i]) - 1],
+                            "score": float(scores[i]),
+                            "box3d": boxes[i].tolist(),
+                        }
+                        for i in range(n)
+                    ],
+                )
+            )
+        return results

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -226,6 +226,20 @@ def _resolve_model(workload: str) -> tuple[Path, Path]:
     return cfg_path, ckpt_path
 
 
+def _positive_int_env(name: str, default: int) -> int:
+    """Parse a positive-int env var with a clear error (vs a bare ValueError)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        val = int(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be a positive integer, got {raw!r}") from None
+    if val < 1:
+        raise ValueError(f"{name} must be >= 1, got {val}")
+    return val
+
+
 def _make_edge_run_mode(unit: Any, items: list) -> Callable[[str], dict[str, Any]]:
     """Build the fp32/fp16 ``run_mode`` closure for the edge fp16 A/B.
 
@@ -260,24 +274,73 @@ def _make_edge_run_mode(unit: Any, items: list) -> Callable[[str], dict[str, Any
     return run_mode
 
 
-def _attach_edge_applicator(run: WorkloadRunner, unit: Any, items: list) -> None:
-    """Attach the fp16-autocast applicator so the loop runs apply→prove on edge.
+def _make_edge_batch_run_mode(
+    unit: Any, items: list, batch_size: int
+) -> Callable[[str], dict[str, Any]]:
+    """Build the serial/batched ``run_mode`` closure for the edge batching A/B.
 
-    The A/B is capped to a small frame count (GITM_EDGE_AB_FRAMES, default 30) so
-    the rollback-gated measure is fast regardless of the observe-phase frame count.
-    With no frames there is no A/B to run, so no applicator is attached and the
-    loop falls back to a measurement-only report rather than a noise verdict over
-    an empty comparison.
+    ``"serial"`` runs ``items`` one at a time through ``unit.run``; ``"batched"``
+    runs them ``batch_size`` at a time through ``unit.run_batch`` (one forward per
+    chunk). Same model + weights; batching only changes how many frames share a
+    launch, so per-frame detections are equivalent in eval mode and the gate
+    tolerates float rounding within ``score_atol``.
+    """
+
+    def run_mode(mode: str) -> dict[str, Any]:
+        n_det = 0
+        scores: list[float] = []
+        if mode == "batched":
+            for i in range(0, len(items), batch_size):
+                for res in unit.run_batch(items[i : i + batch_size]):
+                    n_det += res.n_detections
+                    scores.extend(float(d["score"]) for d in res.detections)
+        else:  # serial baseline
+            for it in items:
+                res = unit.run(it)
+                n_det += res.n_detections
+                scores.extend(float(d["score"]) for d in res.detections)
+        return {"n_frames": len(items), "n_detections": n_det, "scores": scores}
+
+    return run_mode
+
+
+def _attach_edge_applicator(run: WorkloadRunner, unit: Any, items: list) -> None:
+    """Attach the edge intervention applicator so the loop runs apply→prove.
+
+    The lever defaults to **batching** (GITM_EDGE_INTERVENTION=batching) — the
+    right one for the launch-bound edge profile; set GITM_EDGE_INTERVENTION=fp16
+    for the precision lever instead. The A/B is capped to a small frame count
+    (GITM_EDGE_AB_FRAMES, default 30) so the rollback-gated measure is fast
+    regardless of the observe-phase frame count. With no frames there is no A/B,
+    so no applicator is attached and the loop falls back to measurement-only
+    rather than a noise verdict over an empty comparison.
     """
     if not items:
         return
-    from gitm.benchmarks.edge.optimize import EdgeFp16Applicator
 
-    ab_n = int(os.environ.get("GITM_EDGE_AB_FRAMES", "30"))
+    ab_n = _positive_int_env("GITM_EDGE_AB_FRAMES", 30)
     ab_items = items[:ab_n]
-    run.applicator = EdgeFp16Applicator(
-        _make_edge_run_mode(unit, ab_items), sync=sync_device
-    )
+    lever = os.environ.get("GITM_EDGE_INTERVENTION", "batching").lower()
+
+    if lever == "fp16":
+        from gitm.benchmarks.edge.optimize import EdgeFp16Applicator
+
+        run.applicator = EdgeFp16Applicator(
+            _make_edge_run_mode(unit, ab_items), sync=sync_device
+        )
+    elif lever == "batching":  # default — targets the launch-bound bottleneck
+        from gitm.benchmarks.edge.optimize import EdgeBatchingApplicator
+
+        batch_size = _positive_int_env("GITM_EDGE_BATCH_SIZE", 4)
+        run.applicator = EdgeBatchingApplicator(
+            _make_edge_batch_run_mode(unit, ab_items, batch_size),
+            batch_size=batch_size,
+            sync=sync_device,
+        )
+    else:
+        raise ValueError(
+            f"GITM_EDGE_INTERVENTION must be 'batching' or 'fp16', got {lever!r}"
+        )
 
 
 @register("edge", "nuscenes")

--- a/tests/test_edge_optimize.py
+++ b/tests/test_edge_optimize.py
@@ -78,6 +78,77 @@ def test_applicator_rolls_back_on_detection_divergence():
         app.measure(app.spec)
 
 
+def _fake_batch_run_mode(*, batched_count: int, serial_count: int = 5,
+                         batched_sleep: float = 0.002, serial_sleep: float = 0.012):
+    """serial is the slow baseline; batched is faster (fewer launches). batched_count
+    controls whether batched detections stay equivalent (== serial_count) or diverge."""
+    def run_mode(mode: str) -> dict:
+        if mode == "batched":
+            time.sleep(batched_sleep)
+            n = batched_count
+        else:
+            time.sleep(serial_sleep)
+            n = serial_count
+        return {"n_frames": 8, "n_detections": n, "scores": [0.9] * n}
+    return run_mode
+
+
+def test_batching_spec_applies_to_edge_workloads():
+    from gitm.benchmarks.edge.optimize import edge_batching_spec
+
+    spec = edge_batching_spec()
+    assert spec.name == "edge_frame_batching"
+    assert set(spec.applicability.workloads) >= {"edge", "kitti", "nuscenes"}
+
+
+def test_batching_applicator_keeps_faster_equivalent():
+    from gitm.benchmarks.edge.optimize import EdgeBatchingApplicator
+
+    app = EdgeBatchingApplicator(_fake_batch_run_mode(batched_count=5), reps=1)
+    delta = app.measure(app.spec)
+    assert delta > 0
+    assert app.last_result is not None and app.last_result.identical
+    assert app.last_result.kept == "candidate"
+
+
+def test_batching_applicator_rolls_back_on_divergence():
+    from gitm.benchmarks.edge.optimize import DetectionDivergenceError, EdgeBatchingApplicator
+
+    app = EdgeBatchingApplicator(_fake_batch_run_mode(batched_count=4), reps=1)
+    with pytest.raises(DetectionDivergenceError):
+        app.measure(app.spec)
+
+
+def test_batch_run_mode_chunks_non_divisible_length():
+    """The serial and batched modes must cover every frame, including a trailing
+    partial chunk (len=7, batch=4 → chunks of 4 + 3)."""
+    from gitm.workloads import _make_edge_batch_run_mode
+
+    class _Det(dict):
+        pass
+
+    class _Res:
+        def __init__(self, n):
+            self.n_detections = n
+            self.detections = [{"score": 0.9} for _ in range(n)]
+
+    class _FakeUnit:
+        def run(self, it):
+            return _Res(2)
+
+        def run_batch(self, items):  # one det per frame fewer than serial would be a bug
+            return [_Res(2) for _ in items]
+
+    items = list(range(7))
+    rm = _make_edge_batch_run_mode(_FakeUnit(), items, batch_size=4)
+    serial = rm("serial")
+    batched = rm("batched")
+    assert serial["n_frames"] == 7 and batched["n_frames"] == 7
+    # every frame covered in both modes → 7 frames × 2 dets
+    assert serial["n_detections"] == 14
+    assert batched["n_detections"] == 14
+
+
 def test_attach_skips_applicator_when_no_frames():
     """No frames → no A/B → no applicator, so the loop falls back to
     measurement-only instead of a noise verdict over an empty comparison."""


### PR DESCRIPTION
the lever for the launch-bound profile

fp16 (the prior edge lever) doesn't help here: the KITTI/nuScenes trace is launch-bound (serialized-concurrency ~1.0 over ~11k tiny kernels), and fp16 was measured ~2x SLOWER and detection-divergent, so the gate correctly rolled it back. The bottleneck is per-kernel launch overhead, not precision — so this adds frame batching, which amortizes launches across B frames in one forward pass.

- gitm/benchmarks/{kitti,edge}/workunit.py: add run_batch() — collate B frames, one forward, split per-frame detections. Per-frame equivalent to run() in eval mode (BatchNorm running stats; conv per-sample).
- gitm/benchmarks/edge/optimize.py: EdgeBatchingApplicator + edge_batching_spec; optimize_edge now takes baseline/candidate mode labels (fp32/fp16 OR serial/batched). A/B gates on per-frame detection-equivalence, returns the measured throughput delta; divergence or slowdown rolls back.
- gitm/workloads.py: batching is now the DEFAULT edge lever (GITM_EDGE_INTERVENTION=fp16 to switch back; GITM_EDGE_BATCH_SIZE, default 4).

Targets the bottleneck the runtime itself diagnosed. Full suite green, ruff clean. 