### PR TITLE
edge: per-frame detection-equivalence gate 

### DIFF
--- a/gitm/benchmarks/edge/optimize.py
+++ b/gitm/benchmarks/edge/optimize.py
@@ -29,31 +29,71 @@ from dataclasses import dataclass, field
 
 from gitm.kernels.spec import Applicability, InterventionSpec, SafetyGate
 
-# A run_mode runs N frames in a given precision and returns a summary dict:
-#   {"n_frames": int, "n_detections": int, "scores": sorted-desc list[float]}
+# A run_mode runs N frames in a given mode and returns a per-frame summary dict:
+#   {"n_frames": int, "frames": [ [ {"name": str, "score": float,
+#                                    "center": (x, y, z)}, ... ],  # frame 0
+#                                  ... ] }                          # frame 1..N-1
+# Frames are in the SAME order for baseline and candidate (both iterate the same
+# item list), so frame i of one lines up with frame i of the other.
 RunMode = Callable[[str], dict]
 
 
-def detections_equivalent(a: dict, b: dict, *, score_atol: float = 0.02) -> bool:
-    """True iff two detection summaries match within tolerance.
+def _center_dist(p, q) -> float:
+    return ((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2 + (p[2] - q[2]) ** 2) ** 0.5
 
-    Gate: identical detection count, the score list length matches that count
-    (catches a malformed summary), and each confidence score agrees within
-    ``score_atol``. Scores are sorted here defensively, so callers need not
-    pre-sort. This is the perception analogue of HFT's byte-identical signature —
-    strict enough that a real regression (dropped object, shifted confidence)
-    trips it, loose enough to tolerate fp16 rounding.
+
+def _frame_equivalent(da: list, db: list, *, center_atol: float, tol_frac: float) -> bool:
+    """One frame's detections equivalent iff almost every box matches a box of
+    the same class within ``center_atol`` metres.
+
+    Greedy nearest match by class + 3D center, the way the nuScenes metric itself
+    pairs boxes (center distance, not exact equality). A box on either side with
+    no partner counts as a mismatch; we allow up to ``tol_frac`` of the boxes to
+    go unmatched so a single borderline detection flipping in or out (the
+    expected effect of fp/reduction-order rounding) does not fail the frame, but
+    a real divergence (many boxes moved, dropped, or relabelled) does.
     """
-    na, nb = int(a.get("n_detections", -1)), int(b.get("n_detections", -2))
-    if na != nb:
+    used = [False] * len(db)
+    unmatched = 0
+    for d in da:
+        best, best_dist = -1, center_atol
+        for j, e in enumerate(db):
+            if used[j] or e["name"] != d["name"]:
+                continue
+            dist = _center_dist(d["center"], e["center"])
+            if dist <= best_dist:
+                best, best_dist = j, dist
+        if best >= 0:
+            used[best] = True
+        else:
+            unmatched += 1
+    unmatched += used.count(False)  # candidate boxes with no baseline partner
+    allowed = max(1, int(tol_frac * max(len(da), len(db), 1)))
+    return unmatched <= allowed
+
+
+def detections_equivalent(
+    a: dict, b: dict, *, center_atol: float = 0.5, tol_frac: float = 0.05
+) -> bool:
+    """True iff two runs produce equivalent detections, compared per frame.
+
+    For each frame, match predicted boxes by class and 3D center distance, and
+    require all but a small fraction to pair up. This replaces the old aggregate
+    exact-count check, which summed detections across all frames and demanded the
+    total match exactly. That was fine for KITTI (3 classes, sparse) but far too
+    brittle for nuScenes (10 classes, hundreds of boxes per frame, many near the
+    confidence threshold): a single borderline box flipping anywhere in the
+    sample changed the total and failed the whole comparison. Per-frame matching
+    with a tolerance keeps the gate honest (a genuine regression still trips it)
+    without rejecting rounding-level churn.
+    """
+    fa, fb = a.get("frames"), b.get("frames")
+    if fa is None or fb is None or len(fa) != len(fb):
         return False
-    sa = sorted((float(x) for x in a.get("scores", [])), reverse=True)
-    sb = sorted((float(x) for x in b.get("scores", [])), reverse=True)
-    # A well-formed summary carries one score per detection; mismatch = malformed.
-    if len(sa) != na or len(sb) != nb:
-        return False
-    # lengths are equal here (both == na); strict=True surfaces any future drift.
-    return all(abs(x - y) <= score_atol for x, y in zip(sa, sb, strict=True))
+    return all(
+        _frame_equivalent(da, db, center_atol=center_atol, tol_frac=tol_frac)
+        for da, db in zip(fa, fb, strict=True)
+    )
 
 
 @dataclass
@@ -82,7 +122,8 @@ def optimize_edge(
     candidate_mode: str = "fp16",
     reps: int = 2,
     sync: Callable[[], None] | None = None,
-    score_atol: float = 0.02,
+    center_atol: float = 0.5,
+    tol_frac: float = 0.05,
 ) -> EdgeABResult:
     """Run the measure→apply→prove A/B and return a gated verdict.
 
@@ -109,7 +150,9 @@ def optimize_edge(
     base_summary, base_eps = _timed(baseline_mode)
     cand_summary, cand_eps = _timed(candidate_mode)
 
-    identical = detections_equivalent(base_summary, cand_summary, score_atol=score_atol)
+    identical = detections_equivalent(
+        base_summary, cand_summary, center_atol=center_atol, tol_frac=tol_frac
+    )
     speedup = cand_eps / base_eps if base_eps else 0.0
     kept = "candidate" if (identical and cand_eps > base_eps) else "baseline"
 
@@ -193,13 +236,15 @@ class EdgeFp16Applicator:
         *,
         reps: int = 2,
         sync: Callable[[], None] | None = None,
-        score_atol: float = 0.02,
+        center_atol: float = 0.5,
+        tol_frac: float = 0.05,
         spec: InterventionSpec | None = None,
     ):
         self._run_mode = run_mode
         self._reps = reps
         self._sync = sync
-        self._score_atol = score_atol
+        self._center_atol = center_atol
+        self._tol_frac = tol_frac
         self.active = "fp32"
         self.last_result: EdgeABResult | None = None
         self.spec = spec or edge_intervention_spec()
@@ -220,7 +265,8 @@ class EdgeFp16Applicator:
             candidate_mode="fp16",
             reps=self._reps,
             sync=self._sync,
-            score_atol=self._score_atol,
+            center_atol=self._center_atol,
+            tol_frac=self._tol_frac,
         )
         self.last_result = r
         if not r.identical:
@@ -293,14 +339,16 @@ class EdgeBatchingApplicator:
         batch_size: int = 4,
         reps: int = 2,
         sync: Callable[[], None] | None = None,
-        score_atol: float = 0.02,
+        center_atol: float = 0.5,
+        tol_frac: float = 0.05,
         spec: InterventionSpec | None = None,
     ):
         self._run_mode = run_mode
         self._batch_size = batch_size
         self._reps = reps
         self._sync = sync
-        self._score_atol = score_atol
+        self._center_atol = center_atol
+        self._tol_frac = tol_frac
         self.active = "serial"
         self.last_result: EdgeABResult | None = None
         # Default spec records the actual batch size, so provenance ≠ a constant.
@@ -322,7 +370,8 @@ class EdgeBatchingApplicator:
             candidate_mode="batched",
             reps=self._reps,
             sync=self._sync,
-            score_atol=self._score_atol,
+            center_atol=self._center_atol,
+            tol_frac=self._tol_frac,
         )
         self.last_result = r
         if not r.identical:

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -240,14 +240,25 @@ def _positive_int_env(name: str, default: int) -> int:
     return val
 
 
+def _frame_dets(res: Any) -> list[dict[str, Any]]:
+    """One frame's detections in the gate's shape: name + score + 3D center.
+
+    The gate matches boxes per frame by class and center distance, so it needs
+    the center (first three of the 7-number box) and the class name per box, not
+    just the score.
+    """
+    return [
+        {"name": d["name"], "score": float(d["score"]), "center": tuple(d["box3d"][:3])}
+        for d in res.detections
+    ]
+
+
 def _make_edge_run_mode(unit: Any, items: list) -> Callable[[str], dict[str, Any]]:
     """Build the fp32/fp16 ``run_mode`` closure for the edge fp16 A/B.
 
     Runs ``items`` through ``unit.run`` in fp32, or under fp16 autocast when
-    called with ``"fp16"``, and returns a detection summary the A/B gate compares
-    (count + sorted confidence scores). Same model + weights either way — only
-    the autocast context differs — so the only legitimate difference is fp16
-    rounding, which the gate tolerates within ``score_atol``.
+    called with ``"fp16"``, and returns a per-frame detection summary the gate
+    compares. Same model + weights either way; only the autocast context differs.
     """
     import contextlib
 
@@ -260,16 +271,12 @@ def _make_edge_run_mode(unit: Any, items: list) -> Callable[[str], dict[str, Any
             else contextlib.nullcontext()
         )
         # unit.run() already syncs per frame (it does .cpu() on the outputs), and
-        # optimize_edge's _timed syncs after each rep — so no extra sync here. The
-        # gate (detections_equivalent) sorts, so scores stay in collection order.
-        n_det = 0
-        scores: list[float] = []
+        # optimize_edge's _timed syncs after each rep — so no extra sync here.
+        frames: list[list[dict[str, Any]]] = []
         with torch.no_grad(), ctx:
             for it in items:
-                res = unit.run(it)
-                n_det += res.n_detections
-                scores.extend(float(d["score"]) for d in res.detections)
-        return {"n_frames": len(items), "n_detections": n_det, "scores": scores}
+                frames.append(_frame_dets(unit.run(it)))
+        return {"n_frames": len(items), "frames": frames}
 
     return run_mode
 
@@ -282,24 +289,20 @@ def _make_edge_batch_run_mode(
     ``"serial"`` runs ``items`` one at a time through ``unit.run``; ``"batched"``
     runs them ``batch_size`` at a time through ``unit.run_batch`` (one forward per
     chunk). Same model + weights; batching only changes how many frames share a
-    launch, so per-frame detections are equivalent in eval mode and the gate
-    tolerates float rounding within ``score_atol``.
+    launch, so per-frame detections are equivalent in eval mode. Returns the
+    per-frame detection summary the gate compares (frames stay in item order).
     """
 
     def run_mode(mode: str) -> dict[str, Any]:
-        n_det = 0
-        scores: list[float] = []
+        frames: list[list[dict[str, Any]]] = []
         if mode == "batched":
             for i in range(0, len(items), batch_size):
                 for res in unit.run_batch(items[i : i + batch_size]):
-                    n_det += res.n_detections
-                    scores.extend(float(d["score"]) for d in res.detections)
+                    frames.append(_frame_dets(res))
         else:  # serial baseline
             for it in items:
-                res = unit.run(it)
-                n_det += res.n_detections
-                scores.extend(float(d["score"]) for d in res.detections)
-        return {"n_frames": len(items), "n_detections": n_det, "scores": scores}
+                frames.append(_frame_dets(unit.run(it)))
+        return {"n_frames": len(items), "frames": frames}
 
     return run_mode
 

--- a/tests/test_edge_optimize.py
+++ b/tests/test_edge_optimize.py
@@ -1,9 +1,11 @@
-"""Edge fp16 intervention: the apply→prove A/B and its correctness gate.
+"""Edge interventions (fp16 and batching): the apply→prove A/B and its per-frame
+correctness gate.
 
-GPU-free — the A/B is driven by an injected fake run_mode, exactly the seam the
-real OpenPCDet runner plugs into on the pod. Mirrors tests/test_hft_intervention
-in spirit: prove the gate keeps a faster-and-equivalent candidate and rolls back
-a divergent one.
+GPU-free. The A/B is driven by an injected fake run_mode, exactly the seam the
+real OpenPCDet runner plugs into on the pod. The gate matches detections per
+frame by class and 3D center distance, tolerating a small amount of churn (the
+rounding-level flips fp16 / batching cause) while still catching a real
+divergence.
 """
 
 from __future__ import annotations
@@ -14,139 +16,123 @@ import pytest
 
 from gitm.benchmarks.edge.optimize import (
     DetectionDivergenceError,
+    EdgeBatchingApplicator,
     EdgeFp16Applicator,
     detections_equivalent,
+    edge_batching_spec,
     edge_intervention_spec,
     optimize_edge,
 )
 
 
-def _fake_run_mode(*, fp16_count: int, fp32_count: int = 5,
-                   fp16_sleep: float = 0.001, fp32_sleep: float = 0.012):
-    """fp32 is the slow baseline; fp16 is faster. fp16_count controls whether the
-    candidate's detections stay equivalent (== fp32_count) or diverge."""
+def _frames(n_frames: int = 8, n_det: int = 5, *, shift: float = 0.0, drop: int = 0) -> dict:
+    """Per-frame summary: each frame has the same boxes, one car per integer x.
+    ``shift`` moves every box (to break the center match); ``drop`` removes boxes
+    (to simulate detections flipping out)."""
+    out = []
+    for _ in range(n_frames):
+        out.append([
+            {"name": "car", "score": 0.9, "center": (float(i) + shift, 0.0, 0.0)}
+            for i in range(max(0, n_det - drop))
+        ])
+    return {"n_frames": n_frames, "frames": out}
+
+
+def _fake_run_mode(*, equivalent: bool = True, fast_sleep: float = 0.001,
+                   slow_sleep: float = 0.012):
+    """Baseline (slow) vs candidate (fast). Candidate is the fp16/batched mode.
+    When not equivalent, the candidate's boxes are shifted far enough that none
+    match by center, which the gate must reject."""
+    base = _frames()
+    cand = _frames() if equivalent else _frames(shift=10.0)
+
     def run_mode(mode: str) -> dict:
-        if mode == "fp16":
-            time.sleep(fp16_sleep)
-            n = fp16_count
-        else:
-            time.sleep(fp32_sleep)
-            n = fp32_count
-        return {"n_frames": 8, "n_detections": n, "scores": [0.9] * n}
+        if mode in ("fp16", "batched"):       # candidate
+            time.sleep(fast_sleep)
+            return cand
+        time.sleep(slow_sleep)                # baseline
+        return base
     return run_mode
 
 
-def test_detections_equivalent_gate():
-    base = {"n_detections": 3, "scores": [0.9, 0.8, 0.7]}
-    assert detections_equivalent(base, {"n_detections": 3, "scores": [0.91, 0.79, 0.71]})
-    # count mismatch → not equivalent
-    assert not detections_equivalent(base, {"n_detections": 2, "scores": [0.9, 0.8]})
-    # score drift beyond tolerance → not equivalent
-    assert not detections_equivalent(base, {"n_detections": 3, "scores": [0.5, 0.8, 0.7]})
+def test_detections_equivalent_matches_per_frame():
+    base = _frames(n_frames=2, n_det=3)
+    # identical boxes → equivalent
+    assert detections_equivalent(base, _frames(n_frames=2, n_det=3))
+    # one borderline detection flipping out per frame is tolerated
+    assert detections_equivalent(base, _frames(n_frames=2, n_det=3, drop=1))
+    # every box moved beyond the center tolerance → real divergence, rejected
+    assert not detections_equivalent(base, _frames(n_frames=2, n_det=3, shift=10.0))
+    # all detections gone → rejected
+    assert not detections_equivalent(base, _frames(n_frames=2, n_det=0))
+    # frame count mismatch → rejected
+    assert not detections_equivalent(base, _frames(n_frames=1, n_det=3))
 
 
-def test_spec_applies_to_edge_workloads():
-    spec = edge_intervention_spec()
-    assert spec.name == "edge_fp16_autocast"
-    assert set(spec.applicability.workloads) >= {"edge", "kitti", "nuscenes"}
+def test_specs_apply_to_edge_workloads():
+    for spec in (edge_intervention_spec(), edge_batching_spec()):
+        assert set(spec.applicability.workloads) >= {"edge", "kitti", "nuscenes"}
+    assert edge_intervention_spec().name == "edge_fp16_autocast"
+    assert edge_batching_spec().name == "edge_frame_batching"
 
 
 def test_optimize_edge_keeps_faster_equivalent_candidate():
-    rm = _fake_run_mode(fp16_count=5)  # equivalent to fp32 + faster
-    r = optimize_edge(rm, reps=1)
-    assert r.identical
-    assert r.speedup > 1.0
-    assert r.kept == "candidate"
+    r = optimize_edge(_fake_run_mode(equivalent=True), reps=1)
+    assert r.identical and r.speedup > 1.0 and r.kept == "candidate"
     assert "faster" in r.verdict
 
 
-def test_applicator_measure_returns_positive_delta_when_equivalent():
-    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=5), reps=1)
-    snap = app.snapshot()
-    app.apply(app.spec)
-    delta = app.measure(app.spec)
-    assert delta > 0
-    assert app.last_result is not None and app.last_result.identical
-    app.restore(snap)
-    assert app.active == "fp32"
+def test_fp16_applicator_keeps_when_equivalent_and_rolls_back_when_not():
+    keep = EdgeFp16Applicator(_fake_run_mode(equivalent=True), reps=1)
+    snap = keep.snapshot()
+    keep.apply(keep.spec)
+    assert keep.measure(keep.spec) > 0
+    assert keep.last_result is not None and keep.last_result.identical
+    keep.restore(snap)
+    assert keep.active == "fp32"
 
-
-def test_applicator_rolls_back_on_detection_divergence():
-    # fp16 drops a detection → gate must refuse the speedup
-    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=4), reps=1)
+    drift = EdgeFp16Applicator(_fake_run_mode(equivalent=False), reps=1)
     with pytest.raises(DetectionDivergenceError):
-        app.measure(app.spec)
+        drift.measure(drift.spec)
 
 
-def _fake_batch_run_mode(*, batched_count: int, serial_count: int = 5,
-                         batched_sleep: float = 0.002, serial_sleep: float = 0.012):
-    """serial is the slow baseline; batched is faster (fewer launches). batched_count
-    controls whether batched detections stay equivalent (== serial_count) or diverge."""
-    def run_mode(mode: str) -> dict:
-        if mode == "batched":
-            time.sleep(batched_sleep)
-            n = batched_count
-        else:
-            time.sleep(serial_sleep)
-            n = serial_count
-        return {"n_frames": 8, "n_detections": n, "scores": [0.9] * n}
-    return run_mode
+def test_batching_applicator_keeps_when_equivalent_and_rolls_back_when_not():
+    keep = EdgeBatchingApplicator(_fake_run_mode(equivalent=True), reps=1)
+    assert keep.measure(keep.spec) > 0
+    assert keep.last_result is not None and keep.last_result.kept == "candidate"
 
-
-def test_batching_spec_applies_to_edge_workloads():
-    from gitm.benchmarks.edge.optimize import edge_batching_spec
-
-    spec = edge_batching_spec()
-    assert spec.name == "edge_frame_batching"
-    assert set(spec.applicability.workloads) >= {"edge", "kitti", "nuscenes"}
-
-
-def test_batching_applicator_keeps_faster_equivalent():
-    from gitm.benchmarks.edge.optimize import EdgeBatchingApplicator
-
-    app = EdgeBatchingApplicator(_fake_batch_run_mode(batched_count=5), reps=1)
-    delta = app.measure(app.spec)
-    assert delta > 0
-    assert app.last_result is not None and app.last_result.identical
-    assert app.last_result.kept == "candidate"
-
-
-def test_batching_applicator_rolls_back_on_divergence():
-    from gitm.benchmarks.edge.optimize import DetectionDivergenceError, EdgeBatchingApplicator
-
-    app = EdgeBatchingApplicator(_fake_batch_run_mode(batched_count=4), reps=1)
+    drift = EdgeBatchingApplicator(_fake_run_mode(equivalent=False), reps=1)
     with pytest.raises(DetectionDivergenceError):
-        app.measure(app.spec)
+        drift.measure(drift.spec)
 
 
 def test_batch_run_mode_chunks_non_divisible_length():
-    """The serial and batched modes must cover every frame, including a trailing
+    """serial and batched modes must cover every frame, including a trailing
     partial chunk (len=7, batch=4 → chunks of 4 + 3)."""
     from gitm.workloads import _make_edge_batch_run_mode
-
-    class _Det(dict):
-        pass
 
     class _Res:
         def __init__(self, n):
             self.n_detections = n
-            self.detections = [{"score": 0.9} for _ in range(n)]
+            self.detections = [
+                {"name": "car", "score": 0.9, "box3d": [float(i), 0, 0, 1, 1, 1, 0]}
+                for i in range(n)
+            ]
 
     class _FakeUnit:
         def run(self, it):
             return _Res(2)
 
-        def run_batch(self, items):  # one det per frame fewer than serial would be a bug
+        def run_batch(self, items):
             return [_Res(2) for _ in items]
 
     items = list(range(7))
     rm = _make_edge_batch_run_mode(_FakeUnit(), items, batch_size=4)
-    serial = rm("serial")
-    batched = rm("batched")
+    serial, batched = rm("serial"), rm("batched")
     assert serial["n_frames"] == 7 and batched["n_frames"] == 7
     # every frame covered in both modes → 7 frames × 2 dets
-    assert serial["n_detections"] == 14
-    assert batched["n_detections"] == 14
+    assert sum(len(f) for f in serial["frames"]) == 14
+    assert sum(len(f) for f in batched["frames"]) == 14
 
 
 def test_attach_skips_applicator_when_no_frames():
@@ -162,15 +148,14 @@ def test_attach_skips_applicator_when_no_frames():
 
 
 def test_applicator_runs_through_the_apply_gate():
-    """End-to-end through the real rollback gate: equivalent+faster is kept."""
+    """End-to-end through the real rollback gate: equivalent+faster is kept,
+    divergent is rolled back."""
     from gitm.optimizer.apply import apply_intervention
 
-    app = EdgeFp16Applicator(_fake_run_mode(fp16_count=5), reps=1)
-    res = apply_intervention(app.spec, app, min_keep_delta=0.0)
+    keep = EdgeBatchingApplicator(_fake_run_mode(equivalent=True), reps=1)
+    res = apply_intervention(keep.spec, keep, min_keep_delta=0.0)
     assert res.applied and not res.rolled_back
     assert res.measured_delta is not None and res.measured_delta > 0
 
-    # divergent candidate → gate rolls back, no speedup kept
-    app2 = EdgeFp16Applicator(_fake_run_mode(fp16_count=4), reps=1)
-    res2 = apply_intervention(app2.spec, app2, min_keep_delta=0.0)
-    assert res2.rolled_back
+    drift = EdgeBatchingApplicator(_fake_run_mode(equivalent=False), reps=1)
+    assert apply_intervention(drift.spec, drift, min_keep_delta=0.0).rolled_back


### PR DESCRIPTION
fixes nuScenes false rollbacks

The old gate summed detections across all frames and required the total count to match exactly plus sorted scores within tolerance. Fine for KITTI (3 classes, sparse), but far too brittle for nuScenes (10 classes, hundreds of boxes per frame, many near the confidence threshold): a single borderline box flipping anywhere in the sample changed the total and failed the whole comparison. That produced erratic, non-monotonic rollbacks on nuScenes even though batching was correct and faster (B=8 happened to pass at +17.5%, neighbors did not).

New gate compares per frame, matching boxes by class and 3D center distance (the way the nuScenes metric pairs boxes), and allows a small fraction (5%) of boxes to go unmatched. So rounding-level churn (a borderline detection flipping in or out) passes, while a real divergence (boxes moved, dropped, or relabelled) still trips it.

- gitm/benchmarks/edge/optimize.py: detections_equivalent now per-frame center matching (center_atol, tol_frac); applicators + optimize_edge thread those.
- gitm/workloads.py: run_mode builders emit per-frame detections (name + score + center) via _frame_dets, instead of an aggregate count + score list.
- tests: gate tolerates a borderline flip, rejects real divergence; applicators keep/roll-back through the real apply gate.

Full suite green, ruff clean.