### PR TITLE
vLLM embodiment (decode workload, gate-context, live applicator, scheduler-stats attribution, deviation tracing)

### DIFF
--- a/gitm/optimizer/apply.py
+++ b/gitm/optimizer/apply.py
@@ -331,6 +331,9 @@ class LiveEngineApplicator:
             _, old_engine = self._prev
             self._shutdown(self.engine)  # drop the candidate engine we built
             self.engine = old_engine
+        # Consume the restore record so a second restore() can't re-undo (or
+        # re-shutdown the already-discarded candidate engine) a second time.
+        self._prev = None
 
     @staticmethod
     def _shutdown(engine: Any) -> None:

--- a/gitm/optimizer/apply.py
+++ b/gitm/optimizer/apply.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import yaml
 
 from gitm.kernels.spec import InterventionSpec
+from gitm.optimizer.vllm_knobs import get_knob, knob_kind, set_knob
 
 if TYPE_CHECKING:
     from gitm.safety.audit import AuditLog
@@ -195,6 +196,178 @@ class ConfigFileApplicator:
 
     def measure(self, spec: InterventionSpec) -> float | None:
         return self._measure_fn(spec) if self._measure_fn else None
+
+
+@dataclass
+class EngineABResult:
+    """Outcome of the live decode-throughput A/B for one knob change."""
+
+    knob: str
+    value: Any
+    baseline_tps: float
+    candidate_tps: float
+    speedup: float  # candidate / baseline
+    # measure-time indicator (delta >= 0); the *authoritative* keep/rollback
+    # decision is ApplyResult.rolled_back from apply_intervention, which gates on
+    # the caller's min_keep_delta. Report verdicts derive from ApplyResult, not this.
+    kept: bool
+    via: str = "hot-swap"  # "hot-swap" (scheduling knob) | "restart" (structural knob)
+
+    @property
+    def verdict(self) -> str:
+        d = self.speedup - 1.0
+        return f"{'kept' if self.kept else 'rolled back'} ({d:+.1%} decode throughput, via {self.via})"
+
+
+class StructuralKnobRequiresRestart(RuntimeError):
+    """A structural knob was applied with no restart hook to enact it.
+
+    Raised by :meth:`LiveEngineApplicator.apply` so ``apply_intervention`` rolls
+    the candidate back with a clear reason — never silently sets a structural
+    field the running engine won't honor.
+    """
+
+
+class LiveEngineApplicator:
+    """Apply a knob to a live (vLLM) engine, gated by a real decode-throughput A/B.
+
+    Routes by knob taxonomy (:mod:`gitm.optimizer.vllm_knobs`):
+
+    * **scheduling** knobs (``max_num_seqs``, ``max_num_batched_tokens``,
+      ``scheduling_policy``) are *hot-swapped* in place — set on the live
+      scheduler config, effective next step, restored by setting the old value.
+    * **structural** knobs (parallelism, dtype, quantization, block size, …) can
+      only take effect on a fresh engine, so they are routed through
+      ``restart_fn(engine, knob, value) -> new_engine``: the candidate engine
+      replaces the live one for the A/B, and restore swaps the original back
+      (shutting the candidate down best-effort). With no ``restart_fn`` a
+      structural knob raises :class:`StructuralKnobRequiresRestart`, which
+      ``apply_intervention`` turns into a clean rollback — never a silent no-op.
+
+    The Applicator protocol's three phases map to a measured A/B: ``snapshot``
+    benchmarks baseline decode throughput; ``apply`` hot-swaps or restarts;
+    ``measure`` benchmarks the candidate and returns the signed speedup
+    (``candidate/baseline - 1``), so a slowdown trips ``min_keep_delta`` and is
+    rolled back via ``restore``.
+
+    ``throughput_fn(engine) -> tokens_per_second`` is injected (the caller owns
+    what "a decode" means). ``getter``/``setter`` default to the knob-taxonomy
+    resolver and are overridable for engines that gate config behind methods.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        throughput_fn: Callable[[Any], float],
+        restart_fn: Callable[[Any, str, Any], Any] | None = None,
+        getter: Callable[[Any, str], Any] | None = None,
+        setter: Callable[[Any, str, Any], None] | None = None,
+        reps: int = 1,
+    ) -> None:
+        self.engine = engine
+        self._tps = throughput_fn
+        self._restart_fn = restart_fn
+        self._getter = getter or get_knob
+        self._setter = setter or set_knob
+        self._reps = max(1, reps)
+        self._baseline_tps: float | None = None
+        # Restore record: ("hotswap", knob, old_value) | ("restart", old_engine) | None.
+        self._prev: tuple[Any, ...] | None = None
+        self.last_result: EngineABResult | None = None
+
+    def _bench(self) -> float:
+        return sum(self._tps(self.engine) for _ in range(self._reps)) / self._reps
+
+    def snapshot(self) -> dict[str, Any]:
+        # Reset both the restore record AND last_result: snapshot() runs at the
+        # start of every apply_intervention, so a candidate whose apply() fails
+        # (e.g. a structural knob with no restart hook, where measure() never
+        # runs) must not leave the *previous* candidate's A/B result visible.
+        self._prev = None
+        self.last_result = None
+        self._baseline_tps = self._bench()
+        return {"baseline_tps": self._baseline_tps}
+
+    def apply(self, spec: InterventionSpec) -> None:
+        if spec.value is None:
+            raise ValueError(f"intervention {spec.name!r} has no value for knob {spec.knob!r}")
+
+        if knob_kind(spec.knob) == "scheduling":
+            # Hot-swap in place. Record the restore point only AFTER a successful
+            # set: if the knob can't be located the setter raises, _prev stays
+            # None, and restore() is a no-op (nothing changed → nothing to undo).
+            try:
+                prev = self._getter(self.engine, spec.knob)
+            except AttributeError:
+                prev = None
+            self._setter(self.engine, spec.knob, spec.value)
+            self._prev = ("hotswap", spec.knob, prev)
+            return
+
+        # Structural knob — needs a restart to take effect.
+        if self._restart_fn is None:
+            raise StructuralKnobRequiresRestart(
+                f"knob {spec.knob!r} is structural (needs an engine restart); "
+                "no restart_fn supplied, so it cannot be applied live"
+            )
+        old_engine = self.engine
+        new_engine = self._restart_fn(old_engine, spec.knob, spec.value)
+        if new_engine is None:
+            raise StructuralKnobRequiresRestart(
+                f"restart_fn produced no engine for structural knob {spec.knob!r}"
+            )
+        self.engine = new_engine
+        self._prev = ("restart", old_engine)
+
+    def restore(self, snapshot: dict[str, Any]) -> None:
+        if self._prev is None:
+            return
+        tag = self._prev[0]
+        if tag == "hotswap":
+            _, knob, old = self._prev
+            self._setter(self.engine, knob, old)
+        elif tag == "restart":
+            _, old_engine = self._prev
+            self._shutdown(self.engine)  # drop the candidate engine we built
+            self.engine = old_engine
+
+    @staticmethod
+    def _shutdown(engine: Any) -> None:
+        """Best-effort release of a candidate engine built for a restart A/B."""
+        for path in ("shutdown", "llm_engine.shutdown", "engine.shutdown"):
+            obj: Any = engine
+            for attr in path.split("."):
+                obj = getattr(obj, attr, None)
+                if obj is None:
+                    break
+            if callable(obj):
+                try:
+                    obj()
+                except Exception:
+                    pass
+                return
+
+    def measure(self, spec: InterventionSpec) -> float | None:
+        baseline = self._baseline_tps if self._baseline_tps is not None else self._bench()
+        # A non-positive baseline means the A/B has no valid reference — an idle
+        # engine, a probe that returned 0, no tokens produced. Raising (vs forcing
+        # speedup=1.0) makes apply_intervention roll the candidate back instead of
+        # silently *keeping* an unmeasurable change as a non-regression.
+        if baseline <= 0:
+            raise ValueError(
+                f"baseline decode throughput is {baseline}; cannot run a valid A/B "
+                f"for knob {spec.knob!r}"
+            )
+        candidate = self._bench()
+        speedup = candidate / baseline
+        delta = speedup - 1.0
+        via = "restart" if (self._prev and self._prev[0] == "restart") else "hot-swap"
+        self.last_result = EngineABResult(
+            knob=spec.knob, value=spec.value, baseline_tps=baseline,
+            candidate_tps=candidate, speedup=speedup, kept=delta >= 0.0, via=via,
+        )
+        return delta
 
 
 def apply_intervention_from_file(

--- a/gitm/optimizer/deviation.py
+++ b/gitm/optimizer/deviation.py
@@ -1,0 +1,154 @@
+"""Deviation-only tracing — keep only the kernels that depart from prediction.
+
+The behavioral compiler predicts a per-op execution graph; most kernels land
+inside their roofline band and are *uninteresting* — they behaved exactly as
+predicted, so storing them buys nothing. The optimization signal lives in the
+*departures*: kernels slower (or heavier) than predicted, and kernels with no
+predicted counterpart at all (unmodeled work). This module reduces a captured
+trace to just those, so trace storage scales with deviation, not duration (the
+monitor's design principle, applied to the trace itself).
+
+    dev = deviating_kernel_indices(trace, graph)   # which observed kernels departed
+    reduced = deviation_trace(trace, graph)         # a Trace of only those kernels
+
+The band check mirrors :func:`gitm.optimizer.monitor.check_invariants` (same
+``INVARIANTS`` band widths) but is applied per *observed kernel index* so each
+departure maps back to its original event — the residual pass loses that link
+because it keys by predicted op name (many kernels share one op).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from gitm.optimizer.invariants import INVARIANTS, Invariant
+from gitm.planner.graph import Graph
+from gitm.tracer.capture import write_trace_jsonl
+from gitm.tracer.schema import KernelEvent, Trace
+
+
+@dataclass
+class DeviationResult:
+    """Which observed kernels departed from the predicted graph, and how much it compresses."""
+
+    kept_indices: list[int]  # indices into trace.kernels() that departed
+    n_observed: int
+    n_predicted: int
+
+    @property
+    def n_kept(self) -> int:
+        return len(self.kept_indices)
+
+    @property
+    def reduction(self) -> float:
+        """Fraction of observed kernels dropped as in-band (0.0 if none observed)."""
+        return 1.0 - (self.n_kept / self.n_observed) if self.n_observed else 0.0
+
+
+def _departs(
+    ok: KernelEvent,
+    node_pred_s: float,
+    node_pred_bytes: float,
+    inv_kt: Invariant | None,
+    inv_mt: Invariant | None,
+) -> bool:
+    """True if observed kernel ``ok`` is out-of-band vs its predicted node."""
+    t_obs = max((ok.end_ns - ok.start_ns) / 1e9, 1e-12)
+    t_pred = max(node_pred_s, 1e-12)
+    r_kt = (t_obs - t_pred) / t_pred
+    if inv_kt is not None and abs(r_kt) > inv_kt.band_width:
+        return True
+    if (
+        inv_mt is not None
+        and ok.bytes_read is not None
+        and ok.bytes_written is not None
+        and node_pred_bytes > 0
+    ):
+        r_mt = ((ok.bytes_read + ok.bytes_written) - node_pred_bytes) / node_pred_bytes
+        if abs(r_mt) > inv_mt.band_width:
+            return True
+    return False
+
+
+def deviating_kernel_indices(
+    trace: Trace, graph: Graph, invariants: tuple[Invariant, ...] = INVARIANTS
+) -> DeviationResult:
+    """Indices of observed kernels that depart from the predicted graph.
+
+    Decode is a *repeated* step: the predicted graph models one decode step's
+    nodes (see :func:`gitm.planner.graph.predict_graph`), but a real trace spans
+    many steps. So we pair the observed kernels to the predicted step
+    **cyclically** — kernel ``i`` is compared against predicted node
+    ``i % len(pred)`` — instead of truncating at one step's worth (which would
+    label every kernel after the first step as "unmodeled" and keep ~everything,
+    defeating the point of deviation-only storage). A kernel is a *departure* when
+    its kernel-time or memory-traffic residual is out-of-band. With no predicted
+    graph at all, every kernel is unmodeled work and is kept.
+    """
+    obs = trace.kernels()
+    pred = graph.nodes
+    inv_kt = next((i for i in invariants if i.id == "kernel_time"), None)
+    inv_mt = next((i for i in invariants if i.id == "memory_traffic"), None)
+
+    if not pred:
+        # Nothing predicted → all observed kernels are unmodeled departures.
+        return DeviationResult(kept_indices=list(range(len(obs))), n_observed=len(obs),
+                               n_predicted=0)
+
+    kept: list[int] = []
+    for i, ok in enumerate(obs):
+        pn = pred[i % len(pred)]  # cycle the predicted step across repeated decode steps
+        if _departs(ok, pn.prediction.t_pred_s, pn.prediction.bytes, inv_kt, inv_mt):
+            kept.append(i)
+
+    return DeviationResult(kept_indices=kept, n_observed=len(obs), n_predicted=len(pred))
+
+
+def deviation_trace(
+    trace: Trace, graph: Graph, invariants: tuple[Invariant, ...] = INVARIANTS
+) -> Trace:
+    """Return a copy of ``trace`` keeping only kernels that depart from prediction.
+
+    Non-kernel events (memcpy/sync) are dropped — the predicted graph models
+    kernels, so deviation is only defined over them. The header (workload id,
+    fingerprint, run id, duration) is preserved so the reduced trace is still a
+    well-formed, self-describing :class:`Trace`.
+    """
+    obs = trace.kernels()
+    dev = deviating_kernel_indices(trace, graph, invariants)
+    kept_events = [obs[i] for i in dev.kept_indices]
+    return trace.model_copy(update={"events": kept_events})
+
+
+def deviation_summary(
+    trace: Trace, graph: Graph, invariants: tuple[Invariant, ...] = INVARIANTS
+) -> dict:
+    """Compact summary of the deviation filter — for the run dir / report.
+
+    ``kept_ops`` counts departures per predicted op so the report can say *which*
+    ops are the ones that didn't behave as predicted.
+    """
+    pred = graph.nodes
+    dev = deviating_kernel_indices(trace, graph, invariants)
+    kept_ops: dict[str, int] = {}
+    for i in dev.kept_indices:
+        op = pred[i % len(pred)].op if pred else "<unpredicted>"
+        kept_ops[op] = kept_ops.get(op, 0) + 1
+    return {
+        "n_observed": dev.n_observed,
+        "n_predicted": dev.n_predicted,
+        "n_kept": dev.n_kept,
+        "reduction": dev.reduction,
+        "kept_ops": kept_ops,
+    }
+
+
+def write_deviation_jsonl(reduced: Trace, path: str | Path) -> None:
+    """Write a deviation-only trace as JSONL via the canonical trace writer.
+
+    Delegates to :func:`gitm.tracer.capture.write_trace_jsonl` so the reduced
+    trace uses the exact same on-disk format as a full capture (one definition,
+    no drift) and round-trips through the same loaders.
+    """
+    write_trace_jsonl(path, reduced)

--- a/gitm/optimizer/scheduler_attribution.py
+++ b/gitm/optimizer/scheduler_attribution.py
@@ -1,4 +1,4 @@
-"""Scheduler-stats → causal attribution (the "feeds C" half of the tracer adapter).
+"""Scheduler-stats → causal attribution (the engine-signal half of the tracer adapter).
 
 The CUPTI trace explains kernel-level effects; the engine scheduler explains the
 *scheduling* causes behind them — preemptions that force KV recompute, decode
@@ -7,7 +7,7 @@ throughput, KV-cache pressure. :func:`scheduler_causes` turns a
 :class:`~gitm.tracer.vllm_stats.SchedulerStatsSummary` into ranked
 :class:`SchedulerCause` hypotheses so those engine signals enter causal
 attribution alongside the kernel-level Granger hypotheses — and each cause names
-the library knobs it motivates, linking attribution (C) to selection (B).
+the library knobs it motivates, linking attribution to intervention selection.
 
 These are rule-based, severity-ranked observations grounded in vLLM scheduler
 semantics, deliberately *not* dressed up as Granger p-values: the honest signal

--- a/gitm/optimizer/scheduler_attribution.py
+++ b/gitm/optimizer/scheduler_attribution.py
@@ -1,0 +1,133 @@
+"""Scheduler-stats → causal attribution (the "feeds C" half of the tracer adapter).
+
+The CUPTI trace explains kernel-level effects; the engine scheduler explains the
+*scheduling* causes behind them — preemptions that force KV recompute, decode
+batches left half-empty (launch-bound), an admission backlog that caps
+throughput, KV-cache pressure. :func:`scheduler_causes` turns a
+:class:`~gitm.tracer.vllm_stats.SchedulerStatsSummary` into ranked
+:class:`SchedulerCause` hypotheses so those engine signals enter causal
+attribution alongside the kernel-level Granger hypotheses — and each cause names
+the library knobs it motivates, linking attribution (C) to selection (B).
+
+These are rule-based, severity-ranked observations grounded in vLLM scheduler
+semantics, deliberately *not* dressed up as Granger p-values: the honest signal
+is "this scheduler condition held, here is how strongly, and here is what it
+implies", not a false statistical test over a handful of samples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gitm.tracer.vllm_stats import SchedulerStatsSummary
+
+
+@dataclass
+class SchedulerCause:
+    """One scheduler-level causal hypothesis, ranked by ``severity`` (0..1)."""
+
+    signal: str  # e.g. "kv_cache_preemption"
+    effect: str  # the decode symptom it explains
+    severity: float  # 0..1, how strongly the condition held over the window
+    note: str  # human-readable cause → implied fix
+    motivates_knobs: list[str]  # library knobs this cause argues for
+
+
+def scheduler_causes(
+    summary: SchedulerStatsSummary | None,
+    *,
+    occupancy_floor: float = 0.6,
+    cache_pressure: float = 0.9,
+) -> list[SchedulerCause]:
+    """Rank scheduler-level causes from a stats summary (empty when no samples).
+
+    Thresholds are conservative defaults: occupancy below ``occupancy_floor`` is
+    "under-filled", KV-cache above ``cache_pressure`` is "pressured".
+    """
+    if summary is None or summary.n_samples == 0:
+        return []
+
+    causes: list[SchedulerCause] = []
+
+    # Preemptions force KV recompute — a direct, expensive decode tax.
+    if summary.total_preemptions:
+        causes.append(
+            SchedulerCause(
+                signal="kv_cache_preemption",
+                effect="decode throughput (recompute after preemption)",
+                severity=min(1.0, summary.total_preemptions / 10.0),
+                note=(
+                    f"{summary.total_preemptions} preemption(s) over the window forced KV "
+                    "recompute; raise gpu_memory_utilization / add swap_space, or lower "
+                    "max_num_seqs to fit the working set."
+                ),
+                motivates_knobs=[
+                    "gpu_memory_utilization", "swap_space", "kv_cache_dtype", "max_num_seqs"
+                ],
+            )
+        )
+
+    # Under-filled decode batches → launch-bound, GPU starved of parallel work.
+    if summary.mean_batch_occupancy is not None and summary.mean_batch_occupancy < occupancy_floor:
+        deficit = (occupancy_floor - summary.mean_batch_occupancy) / occupancy_floor
+        causes.append(
+            SchedulerCause(
+                signal="under_filled_batch",
+                effect="decode is launch-bound (small batches)",
+                severity=min(1.0, deficit),
+                note=(
+                    f"mean batch occupancy {summary.mean_batch_occupancy:.0%} < "
+                    f"{occupancy_floor:.0%}: decode batches are under-filled. Raise "
+                    "max_num_seqs / max_num_batched_tokens, or capture CUDA graphs "
+                    "(enforce_eager=false) to cut per-step launch overhead."
+                ),
+                motivates_knobs=[
+                    "max_num_seqs", "max_num_batched_tokens", "enforce_eager",
+                    "enable_chunked_prefill",
+                ],
+            )
+        )
+
+    # Admission backlog: more waiting than running → scheduler can't admit fast
+    # enough. Guard on ``is not None`` (not truthiness): peak_running == 0 with a
+    # non-empty queue is the *worst* backlog (nothing admitted at all), and must
+    # not be silently dropped by a falsy-zero check.
+    if (
+        summary.peak_queue_depth is not None
+        and summary.peak_running is not None
+        and summary.peak_queue_depth > summary.peak_running
+    ):
+        ratio = (summary.peak_queue_depth - summary.peak_running) / max(summary.peak_running, 1)
+        causes.append(
+            SchedulerCause(
+                signal="admission_backlog",
+                effect="throughput ceiling (requests waiting, not running)",
+                severity=min(1.0, ratio),
+                note=(
+                    f"peak queue depth {summary.peak_queue_depth} exceeded peak running "
+                    f"{summary.peak_running}: admission is the bottleneck. Raise max_num_seqs "
+                    "/ max_num_batched_tokens to admit more concurrently."
+                ),
+                motivates_knobs=["max_num_seqs", "max_num_batched_tokens"],
+            )
+        )
+
+    # KV-cache near full → preemption risk; fewer bytes per token helps.
+    if summary.peak_gpu_cache_usage is not None and summary.peak_gpu_cache_usage > cache_pressure:
+        over = (summary.peak_gpu_cache_usage - cache_pressure) / max(1.0 - cache_pressure, 1e-6)
+        causes.append(
+            SchedulerCause(
+                signal="kv_cache_pressure",
+                effect="preemption risk (KV cache near full)",
+                severity=min(1.0, over),
+                note=(
+                    f"peak KV-cache usage {summary.peak_gpu_cache_usage:.0%}: cache is "
+                    "pressured. fp8 KV cache or a larger block size frees capacity before "
+                    "preemption kicks in."
+                ),
+                motivates_knobs=["kv_cache_dtype", "block_size", "gpu_memory_utilization"],
+            )
+        )
+
+    causes.sort(key=lambda c: c.severity, reverse=True)
+    return causes

--- a/gitm/optimizer/vllm_knobs.py
+++ b/gitm/optimizer/vllm_knobs.py
@@ -1,0 +1,187 @@
+"""vLLM knob taxonomy — where each library knob lives, and how it can be applied.
+
+The intervention library (:mod:`gitm.kernels.library`) names knobs flat
+(``max_num_seqs``, ``block_size``, …). A *live* vLLM engine keeps them on nested
+config objects (``scheduler_config.max_num_seqs``, ``cache_config.block_size``,
+``parallel_config.tensor_parallel_size``), and only a few are safe to mutate on a
+running engine. This module is the single source of truth for both:
+
+* **path** — the dotted location on the engine (tried under several prefixes so
+  it survives vLLM laying configs out as ``engine.vllm_config.<cfg>`` vs
+  ``engine.<cfg>`` across versions), or ``env:VLLM_*`` for env-var knobs.
+* **kind** — ``"scheduling"`` (hot-swappable: takes effect next scheduler step)
+  vs ``"structural"`` (requires an engine restart to take effect).
+
+:class:`gitm.optimizer.apply.LiveEngineApplicator` uses this to hot-swap a
+scheduling knob in place, and to route a structural knob through a restart hook
+(or roll it back cleanly when no restart hook is available) — never to silently
+set a structural field that the running engine won't actually honor.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+
+KnobKind = Literal["scheduling", "structural"]
+
+# Prefixes a config object may hide behind, newest-first. ``""`` = the config is
+# a direct attribute of the engine (older vLLM / our test doubles).
+_PREFIXES = (
+    "",
+    "vllm_config.",
+    "engine.vllm_config.",
+    "llm_engine.vllm_config.",
+    "engine.",
+    "llm_engine.",
+)
+
+
+@dataclass(frozen=True)
+class KnobSpec:
+    """Where a flat library knob lives on the engine, and how it can be applied."""
+
+    knob: str
+    path: str  # dotted engine path, or "env:NAME" for an env-var knob
+    kind: KnobKind
+
+    @property
+    def is_env(self) -> bool:
+        return self.path.startswith("env:")
+
+
+# The curated map. Only the three scheduler knobs vLLM honors mid-run are
+# "scheduling"; everything else is fixed at construction → "structural".
+_KNOBS: dict[str, KnobSpec] = {
+    # --- scheduling: live-settable on the scheduler, effective next step -------
+    "max_num_seqs": KnobSpec("max_num_seqs", "scheduler_config.max_num_seqs", "scheduling"),
+    "max_num_batched_tokens": KnobSpec(
+        "max_num_batched_tokens", "scheduler_config.max_num_batched_tokens", "scheduling"
+    ),
+    "scheduling_policy": KnobSpec("scheduling_policy", "scheduler_config.policy", "scheduling"),
+    # --- structural: fixed at engine construction, need a restart to change ----
+    "block_size": KnobSpec("block_size", "cache_config.block_size", "structural"),
+    "kv_cache_dtype": KnobSpec("kv_cache_dtype", "cache_config.cache_dtype", "structural"),
+    "gpu_memory_utilization": KnobSpec(
+        "gpu_memory_utilization", "cache_config.gpu_memory_utilization", "structural"
+    ),
+    "swap_space": KnobSpec("swap_space", "cache_config.swap_space_bytes", "structural"),
+    "enable_prefix_caching": KnobSpec(
+        "enable_prefix_caching", "cache_config.enable_prefix_caching", "structural"
+    ),
+    "enable_chunked_prefill": KnobSpec(
+        "enable_chunked_prefill", "scheduler_config.chunked_prefill_enabled", "structural"
+    ),
+    "num_speculative_tokens": KnobSpec(
+        "num_speculative_tokens", "speculative_config.num_speculative_tokens", "structural"
+    ),
+    "enforce_eager": KnobSpec("enforce_eager", "model_config.enforce_eager", "structural"),
+    "max_seq_len_to_capture": KnobSpec(
+        "max_seq_len_to_capture", "model_config.max_seq_len_to_capture", "structural"
+    ),
+    "quantization": KnobSpec("quantization", "model_config.quantization", "structural"),
+    "tensor_parallel_size": KnobSpec(
+        "tensor_parallel_size", "parallel_config.tensor_parallel_size", "structural"
+    ),
+    "pipeline_parallel_size": KnobSpec(
+        "pipeline_parallel_size", "parallel_config.pipeline_parallel_size", "structural"
+    ),
+    "disable_custom_all_reduce": KnobSpec(
+        "disable_custom_all_reduce", "parallel_config.disable_custom_all_reduce", "structural"
+    ),
+    "distributed_executor_backend": KnobSpec(
+        "distributed_executor_backend", "parallel_config.distributed_executor_backend", "structural"
+    ),
+    # Env-var knob: read by vLLM at construction → structural.
+    "VLLM_ATTENTION_BACKEND": KnobSpec(
+        "VLLM_ATTENTION_BACKEND", "env:VLLM_ATTENTION_BACKEND", "structural"
+    ),
+}
+
+
+def resolve_knob(knob: str) -> KnobSpec | None:
+    """The :class:`KnobSpec` for ``knob``, or ``None`` if it isn't in the taxonomy."""
+    return _KNOBS.get(knob)
+
+
+def _holder_and_leaf(engine: Any, path: str) -> tuple[Any, str] | None:
+    """Resolve ``path`` on ``engine`` to ``(holder_object, leaf_attr)``.
+
+    Tries each prefix in turn; returns the first where the parent chain resolves
+    to a real object that has the leaf attribute. ``None`` if nothing matches.
+    """
+    leaf = path.rsplit(".", 1)[-1]
+    rel_parents = path.rsplit(".", 1)[0] if "." in path else ""
+    for prefix in _PREFIXES:
+        full_parent = f"{prefix}{rel_parents}".strip(".")
+        holder: Any = engine
+        ok = True
+        for attr in (a for a in full_parent.split(".") if a):
+            holder = getattr(holder, attr, None)
+            if holder is None:
+                ok = False
+                break
+        if ok and holder is not None and hasattr(holder, leaf):
+            return holder, leaf
+    return None
+
+
+def get_knob(engine: Any, knob: str) -> Any:
+    """Read ``knob`` from the live engine via its taxonomy path.
+
+    Falls back to a flat attribute on the engine when the knob isn't in the
+    taxonomy or its structured path isn't present (duck-typing across versions
+    and test doubles). Raises ``AttributeError`` if nothing resolves.
+    """
+    spec = resolve_knob(knob)
+    if spec is not None and spec.is_env:
+        return os.environ.get(spec.path.split(":", 1)[1])
+    if spec is not None:
+        hl = _holder_and_leaf(engine, spec.path)
+        if hl is not None:
+            holder, leaf = hl
+            return getattr(holder, leaf)
+    # Flat fallback.
+    if hasattr(engine, knob):
+        return getattr(engine, knob)
+    raise AttributeError(f"engine has no knob {knob!r} (taxonomy path or flat attr)")
+
+
+def set_knob(engine: Any, knob: str, value: Any) -> None:
+    """Set ``knob`` on the live engine via its taxonomy path (scheduling knobs).
+
+    Raises ``AttributeError`` when the knob can't be located — the caller
+    (:class:`~gitm.optimizer.apply.LiveEngineApplicator`) turns that into a
+    rollback rather than silently no-op'ing.
+    """
+    spec = resolve_knob(knob)
+    if spec is not None and spec.is_env:
+        name = spec.path.split(":", 1)[1]
+        # Restoring an originally-unset env var means *unsetting* it — never
+        # writing the literal string "None", which vLLM would read as a backend.
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = str(value)
+        return
+    if spec is not None:
+        hl = _holder_and_leaf(engine, spec.path)
+        if hl is not None:
+            holder, leaf = hl
+            setattr(holder, leaf, value)
+            return
+    if hasattr(engine, knob):
+        setattr(engine, knob, value)
+        return
+    raise AttributeError(f"engine has no hot-swappable knob {knob!r}")
+
+
+def knob_kind(knob: str) -> KnobKind:
+    """``"scheduling"`` or ``"structural"`` for ``knob``.
+
+    Unknown knobs default to ``"structural"`` — the safe assumption is that a
+    knob we don't recognize needs a restart, never that it's safe to hot-swap.
+    """
+    spec = resolve_knob(knob)
+    return spec.kind if spec is not None else "structural"

--- a/gitm/planner/context.py
+++ b/gitm/planner/context.py
@@ -1,0 +1,143 @@
+"""Planner gate-context: the deployment facts levers are matched against.
+
+The precondition gate (:mod:`gitm.optimizer.preconditions`) and the metrics
+module (:mod:`gitm.optimizer.metrics`) both need ground truth about this box:
+which SKU, what dtype, how big the KV cache, how many GPUs, NVLink or not, and
+the hardware peak FLOP/bandwidth. This module assembles that once, from NVML and
+the live engine, so downstream code never guesses.
+
+Everything degrades cleanly: no NVML → read ``GITM_GPU_SKU``; unknown SKU →
+``None`` peaks (HFU/MFU simply stay unreported rather than wrong). Engine
+introspection is duck-typed so it survives vLLM version drift.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from gitm.optimizer.metrics import HardwarePeak
+from gitm.optimizer.preconditions import GateContext
+
+# Dense fp16/bf16 tensor-core peaks (FLOP/s) and HBM bandwidth (bytes/s) by SKU
+# substring. Conservative vendor figures; used for HFU/MFU/MBU denominators.
+_PEAKS: dict[str, tuple[float, float]] = {
+    "H100": (989e12, 3350e9),
+    "H200": (989e12, 4800e9),
+    "A100-SXM": (312e12, 2039e9),
+    "A100": (312e12, 1555e9),  # PCIe / 40GB fallback
+    "L40": (181e12, 864e9),
+    "L4": (121e12, 300e9),
+    "V100": (125e12, 900e9),
+}
+
+
+@dataclass
+class PlannerContext:
+    """The assembled deployment facts for one run.
+
+    ``gate`` is what the precondition gate matches levers against; ``peak`` is
+    the SKU's dense peaks (``None`` on an unknown SKU). ``sku``/``num_gpus`` are
+    surfaced for the report.
+    """
+
+    gate: GateContext
+    peak: HardwarePeak | None
+    sku: str | None
+    num_gpus: int
+
+
+def _query_nvml() -> tuple[str | None, int | None]:
+    """(SKU name, device count) via NVML in a single init/shutdown cycle.
+
+    Returns ``(None, None)`` when NVML/pynvml is unavailable. One cycle for both
+    queries — they describe the same device set, so there's no reason to init,
+    shutdown, and re-init.
+    """
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        try:
+            name = pynvml.nvmlDeviceGetName(pynvml.nvmlDeviceGetHandleByIndex(0))
+            name_s = name.decode() if isinstance(name, bytes) else str(name)
+            return name_s, int(pynvml.nvmlDeviceGetCount())
+        finally:
+            pynvml.nvmlShutdown()
+    except Exception:
+        return None, None
+
+
+def peak_for_sku(sku: str | None) -> HardwarePeak | None:
+    """Look up dense peaks for a SKU string (substring match), else None."""
+    if not sku:
+        return None
+    for key, (flops, bw) in _PEAKS.items():
+        if key.lower() in sku.lower():
+            return HardwarePeak(name=sku, peak_flops=flops, peak_bw_bytes_s=bw)
+    return None
+
+
+def _engine_dtype(engine: Any) -> str | None:
+    if engine is None:
+        return None
+    for path in ("model_config.dtype", "dtype"):
+        obj: Any = engine
+        for attr in path.split("."):
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if obj is not None:
+            s = str(obj).lower()
+            for dt in ("bfloat16", "bf16", "float16", "fp16", "float32", "fp32"):
+                if dt in s:
+                    return {"bfloat16": "bf16", "float16": "fp16", "float32": "fp32"}.get(dt, dt)
+    return None
+
+
+def _engine_kv_len(engine: Any) -> int | None:
+    if engine is None:
+        return None
+    for path in ("cache_config.max_model_len", "model_config.max_model_len", "max_model_len"):
+        obj: Any = engine
+        for attr in path.split("."):
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if isinstance(obj, int):
+            return obj
+    return None
+
+
+def build_planner_context(
+    engine: Any = None,
+    *,
+    workload: str = "vllm-decode",
+    num_gpus: int | None = None,
+) -> PlannerContext:
+    """Assemble the gate context + hardware peaks for this run.
+
+    ``GITM_GPU_SKU`` overrides NVML (useful in CI / on a box without pynvml).
+    """
+    env_sku = os.environ.get("GITM_GPU_SKU")
+    # Only touch NVML if something it provides is actually missing.
+    nvml_name = nvml_count = None
+    if env_sku is None or num_gpus is None:
+        nvml_name, nvml_count = _query_nvml()
+    sku = env_sku or nvml_name
+    n = num_gpus or nvml_count or 1
+    peak = peak_for_sku(sku)
+    dtype = _engine_dtype(engine)
+    kv_len = _engine_kv_len(engine)
+
+    gate = GateContext(
+        workload=workload,
+        dtype=dtype,
+        hardware=sku,
+        kv_cache_len=kv_len,
+        num_gpus=n,
+        has_collective=n > 1,
+        has_interconnect=n > 1,  # refined later by NVLink/IB probe
+    )
+    return PlannerContext(gate=gate, peak=peak, sku=sku, num_gpus=n)

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -339,7 +339,7 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
                     for h in dr_hypotheses.top(5)
                 ],
                 # Engine-scheduler causes (from the vLLM stats adapter) ranked
-                # alongside the kernel-level hypotheses — the "feeds C" link.
+                # alongside the kernel-level hypotheses (the engine-signal causal link).
                 "scheduler_causes": [
                     {"signal": c.signal, "effect": c.effect, "severity": c.severity,
                      "note": c.note, "motivates_knobs": c.motivates_knobs}

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -9,26 +9,37 @@ partial run is still useful; the durable copy is synced to S3 afterwards.
 from __future__ import annotations
 
 import json
+import os
 import re
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
 from gitm._paths import runs_dir, traces_dir
 from gitm.agents.policy import Policy, select_interventions
 from gitm.kernels.library import load_library
-from gitm.optimizer.apply import DryRunApplicator, apply_intervention
+from gitm.optimizer.apply import (
+    Applicator,
+    DryRunApplicator,
+    LiveEngineApplicator,
+    apply_intervention,
+)
 from gitm.optimizer.attribution import attribute
+from gitm.optimizer.deviation import deviation_summary, deviation_trace, write_deviation_jsonl
 from gitm.optimizer.dr import attribute_dr
 from gitm.optimizer.measure import measure_trace, measurement_claims, measurement_summary
 from gitm.optimizer.monitor import check_invariants, residuals
 from gitm.optimizer.qualification import qualify
 from gitm.optimizer.report import Claim, build_provenance, write_report
+from gitm.optimizer.scheduler_attribution import scheduler_causes
+from gitm.optimizer.vllm_knobs import knob_kind
+from gitm.planner.context import build_planner_context
 from gitm.planner.graph import predict_graph
 from gitm.safety.audit import AuditLog, _write_report
 from gitm.tracer.capture import capture
+from gitm.tracer.vllm_stats import sample_scheduler_stats
 from gitm.workloads import WorkloadRunner, get_factory, sync_device
 
 _BUDGET_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd])\s*$")
@@ -60,6 +71,62 @@ def _parse_budget_s(budget: str) -> float:
         raise ValueError(f"unparseable budget: {budget!r} (use 24h, 90m, 3600s, 1d)")
     value, unit = float(m.group(1)), m.group(2)
     return value * {"s": 1.0, "m": 60.0, "h": 3600.0, "d": 86400.0}[unit]
+
+def _engine_throughput_fn(engine: Any, runner: Any) -> Any:
+    """Resolve a decode-throughput probe for the live A/B.
+
+    Prefers an explicit ``engine.gitm_throughput_fn`` (the engine owns what "a
+    decode" means); otherwise times the workload ``runner`` and divides generated
+    tokens by elapsed seconds. Re-running the runner re-runs the decode under the
+    engine's current config, so an in-place hot-swap is reflected in the measurement.
+
+    Contract: this default probe re-runs the (potentially expensive) full workload
+    and is bound to the *original* engine, so it is only valid for in-place
+    hot-swap A/Bs. A deployment that supplies ``gitm_restart_fn`` (structural-knob
+    restart-apply, which swaps in a *new* engine) MUST also supply an engine-aware
+    ``gitm_throughput_fn`` — the default cannot measure the restarted engine.
+    """
+    explicit = getattr(engine, "gitm_throughput_fn", None)
+    if callable(explicit):
+        return explicit
+
+    def _tps(_engine: Any) -> float:
+        t0 = time.perf_counter()
+        out = runner() if runner is not None else {}
+        dt = max(time.perf_counter() - t0, 1e-9)
+        # First key that is actually present wins — `or` would treat a legitimate
+        # 0 (a window that produced no tokens) as missing and fabricate a count.
+        toks: float = 1.0
+        if isinstance(out, dict):
+            for key in ("generated_tokens", "decode_steps", "events"):
+                if out.get(key) is not None:
+                    toks = float(out[key])
+                    break
+        return toks / dt
+
+    return _tps
+
+
+def _scheduler_note(s: Any) -> str | None:
+    """One-line scheduler-stats sentence for the report, or None if no samples.
+
+    ``s`` is a :class:`gitm.tracer.vllm_stats.SchedulerStatsSummary`; read
+    duck-typed so an empty/absent summary degrades to no note rather than a crash.
+    """
+    if s is None or getattr(s, "n_samples", 0) == 0:
+        return None
+    parts: list[str] = []
+    if s.peak_queue_depth is not None:
+        parts.append(f"peak queue depth {s.peak_queue_depth}")
+    if s.mean_batch_occupancy is not None:
+        parts.append(f"mean batch occupancy {s.mean_batch_occupancy:.0%}")
+    if s.total_preemptions is not None:
+        parts.append(f"{s.total_preemptions} preemption(s)")
+    if s.peak_gpu_cache_usage is not None:
+        parts.append(f"peak KV-cache {s.peak_gpu_cache_usage:.0%}")
+    if not parts:
+        return None
+    return "Engine scheduler: " + ", ".join(parts) + f" (over {s.n_samples} samples)."
 
 
 @dataclass
@@ -103,13 +170,32 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         else:
             runner_error = f"no workload runner registered for {workload!r}"
 
-    with capture(trace_path, workload_id=workload, run_id=run_id) as trace:
+    # Sample the engine scheduler (queue depth, batch occupancy, preemptions)
+    # over the same window as the CUPTI capture — engine-level telemetry the GPU
+    # trace can't see. A no-op when no engine is attached (empty series).
+    with (
+        capture(trace_path, workload_id=workload, run_id=run_id) as trace,
+        sample_scheduler_stats(cfg.engine) as sched_stats,
+    ):
         if runner is not None:
             try:
                 runner()
                 sync_device()  # ensure all kernels land in the trace before stop
             except Exception as exc:
                 runner_error = f"workload run failed: {exc}"
+
+    # Persist the scheduler series + summary when an engine actually produced one.
+    # Turn the summary into ranked causal hypotheses (feeds attribution / claim
+    # evidence below) — empty when no engine produced samples.
+    sched_summary = sched_stats.summary()
+    sched_causes = scheduler_causes(sched_summary)
+    if sched_stats.samples:
+        (run_dir / "scheduler_stats.json").write_text(
+            json.dumps(
+                {"summary": asdict(sched_summary), "samples": sched_stats.to_records()},
+                indent=2,
+            )
+        )
 
     qual = qualify(trace, target_floor=cfg.target)
     (run_dir / "qualification.json").write_text(
@@ -252,15 +338,35 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
                      "notes": h.notes}
                     for h in dr_hypotheses.top(5)
                 ],
+                # Engine-scheduler causes (from the vLLM stats adapter) ranked
+                # alongside the kernel-level hypotheses — the "feeds C" link.
+                "scheduler_causes": [
+                    {"signal": c.signal, "effect": c.effect, "severity": c.severity,
+                     "note": c.note, "motivates_knobs": c.motivates_knobs}
+                    for c in sched_causes
+                ],
             },
             indent=2,
         )
     )
 
+    # Deviation-only tracing: record only the kernels that *departed* from the
+    # predicted graph — trace storage scales with deviation, not duration. We
+    # always write the compact summary (n_kept, reduction, which ops departed);
+    # the full reduced JSONL is written only under GITM_DEVIATION_ONLY=1 (it is
+    # the storage-saving artifact, off by default while capture-time integration
+    # is still on the roadmap).
+    (run_dir / "deviations.json").write_text(
+        json.dumps(deviation_summary(trace, graph), indent=2)
+    )
+    if os.environ.get("GITM_DEVIATION_ONLY") == "1":
+        write_deviation_jsonl(deviation_trace(trace, graph), run_dir / "deviation_trace.jsonl")
+
     # Phase 3 — library + counterfactual replay ranking
-    library = load_library()
+    pctx = build_planner_context(cfg.engine, workload = workload)
+    library = load_library(workload = workload)
     policy = Policy(require_qualification_commit=qual.commit, skip_high_risk=not qual.commit)
-    ranked = select_interventions(trace, library, policy, top_n=cfg.top_n_interventions)
+    ranked = select_interventions(trace, library, policy, top_n=cfg.top_n_interventions, ctx=pctx.gate)
     (run_dir / "ranked_candidates.json").write_text(
         json.dumps(
             [
@@ -275,7 +381,25 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         )
     )
 
-    # Phase 4 — apply with rollback gates
+    # Phase 4 — apply with rollback gates.
+    # With a live engine attached, each candidate runs the rollback-gated decode-
+    # throughput A/B (LiveEngineApplicator): snapshot baseline tps → hot-swap the
+    # knob → measure candidate tps → keep only on a non-negative delta, else
+    # restore. Scheduling knobs are hot-swapped; structural knobs are routed
+    # through ``engine.gitm_restart_fn`` (if the deployment provides one) or
+    # rolled back rather than silently no-op'd. With no engine it's predict-only
+    # (DryRunApplicator): candidates land in the report as unverified
+    # (measured_delta=None), never claimed as won.
+    live_restart_fn = getattr(cfg.engine, "gitm_restart_fn", None) if cfg.engine else None
+    if cfg.engine is not None:
+        applicator: Applicator = LiveEngineApplicator(
+            cfg.engine,
+            throughput_fn=_engine_throughput_fn(cfg.engine, runner),
+            restart_fn=live_restart_fn,
+        )
+    else:
+        applicator = DryRunApplicator()
+
     claims: list[Claim] = []
     rolled_back: list[str] = []
     rejected: list[str] = []
@@ -283,20 +407,42 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         if c.rejected_reason is not None:
             rejected.append(f"{c.spec.name} ({c.rejected_reason})")
             continue
-        # No live engine attached -> predict-only, unverified claims.
-        # A live run passes an engine applicator here.
-        result = apply_intervention(c.spec, DryRunApplicator())
+        # Live + structural knob + no restart hook → it *cannot* be enacted on the
+        # running engine, so it's "not evaluable here", not a regression. Mark it
+        # rejected (honest) instead of attempting an apply that would roll back and
+        # read as "tried and lost" — and skip the wasted baseline benchmark.
+        if cfg.engine is not None and live_restart_fn is None and knob_kind(c.spec.knob) == "structural":
+            rejected.append(f"{c.spec.name} (structural knob: needs engine restart, no restart_fn)")
+            continue
+        result = apply_intervention(c.spec, applicator, min_keep_delta=0.0)
+        ab = getattr(applicator, "last_result", None)
         if result.rolled_back:
             rolled_back.append(c.spec.name)
+        # Causal evidence: the measured A/B verdict when live, else the Granger
+        # signal that motivated the candidate. The kept/rolled-back wording comes
+        # from the authoritative ApplyResult (the real gate decision), not from
+        # EngineABResult.kept (a measure-time delta>=0 indicator).
+        if ab is not None:
+            outcome = "rolled back" if result.rolled_back else "kept"
+            causal_evidence = (
+                f"live A/B: {outcome} ({ab.speedup - 1.0:+.1%} decode throughput, via {ab.via}); "
+                f"baseline {ab.baseline_tps:.1f} → candidate {ab.candidate_tps:.1f} tok/s"
+            )
+        else:
+            causal_evidence = ", ".join(
+                f"{h.cause_op}→{h.effect_op} (p={h.p_value:.2g})" for h in hypotheses.top(2)
+            ) or "no strong causal signal"
+        # Attach the top scheduler cause that argues for *this* knob — the
+        # engine-level signal (C) tied to the specific lever it motivates (B).
+        motivating = next((sc for sc in sched_causes if c.spec.knob in sc.motivates_knobs), None)
+        if motivating is not None:
+            causal_evidence += f"; scheduler[{motivating.signal}]: {motivating.note}"
         claims.append(
             Claim(
                 summary=c.spec.summary,
                 residual_invariant="kernel_time",
                 residual_value=0.0,
-                causal_evidence=", ".join(
-                    f"{h.cause_op}→{h.effect_op} (p={h.p_value:.2g})" for h in hypotheses.top(2)
-                )
-                or "no strong causal signal",
+                causal_evidence=causal_evidence,
                 intervention_name=c.spec.name,
                 predicted_delta=c.predicted_delta,
                 measured_delta=result.measured_delta,
@@ -317,10 +463,17 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     provenance.rejected_candidates = rejected
     provenance.rolled_back = rolled_back
 
+    sched_note = _scheduler_note(sched_summary)
     report_md = write_report(
         claims=claims,
         provenance=provenance,
         qualification_diagnostic=qual.diagnostic,
+        summary=(
+            f"vLLM decode on {pctx.sku or 'unknown SKU'}: {len(claims)} candidate(s) "
+            f"evaluated, {len(rolled_back)} rolled back. {sched_note}"
+            if sched_note
+            else None
+        ),
     )
     _write_report(run_dir, report_md)
 
@@ -335,6 +488,7 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         "n_claims": len(claims),
         "n_rolled_back": len(rolled_back),
         "n_rejected": len(rejected),
+        "scheduler_stats": asdict(sched_summary) if sched_stats.samples else None,
         "report_path": str(run_dir / "report.md"),
     }
     return {"summary": summary, "report_md": report_md, "run_dir": str(run_dir)}

--- a/gitm/tracer/capture.py
+++ b/gitm/tracer/capture.py
@@ -78,8 +78,14 @@ def capture(
         _write_jsonl(out_path, trace)
 
 
-def _write_jsonl(path: Path, trace: Trace) -> None:
-    """Stream trace events to JSONL — header line, then one event per line."""
+def write_trace_jsonl(path: str | Path, trace: Trace) -> None:
+    """Write a trace to JSONL — header line, then one event per line.
+
+    The canonical on-disk trace format, shared by ``capture()`` and the
+    deviation-only trace writer so the two never drift. Creates the parent dir.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:
         header = trace.model_dump(exclude={"events"})
         fh.write(json.dumps({"_header": header}))
@@ -87,6 +93,10 @@ def _write_jsonl(path: Path, trace: Trace) -> None:
         for ev in trace.events:
             fh.write(ev.model_dump_json())
             fh.write("\n")
+
+
+# Back-compat internal alias.
+_write_jsonl = write_trace_jsonl
 
 
 def _backend():

--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -94,7 +94,7 @@ def _schedulers(engine: Any) -> list[Any]:
     )
     if sched is None:
         return []
-    return list(sched) if isinstance(sched, (list, tuple)) else [sched]
+    return list(sched) if isinstance(sched, list | tuple) else [sched]
 
 
 def _max_num_seqs(engine: Any) -> int | None:

--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -5,7 +5,7 @@ us what the *engine scheduler* did: how deep the waiting queue got, how full eac
 decode batch was, whether sequences were preempted and recomputed. Those are the
 signals that explain *why* the kernels look the way they do — a half-empty decode
 batch is launch-bound for a scheduling reason, not a kernel reason — so this
-series feeds causal attribution (stream C).
+series feeds causal attribution.
 
 Usage mirrors :func:`gitm.tracer.capture.capture`: wrap the same window.
 

--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -1,0 +1,306 @@
+"""vLLM scheduler-stats adapter — engine-level telemetry alongside the CUPTI trace.
+
+CUPTI tells us what the *GPU* did (per-kernel timings, streams). It cannot tell
+us what the *engine scheduler* did: how deep the waiting queue got, how full each
+decode batch was, whether sequences were preempted and recomputed. Those are the
+signals that explain *why* the kernels look the way they do — a half-empty decode
+batch is launch-bound for a scheduling reason, not a kernel reason — so this
+series feeds causal attribution (stream C).
+
+Usage mirrors :func:`gitm.tracer.capture.capture`: wrap the same window.
+
+    from gitm.tracer.capture import capture
+    from gitm.tracer.vllm_stats import sample_scheduler_stats
+
+    with capture(trace_path) as trace, sample_scheduler_stats(engine) as stats:
+        run_decode()
+    stats.summary()  # peak queue depth, mean batch occupancy, preemptions, ...
+
+Everything is **duck-typed and best-effort**: vLLM moves scheduler internals
+between releases, so each field is probed across several known attribute paths
+and silently left ``None`` when unavailable. A read never raises into the
+workload, and on a box without vLLM the sampler degrades to an empty series — the
+honest "no engine stats" outcome, never fabricated numbers.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass
+class SchedulerSample:
+    """One scheduler snapshot. Any field is ``None`` if the engine didn't expose it."""
+
+    t_ns: int  # ns since sampling started
+    num_running: int | None = None  # sequences decoding this step
+    num_waiting: int | None = None  # queue depth
+    num_swapped: int | None = None  # sequences swapped to CPU
+    num_unfinished: int | None = None  # total in-flight requests
+    preemptions_cumulative: int | None = None  # running total of preemptions
+    gpu_cache_usage: float | None = None  # KV-cache blocks used / total, 0..1
+    cpu_cache_usage: float | None = None
+    batch_occupancy: float | None = None  # num_running / max_num_seqs, 0..1
+
+
+@dataclass
+class SchedulerStatsSummary:
+    """Aggregates over the sampled window — the compact form attribution consumes."""
+
+    n_samples: int
+    duration_s: float
+    peak_queue_depth: int | None
+    mean_running: float | None
+    peak_running: int | None
+    mean_batch_occupancy: float | None
+    total_preemptions: int | None  # delta of cumulative counter over the window
+    peak_gpu_cache_usage: float | None
+    peak_swapped: int | None
+
+
+def _first_attr(obj: Any, *paths: str) -> Any:
+    """Return the first dotted-path attribute on ``obj`` that resolves non-None.
+
+    Duck-typing across vLLM versions: try ``engine.scheduler``,
+    ``engine.engine.scheduler``, ``engine.llm_engine.scheduler`` in turn.
+    """
+    for path in paths:
+        cur: Any = obj
+        for attr in path.split("."):
+            cur = getattr(cur, attr, None)
+            if cur is None:
+                break
+        if cur is not None:
+            return cur
+    return None
+
+
+def _len_or_none(x: Any) -> int | None:
+    try:
+        return len(x)
+    except TypeError:
+        return None
+
+
+def _schedulers(engine: Any) -> list[Any]:
+    """Resolve the engine's scheduler(s) as a list (vLLM may keep one per PP stage)."""
+    sched = _first_attr(
+        engine, "scheduler", "engine.scheduler", "llm_engine.scheduler"
+    )
+    if sched is None:
+        return []
+    return list(sched) if isinstance(sched, (list, tuple)) else [sched]
+
+
+def _max_num_seqs(engine: Any) -> int | None:
+    val = _first_attr(
+        engine,
+        "scheduler_config.max_num_seqs",
+        "engine.scheduler_config.max_num_seqs",
+        "llm_engine.scheduler_config.max_num_seqs",
+        "vllm_config.scheduler_config.max_num_seqs",
+    )
+    return int(val) if isinstance(val, int) and val > 0 else None
+
+
+def read_scheduler_stats(engine: Any, *, t_ns: int = 0) -> SchedulerSample | None:
+    """One duck-typed snapshot of the engine scheduler, or ``None`` if unreadable.
+
+    Reads queue/running/swapped depths off the scheduler's request deques, the
+    cumulative preemption counter, and KV-cache usage off the block manager.
+    Each is independent — a version that exposes some but not others yields a
+    partial sample rather than nothing.
+    """
+    if engine is None:
+        return None
+
+    schedulers = _schedulers(engine)
+    sample = SchedulerSample(t_ns=t_ns)
+    saw_any = False
+
+    if schedulers:
+        # Sum each depth across schedulers, but only report a field if at least
+        # one scheduler exposed it (a missing attr must not read as 0).
+        totals: dict[str, int] = {}
+        for sch in schedulers:
+            for field_name, attr, is_len in (
+                ("num_running", "running", True),
+                ("num_waiting", "waiting", True),
+                ("num_swapped", "swapped", True),
+                ("preemptions_cumulative", "num_cumulative_preemption", False),
+            ):
+                raw = getattr(sch, attr, None)
+                val = _len_or_none(raw) if is_len else (raw if isinstance(raw, int) else None)
+                if val is not None:
+                    totals[field_name] = totals.get(field_name, 0) + val
+        for field_name, val in totals.items():
+            setattr(sample, field_name, val)
+            saw_any = True
+
+        # KV-cache usage off the first scheduler's block manager (best-effort).
+        usage = _gpu_cache_usage(schedulers[0])
+        if usage is not None:
+            sample.gpu_cache_usage = usage
+            saw_any = True
+
+    # Total unfinished — a stable public method on LLMEngine across versions.
+    getter = _first_attr(
+        engine,
+        "get_num_unfinished_requests",
+        "engine.get_num_unfinished_requests",
+        "llm_engine.get_num_unfinished_requests",
+    )
+    if callable(getter):
+        try:
+            sample.num_unfinished = int(getter())
+            saw_any = True
+        except Exception:
+            pass
+
+    if sample.num_running is not None:
+        max_seqs = _max_num_seqs(engine)
+        if max_seqs:
+            # num_running is summed across schedulers, so the capacity is
+            # max_num_seqs per scheduler — divide by both, and clamp to [0,1] so a
+            # transient over-count (or a partially-exposed config) can never make a
+            # half-empty engine read as full and silently suppress under_filled.
+            capacity = max_seqs * max(len(schedulers), 1)
+            sample.batch_occupancy = min(1.0, sample.num_running / capacity)
+
+    return sample if saw_any else None
+
+
+def _gpu_cache_usage(scheduler: Any) -> float | None:
+    """KV-cache block occupancy (0..1) off a scheduler's block manager, if exposed."""
+    bm = getattr(scheduler, "block_manager", None)
+    if bm is None:
+        return None
+    # Newer vLLM: get_num_free_gpu_blocks(); total via num_total_gpu_blocks.
+    free_fn = getattr(bm, "get_num_free_gpu_blocks", None)
+    total = getattr(bm, "num_total_gpu_blocks", None)
+    if callable(free_fn) and isinstance(total, int) and total > 0:
+        try:
+            return max(0.0, 1.0 - free_fn() / total)
+        except Exception:
+            return None
+    return None
+
+
+class SchedulerStatsSampler:
+    """Background sampler: snapshots the engine scheduler on a fixed interval.
+
+    Runs a daemon thread so it never outlives the process. ``start``/``stop`` are
+    idempotent; ``stop`` joins the thread so all samples are flushed before
+    :meth:`summary` is called. Reads are best-effort — a read that raises is
+    dropped, not propagated into the workload.
+    """
+
+    def __init__(self, engine: Any, *, interval_s: float = 0.05) -> None:
+        self.engine = engine
+        self.interval_s = max(interval_s, 1e-3)
+        self.samples: list[SchedulerSample] = []
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._t0_ns: int = 0
+
+    def start(self) -> None:
+        if self._thread is not None or self.engine is None:
+            return
+        self._t0_ns = time.perf_counter_ns()
+        # Take one snapshot synchronously so even a decode shorter than one
+        # sampling interval still yields a scheduler reading (no start/stop race).
+        try:
+            s0 = read_scheduler_stats(self.engine, t_ns=0)
+            if s0 is not None:
+                self.samples.append(s0)
+        except Exception:
+            pass
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="gitm-vllm-stats", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                s = read_scheduler_stats(self.engine, t_ns=time.perf_counter_ns() - self._t0_ns)
+                if s is not None:
+                    self.samples.append(s)
+            except Exception:
+                pass  # best-effort; never let sampling crash the run
+            self._stop.wait(self.interval_s)
+
+    def stop(self) -> None:
+        if self._thread is None:
+            return
+        self._stop.set()
+        self._thread.join(timeout=2.0)
+        self._thread = None
+
+    def summary(self) -> SchedulerStatsSummary:
+        # Snapshot first: stop() joins with a timeout, so in the pathological case
+        # where the daemon thread is still alive, summarize must iterate a stable
+        # copy rather than a list being appended to concurrently.
+        return summarize(list(self.samples))
+
+    def to_records(self) -> list[dict[str, Any]]:
+        """Samples as plain dicts, ready for JSONL alongside the kernel trace."""
+        return [asdict(s) for s in list(self.samples)]
+
+
+def summarize(samples: list[SchedulerSample]) -> SchedulerStatsSummary:
+    """Aggregate a sample series into the compact summary attribution consumes."""
+    if not samples:
+        return SchedulerStatsSummary(
+            n_samples=0, duration_s=0.0, peak_queue_depth=None, mean_running=None,
+            peak_running=None, mean_batch_occupancy=None, total_preemptions=None,
+            peak_gpu_cache_usage=None, peak_swapped=None,
+        )
+
+    def _vals(attr: str) -> list[float]:
+        return [getattr(s, attr) for s in samples if getattr(s, attr) is not None]
+
+    waiting = _vals("num_waiting")
+    running = _vals("num_running")
+    occ = _vals("batch_occupancy")
+    preempt = _vals("preemptions_cumulative")
+    cache = _vals("gpu_cache_usage")
+    swapped = _vals("num_swapped")
+    duration_s = max(samples[-1].t_ns - samples[0].t_ns, 0) / 1e9
+
+    return SchedulerStatsSummary(
+        n_samples=len(samples),
+        duration_s=duration_s,
+        peak_queue_depth=int(max(waiting)) if waiting else None,
+        mean_running=(sum(running) / len(running)) if running else None,
+        peak_running=int(max(running)) if running else None,
+        mean_batch_occupancy=(sum(occ) / len(occ)) if occ else None,
+        # Preemptions over the window: max − min of the cumulative counter, which
+        # is monotonic within a single engine/sampling window (the sampler runs
+        # over one engine — the restart A/B happens later, after sampling stops).
+        total_preemptions=int(max(preempt) - min(preempt)) if preempt else None,
+        peak_gpu_cache_usage=max(cache) if cache else None,
+        peak_swapped=int(max(swapped)) if swapped else None,
+    )
+
+
+@contextmanager
+def sample_scheduler_stats(
+    engine: Any, *, interval_s: float = 0.05
+) -> Iterator[SchedulerStatsSampler]:
+    """Sample the engine scheduler for the duration of the ``with`` block.
+
+    A no-op (empty series) when ``engine`` is ``None`` — the loop can wrap every
+    capture window in this unconditionally and only get stats when an engine is
+    actually attached.
+    """
+    sampler = SchedulerStatsSampler(engine, interval_s=interval_s)
+    sampler.start()
+    try:
+        yield sampler
+    finally:
+        sampler.stop()

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -532,6 +532,67 @@ def _openfold_factory(cfg: LoopConfig) -> WorkloadRunner:
     )
     return run
 
+@register("vllm-decode")
+def _vllm_decode_factory(cfg: LoopConfig) -> WorkloadRunner:
+    """Launch a vLLM decode job inside the tracer capture window.
+
+    The heavy engine build (weight load, CUDA graph capture) happens here in the
+    factory, outside the capture window. The returned runner only issues the
+    decode ``llm.generate``, so the trace is the decode compute, not the model load.
+
+    Reads its config from the environment:
+        GITM_VLLM_MODEL       HF model id (default facebook/opt-125m)
+        GITM_VLLM_PROMPTS     number of prompts to decode (default 64)
+        GITM_VLLM_MAX_TOKENS  tokens to generate per prompt (default 128)
+        GITM_VLLM_SYNTHETIC   "1" -> CPU-only decode stand-in instead of vLLM
+                              (exercises the wire/registry path with no GPU or
+                              vLLM; produces no GPU kernels)
+
+    On a box without vLLM/GPU the import raises; ``run_loop`` catches it and the
+    empty-trace guard reports "no-data" rather than fabricating a result.
+    """
+    model = os.environ.get("GITM_VLLM_MODEL", "facebook/opt-125m")
+    n_prompts = int(os.environ.get("GITM_VLLM_PROMPTS", "64"))
+    max_tokens = int(os.environ.get("GITM_VLLM_MAX_TOKENS", "128"))
+
+    if os.environ.get("GITM_VLLM_SYNTHETIC") == "1":
+        return _vllm_synthetic_runner(n_prompts, max_tokens)
+
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(model=model)
+    prompts = [f"Benchmark decode prompt {i}." for i in range(n_prompts)]
+    params = SamplingParams(max_tokens=max_tokens, temperature=0.0)
+
+    def run() -> dict[str, Any]:
+        outputs = llm.generate(prompts, params)
+        produced = sum(len(o.outputs[0].token_ids) for o in outputs)
+        sync_device()
+        return {"prompts": len(prompts), "generated_tokens": produced, "model": model}
+    return run
+
+def _vllm_synthetic_runner(n_prompts: int, max_tokens: int) -> WorkloadRunner:
+    """A CPU-only stand-in for the decode loop (no vLLM, no GPU).
+
+    Exercises the registry → runner → capture path so the end-to-end wire can be
+    tested without GPU hardware. It does real CPU work (small matmuls per "token")
+    so the runner isn't an instant no-op, but emits no GPU kernels — the loop's
+    empty-trace guard then reports no-data, which is the honest outcome here.
+    """
+    import numpy as np
+
+    def run() -> dict[str, Any]:
+        steps = 0
+        a = np.ones((32, 32), dtype=np.float32)
+        for _ in range(max_tokens):
+            # A real (small) matmul per "token" so the runner isn't an instant
+            # no-op; the product is discarded — we only want CPU cycles, and `a`
+            # stays bounded (all-ones) rather than overflowing across iterations.
+            _ = a @ a
+            steps += 1
+        return {"prompts": n_prompts, "decode_steps": steps, "synthetic": True}
+
+    return run
 
 def sync_device() -> None:
     """Block until queued GPU work completes, so all kernels land in the trace

--- a/tests/test_run_loop_workload.py
+++ b/tests/test_run_loop_workload.py
@@ -149,4 +149,7 @@ def test_hft_is_registered():
 
     assert "hft" in registered() and "hft-lob" in registered()
     assert get_factory("hft") is not None
-    assert get_factory("vllm-decode") is None
+    # vllm-decode now has a registered factory (Stream A task 1); an unknown id
+    # still resolves to None.
+    assert get_factory("vllm-decode") is not None
+    assert get_factory("not-a-workload") is None

--- a/tests/test_vllm_embodiment.py
+++ b/tests/test_vllm_embodiment.py
@@ -1,4 +1,4 @@
-"""Stream A — vLLM embodiment: gate-context, precondition gate, live-engine
+"""vLLM embodiment: gate-context, precondition gate, live-engine
 applicator, scheduler-stats adapter, and deviation-only tracing.
 
 These cover the new wiring added for the ``vllm-decode`` workload without needing

--- a/tests/test_vllm_embodiment.py
+++ b/tests/test_vllm_embodiment.py
@@ -1,0 +1,338 @@
+"""Stream A — vLLM embodiment: gate-context, precondition gate, live-engine
+applicator, scheduler-stats adapter, and deviation-only tracing.
+
+These cover the new wiring added for the ``vllm-decode`` workload without needing
+a GPU or a real vLLM install: a fake duck-typed engine stands in for the live
+engine, and the loop is driven through a monkeypatched capture window.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gitm.kernels.spec import InterventionSpec
+from gitm.optimizer.metrics import HardwarePeak, hfu, mbu, mfu
+from gitm.optimizer.preconditions import GateContext, check_gate
+
+from .conftest import make_kernel, make_trace
+
+
+# --------------------------------------------------------------------------- #
+# metrics: HFU / MFU / MBU                                                     #
+# --------------------------------------------------------------------------- #
+def test_utilization_ratios_and_none_guards():
+    peak = HardwarePeak("A100", peak_flops=312e12, peak_bw_bytes_s=2039e9)
+    assert hfu(156e12, peak) == pytest.approx(0.5)
+    assert mbu(2039e9, peak) == pytest.approx(1.0)
+    assert mfu(312e12, 1.0, peak) == pytest.approx(1.0)
+    # Unknown peak / bad inputs => None (never a misleading number).
+    assert hfu(1e12, None) is None
+    assert mbu(None, peak) is None
+    assert mfu(1e12, 0.0, peak) is None  # zero elapsed
+    assert hfu(-1.0, peak) is None  # negative achieved
+
+
+# --------------------------------------------------------------------------- #
+# preconditions: the applicability gate                                       #
+# --------------------------------------------------------------------------- #
+def _spec(**over) -> InterventionSpec:
+    base = dict(
+        name="x", summary="s", knob="k", value=1,
+        expected_delta_mean=0.05, expected_delta_lo=0.0, expected_delta_hi=0.1,
+        source="test",
+    )
+    base.update(over)
+    return InterventionSpec.model_validate(base)
+
+
+def test_gate_workload_mismatch_rejects():
+    spec = _spec(applicability={"workloads": ["vllm-decode"]})
+    res = check_gate(spec, GateContext(workload="hft"))
+    assert not res.ok and "workload" in res.reason
+
+
+def test_gate_dtype_known_mismatch_rejects_but_unknown_is_lenient():
+    spec = _spec(applicability={"workloads": ["vllm-decode"], "requires_dtype": ["fp16", "bf16"]})
+    # Known fp32 box => rejected.
+    assert not check_gate(spec, GateContext(workload="vllm-decode", dtype="fp32")).ok
+    # Unknown dtype => not rejected (gate is conservative about unknowns).
+    assert check_gate(spec, GateContext(workload="vllm-decode", dtype=None)).ok
+
+
+def test_gate_hardware_substring_match():
+    spec = _spec(applicability={"workloads": ["vllm-decode"], "requires_hardware": ["A100", "H100"]})
+    assert check_gate(spec, GateContext(workload="vllm-decode", hardware="NVIDIA A100-SXM4-80GB")).ok
+    assert not check_gate(spec, GateContext(workload="vllm-decode", hardware="NVIDIA L4")).ok
+
+
+def test_gate_kv_cache_bounds():
+    spec = _spec(applicability={"workloads": ["vllm-decode"], "max_kv_cache_len": 4096})
+    assert check_gate(spec, GateContext(workload="vllm-decode", kv_cache_len=2048)).ok
+    assert not check_gate(spec, GateContext(workload="vllm-decode", kv_cache_len=8192)).ok
+
+
+def test_gate_multi_gpu_knob_on_single_gpu_rejected():
+    spec = _spec(knob="tensor_parallel_size", value=2)
+    assert not check_gate(spec, GateContext(workload="vllm-decode", num_gpus=1)).ok
+    assert check_gate(spec, GateContext(workload="vllm-decode", num_gpus=2)).ok
+
+
+# --------------------------------------------------------------------------- #
+# planner context                                                             #
+# --------------------------------------------------------------------------- #
+def test_build_planner_context_sku_override(monkeypatch):
+    from gitm.planner.context import build_planner_context
+
+    monkeypatch.setenv("GITM_GPU_SKU", "NVIDIA A100-SXM4-80GB")
+    pctx = build_planner_context(engine=None, workload="vllm-decode", num_gpus=1)
+    assert pctx.peak is not None and pctx.peak.peak_flops == 312e12
+    assert pctx.gate.workload == "vllm-decode"
+    assert pctx.gate.hardware == "NVIDIA A100-SXM4-80GB"
+    assert pctx.gate.dtype is None  # no engine attached
+
+
+def test_unknown_sku_yields_no_peak(monkeypatch):
+    from gitm.planner.context import build_planner_context
+
+    monkeypatch.setenv("GITM_GPU_SKU", "SomeFutureGPU-9000")
+    pctx = build_planner_context(engine=None, num_gpus=1)
+    assert pctx.peak is None  # unknown => unreported, never wrong
+
+
+# --------------------------------------------------------------------------- #
+# library + policy: workload filter and gate-driven selection                 #
+# --------------------------------------------------------------------------- #
+def test_load_library_filters_by_workload():
+    from gitm.kernels.library import load_library
+
+    vllm = load_library(workload="vllm-decode")
+    assert len(vllm) > 0
+    other = load_library(workload="hft")  # no vLLM lever lists hft
+    assert other == []
+
+
+def test_select_interventions_gate_rejects_inapplicable_levers():
+    from gitm.agents.policy import Policy, select_interventions
+    from gitm.kernels.library import load_library
+
+    library = load_library(workload="vllm-decode")
+    trace = make_trace(events=[make_kernel("paged_attention", end_ns=500)])
+    # Single fp32 GPU: fp8-KV (requires fp16/bf16) and TP=2 (multi-GPU) must be rejected.
+    ctx = GateContext(workload="vllm-decode", dtype="fp32", hardware="NVIDIA L4", num_gpus=1)
+    ranked = select_interventions(trace, library, Policy(), top_n=50, ctx=ctx)
+    by_knob = {c.spec.knob: c for c in ranked}
+    assert by_knob["tensor_parallel_size"].rejected_reason.startswith("precondition")
+    assert by_knob["kv_cache_dtype"].rejected_reason.startswith("precondition")
+    # Without a ctx the gate is skipped — those levers are no longer pre-rejected.
+    ranked_no_ctx = select_interventions(trace, library, Policy(), top_n=50)
+    knob_reasons = {c.spec.knob: c.rejected_reason for c in ranked_no_ctx}
+    assert knob_reasons["tensor_parallel_size"] != "precondition: knob 'tensor_parallel_size' requires >1 GPU (num_gpus=1)"
+
+
+# --------------------------------------------------------------------------- #
+# scheduler-stats adapter (Task 2)                                            #
+# --------------------------------------------------------------------------- #
+class _FakeDeque(list):
+    """A list that also stands in for vLLM's request deques (len() is what we read)."""
+
+
+class _FakeScheduler:
+    def __init__(self, running, waiting, swapped, preempt):
+        self.running = _FakeDeque(range(running))
+        self.waiting = _FakeDeque(range(waiting))
+        self.swapped = _FakeDeque(range(swapped))
+        self.num_cumulative_preemption = preempt
+
+
+class _FakeSchedulerConfig:
+    max_num_seqs = 256
+
+
+class _FakeEngine:
+    """Duck-typed stand-in for a vLLM LLMEngine (only the attrs the adapter reads)."""
+
+    def __init__(self, running=4, waiting=10, swapped=2, preempt=3):
+        self.scheduler = [_FakeScheduler(running, waiting, swapped, preempt)]
+        self.scheduler_config = _FakeSchedulerConfig()
+
+    def get_num_unfinished_requests(self):
+        return 16
+
+
+def test_read_scheduler_stats_duck_typed():
+    from gitm.tracer.vllm_stats import read_scheduler_stats
+
+    s = read_scheduler_stats(_FakeEngine(running=4, waiting=10))
+    assert s is not None
+    assert s.num_running == 4 and s.num_waiting == 10 and s.num_swapped == 2
+    assert s.num_unfinished == 16
+    assert s.preemptions_cumulative == 3
+    assert s.batch_occupancy == pytest.approx(4 / 256)
+
+
+def test_read_scheduler_stats_none_when_unreadable():
+    from gitm.tracer.vllm_stats import read_scheduler_stats
+
+    assert read_scheduler_stats(None) is None
+    assert read_scheduler_stats(object()) is None  # nothing readable => None, not a crash
+
+
+def test_sample_scheduler_stats_collects_and_summarizes():
+    from gitm.tracer.vllm_stats import sample_scheduler_stats
+
+    engine = _FakeEngine(running=8, waiting=5, swapped=0, preempt=0)
+    with sample_scheduler_stats(engine, interval_s=0.002) as sampler:
+        # Let a few samples land.
+        for _ in range(2000):
+            engine.get_num_unfinished_requests()
+    summ = sampler.summary()
+    assert summ.n_samples > 0
+    assert summ.peak_running == 8
+    assert summ.peak_queue_depth == 5
+    assert summ.mean_batch_occupancy == pytest.approx(8 / 256, rel=0.01)
+
+
+def test_sample_scheduler_stats_no_engine_is_noop():
+    from gitm.tracer.vllm_stats import sample_scheduler_stats
+
+    with sample_scheduler_stats(None) as sampler:
+        pass
+    assert sampler.samples == []
+    assert sampler.summary().n_samples == 0
+
+
+# --------------------------------------------------------------------------- #
+# deviation-only tracing (Task 6)                                             #
+# --------------------------------------------------------------------------- #
+def _decode_graph():
+    from gitm.planner.graph import predict_graph
+
+    return predict_graph()
+
+
+def test_deviation_trace_keeps_only_departures():
+    from gitm.optimizer.deviation import deviation_summary, deviation_trace
+
+    graph = _decode_graph()
+    # Build observed kernels: most match prediction (in-band), a few are 100x slower.
+    obs = []
+    for i, node in enumerate(graph.nodes):
+        dur = node.prediction.t_pred_s
+        scale = 100.0 if i % 10 == 0 else 1.0  # every 10th kernel grossly over-runs
+        ns = max(int(dur * scale * 1e9), 1)
+        obs.append(make_kernel(node.op, start_ns=i * 10_000, end_ns=i * 10_000 + ns))
+    trace = make_trace(events=obs)
+
+    reduced = deviation_trace(trace, graph)
+    summ = deviation_summary(trace, graph)
+    assert summ["n_observed"] == len(obs)
+    assert 0 < summ["n_kept"] < summ["n_observed"]  # some dropped, some kept
+    assert summ["reduction"] > 0.0
+    assert len(reduced.kernels()) == summ["n_kept"]
+    # The reduced trace is still a well-formed Trace with the header preserved.
+    assert reduced.workload_id == trace.workload_id and reduced.run_id == trace.run_id
+
+
+def test_unpredicted_kernels_are_always_departures():
+    from gitm.optimizer.deviation import deviating_kernel_indices
+
+    graph = _decode_graph()
+    n_pred = len(graph.nodes)
+    # One in-band predicted kernel + 3 extra unmodeled kernels past the graph.
+    obs = [make_kernel(graph.nodes[0].op,
+                       end_ns=max(int(graph.nodes[0].prediction.t_pred_s * 1e9), 1))]
+    obs += [make_kernel("mystery_kernel", start_ns=i, end_ns=i + 5) for i in range(3)]
+    trace = make_trace(events=obs)
+    dev = deviating_kernel_indices(trace, graph)
+    # The 3 unpredicted kernels (indices 1,2,3) are kept regardless of timing.
+    assert {1, 2, 3}.issubset(set(dev.kept_indices))
+    assert dev.n_predicted == n_pred
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end: live-engine applicator through run_loop (Task 4 + 5)            #
+# --------------------------------------------------------------------------- #
+class _ModelConfig:
+    dtype = "torch.bfloat16"  # _engine_dtype reads model_config.dtype => "bf16"
+
+
+class _LiveEngine:
+    """Duck-typed vLLM engine with one hot-swappable knob and a deterministic
+    throughput probe, so the rollback-gated A/B has a real (noise-free) signal."""
+
+    def __init__(self):
+        self.model_config = _ModelConfig()
+        self.max_num_seqs = 32  # the one knob this fake engine can hot-swap
+        # Decode throughput scales with batch width — so raising max_num_seqs is a
+        # measurable win and is kept; knobs with no matching attribute raise on
+        # apply and are rolled back (the "structural knob can't hot-swap" path).
+        self.gitm_throughput_fn = lambda e: float(e.max_num_seqs)
+
+
+def test_run_loop_live_engine_keeps_winning_knob_and_rolls_back_unswappable(
+    tmp_path: Path, monkeypatch
+):
+    from contextlib import contextmanager
+
+    import gitm.scheduler.loop as loop
+    from gitm.scheduler.loop import LoopConfig, run_loop
+
+    # Populated nvidia trace so the guard passes and the vLLM library path runs.
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        kernels = [
+            make_kernel(f"paged_attention_{i % 4}", start_ns=i * 100, end_ns=i * 100 + 80)
+            for i in range(80)
+        ]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    engine = _LiveEngine()
+    cfg = LoopConfig(
+        engine=engine,
+        workload="vllm-decode",
+        budget="5s",
+        scratch=str(tmp_path),
+        top_n_interventions=50,  # evaluate the whole library, not just top 5
+        workload_runner=lambda: {"generated_tokens": 128},
+    )
+    out = run_loop(cfg)
+    summary = out["summary"]
+    assert summary["status"] == "ok" and summary["mode"] == "intervention"
+
+    # The hot-swappable winning knob is kept with a measured positive delta.
+    assert engine.max_num_seqs == 256
+    import json
+
+    claims = json.loads((Path(out["run_dir"]) / "ranked_candidates.json").read_text())
+    assert any(c["name"] == "max_num_seqs_256" for c in claims)
+    # report carries the measured live A/B verdict (not a prediction).
+    assert "live A/B" in out["report_md"]
+    # Knobs the engine can't hot-swap were rolled back, not silently kept.
+    assert summary["n_rolled_back"] >= 1
+
+
+def test_run_loop_no_engine_is_predict_only(tmp_path: Path, monkeypatch):
+    """Without an engine, candidates are unverified (no measured delta), never won."""
+    from contextlib import contextmanager
+
+    import gitm.scheduler.loop as loop
+    from gitm.scheduler.loop import LoopConfig, run_loop
+
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        kernels = [make_kernel("paged_attention", start_ns=i * 100, end_ns=i * 100 + 80)
+                   for i in range(40)]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    out = run_loop(LoopConfig(workload="vllm-decode", budget="5s", scratch=str(tmp_path)))
+    assert out["summary"]["status"] == "ok"
+    # No scheduler stats without an engine.
+    assert out["summary"]["scheduler_stats"] is None

--- a/tests/test_vllm_embodiment.py
+++ b/tests/test_vllm_embodiment.py
@@ -14,7 +14,7 @@ import pytest
 
 from gitm.kernels.spec import InterventionSpec
 from gitm.optimizer.metrics import HardwarePeak, hfu, mbu, mfu
-from gitm.optimizer.preconditions import GateContext, check_gate
+from gitm.optimizer.preconditions import GateContext, applicable
 
 from .conftest import make_kernel, make_trace
 
@@ -49,34 +49,39 @@ def _spec(**over) -> InterventionSpec:
 
 def test_gate_workload_mismatch_rejects():
     spec = _spec(applicability={"workloads": ["vllm-decode"]})
-    res = check_gate(spec, GateContext(workload="hft"))
-    assert not res.ok and "workload" in res.reason
+    ok, reason = applicable(spec, GateContext(workload="hft"))
+    assert not ok and "workload" in reason
 
 
-def test_gate_dtype_known_mismatch_rejects_but_unknown_is_lenient():
+def test_gate_dtype_known_and_unknown_both_reject():
     spec = _spec(applicability={"workloads": ["vllm-decode"], "requires_dtype": ["fp16", "bf16"]})
     # Known fp32 box => rejected.
-    assert not check_gate(spec, GateContext(workload="vllm-decode", dtype="fp32")).ok
-    # Unknown dtype => not rejected (gate is conservative about unknowns).
-    assert check_gate(spec, GateContext(workload="vllm-decode", dtype=None)).ok
+    assert not applicable(spec, GateContext(workload="vllm-decode", dtype="fp32"))[0]
+    # Unknown dtype => also rejected: the gate is strict — it won't apply a
+    # dtype-gated lever it can't confirm is safe for this run.
+    assert not applicable(spec, GateContext(workload="vllm-decode", dtype=None))[0]
+    # Matching dtype => applies.
+    assert applicable(spec, GateContext(workload="vllm-decode", dtype="bf16"))[0]
 
 
 def test_gate_hardware_substring_match():
     spec = _spec(applicability={"workloads": ["vllm-decode"], "requires_hardware": ["A100", "H100"]})
-    assert check_gate(spec, GateContext(workload="vllm-decode", hardware="NVIDIA A100-SXM4-80GB")).ok
-    assert not check_gate(spec, GateContext(workload="vllm-decode", hardware="NVIDIA L4")).ok
+    assert applicable(spec, GateContext(workload="vllm-decode", hardware="NVIDIA A100-SXM4-80GB"))[0]
+    assert not applicable(spec, GateContext(workload="vllm-decode", hardware="NVIDIA L4"))[0]
 
 
 def test_gate_kv_cache_bounds():
     spec = _spec(applicability={"workloads": ["vllm-decode"], "max_kv_cache_len": 4096})
-    assert check_gate(spec, GateContext(workload="vllm-decode", kv_cache_len=2048)).ok
-    assert not check_gate(spec, GateContext(workload="vllm-decode", kv_cache_len=8192)).ok
+    assert applicable(spec, GateContext(workload="vllm-decode", kv_cache_len=2048))[0]
+    assert not applicable(spec, GateContext(workload="vllm-decode", kv_cache_len=8192))[0]
 
 
-def test_gate_multi_gpu_knob_on_single_gpu_rejected():
-    spec = _spec(knob="tensor_parallel_size", value=2)
-    assert not check_gate(spec, GateContext(workload="vllm-decode", num_gpus=1)).ok
-    assert check_gate(spec, GateContext(workload="vllm-decode", num_gpus=2)).ok
+def test_gate_multi_gpu_lever_on_single_gpu_rejected():
+    # main's gate keys multi-GPU off applicability.min_gpus, not the knob name.
+    spec = _spec(knob="tensor_parallel_size", value=2,
+                 applicability={"workloads": ["vllm-decode"], "min_gpus": 2})
+    assert not applicable(spec, GateContext(workload="vllm-decode", num_gpus=1))[0]
+    assert applicable(spec, GateContext(workload="vllm-decode", num_gpus=2))[0]
 
 
 # --------------------------------------------------------------------------- #
@@ -107,10 +112,19 @@ def test_unknown_sku_yields_no_peak(monkeypatch):
 def test_load_library_filters_by_workload():
     from gitm.kernels.library import load_library
 
+    # The catalog is unified (vLLM + other workloads), so the workload filter is
+    # what keeps a workload from seeing another's levers. Assert the filter, not a
+    # count: every returned lever lists the requested workload, and vLLM serving
+    # knobs never leak into another workload's set.
     vllm = load_library(workload="vllm-decode")
     assert len(vllm) > 0
-    other = load_library(workload="hft")  # no vLLM lever lists hft
-    assert other == []
+    assert all("vllm-decode" in s.applicability.workloads for s in vllm)
+    vllm_knobs = {s.knob for s in vllm}
+    assert "max_num_seqs" in vllm_knobs
+
+    hft = load_library(workload="hft")
+    assert all("hft" in s.applicability.workloads for s in hft)
+    assert "max_num_seqs" not in {s.knob for s in hft}  # no vLLM knob leaks in
 
 
 def test_select_interventions_gate_rejects_inapplicable_levers():
@@ -119,16 +133,18 @@ def test_select_interventions_gate_rejects_inapplicable_levers():
 
     library = load_library(workload="vllm-decode")
     trace = make_trace(events=[make_kernel("paged_attention", end_ns=500)])
-    # Single fp32 GPU: fp8-KV (requires fp16/bf16) and TP=2 (multi-GPU) must be rejected.
+    # Single fp32 GPU on an L4: fp8-KV (requires fp16/bf16) and TP=2 (requires
+    # A100/H100) must be gated out with main's "not_applicable: ..." reason.
     ctx = GateContext(workload="vllm-decode", dtype="fp32", hardware="NVIDIA L4", num_gpus=1)
     ranked = select_interventions(trace, library, Policy(), top_n=50, ctx=ctx)
     by_knob = {c.spec.knob: c for c in ranked}
-    assert by_knob["tensor_parallel_size"].rejected_reason.startswith("precondition")
-    assert by_knob["kv_cache_dtype"].rejected_reason.startswith("precondition")
-    # Without a ctx the gate is skipped — those levers are no longer pre-rejected.
+    assert by_knob["tensor_parallel_size"].rejected_reason.startswith("not_applicable")
+    assert by_knob["kv_cache_dtype"].rejected_reason.startswith("not_applicable")
+    # Without a ctx the applicability gate is skipped — no lever is rejected for
+    # not_applicable (a rejection, if any, would be a safety-tier reason instead).
     ranked_no_ctx = select_interventions(trace, library, Policy(), top_n=50)
-    knob_reasons = {c.spec.knob: c.rejected_reason for c in ranked_no_ctx}
-    assert knob_reasons["tensor_parallel_size"] != "precondition: knob 'tensor_parallel_size' requires >1 GPU (num_gpus=1)"
+    reasons = {c.spec.knob: (c.rejected_reason or "") for c in ranked_no_ctx}
+    assert not reasons["kv_cache_dtype"].startswith("not_applicable")
 
 
 # --------------------------------------------------------------------------- #
@@ -295,7 +311,10 @@ def test_run_loop_live_engine_keeps_winning_knob_and_rolls_back_unswappable(
     cfg = LoopConfig(
         engine=engine,
         workload="vllm-decode",
-        budget="5s",
+        # Non-expiring budget: max_num_seqs_256 ranks low, and this test asserts it
+        # is reached + kept. A short wall-clock budget would make that racy under
+        # load (the loop is budget-bounded by design), so give it plenty of room.
+        budget="24h",
         scratch=str(tmp_path),
         top_n_interventions=50,  # evaluate the whole library, not just top 5
         workload_runner=lambda: {"generated_tokens": 128},

--- a/tests/test_vllm_embodiment.py
+++ b/tests/test_vllm_embodiment.py
@@ -13,25 +13,9 @@ from pathlib import Path
 import pytest
 
 from gitm.kernels.spec import InterventionSpec
-from gitm.optimizer.metrics import HardwarePeak, hfu, mbu, mfu
 from gitm.optimizer.preconditions import GateContext, applicable
 
 from .conftest import make_kernel, make_trace
-
-
-# --------------------------------------------------------------------------- #
-# metrics: HFU / MFU / MBU                                                     #
-# --------------------------------------------------------------------------- #
-def test_utilization_ratios_and_none_guards():
-    peak = HardwarePeak("A100", peak_flops=312e12, peak_bw_bytes_s=2039e9)
-    assert hfu(156e12, peak) == pytest.approx(0.5)
-    assert mbu(2039e9, peak) == pytest.approx(1.0)
-    assert mfu(312e12, 1.0, peak) == pytest.approx(1.0)
-    # Unknown peak / bad inputs => None (never a misleading number).
-    assert hfu(1e12, None) is None
-    assert mbu(None, peak) is None
-    assert mfu(1e12, 0.0, peak) is None  # zero elapsed
-    assert hfu(-1.0, peak) is None  # negative achieved
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_vllm_knobs_and_restart.py
+++ b/tests/test_vllm_knobs_and_restart.py
@@ -1,0 +1,265 @@
+"""Stream A finishers — knob taxonomy, restart-apply for structural knobs, and
+scheduler-stats causal attribution (the "feeds C" link).
+
+No GPU / no vLLM: fake engines stand in. These cover the two pieces that were
+still in progress — #4 (hot-swap vs restart-apply) and #2 (stats → attribution).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gitm.kernels.spec import InterventionSpec
+from gitm.optimizer.apply import (
+    LiveEngineApplicator,
+    StructuralKnobRequiresRestart,
+    apply_intervention,
+)
+from gitm.optimizer.scheduler_attribution import scheduler_causes
+from gitm.optimizer.vllm_knobs import get_knob, knob_kind, resolve_knob, set_knob
+from gitm.tracer.vllm_stats import SchedulerStatsSummary
+
+
+def _spec(knob: str, value) -> InterventionSpec:
+    return InterventionSpec.model_validate(
+        dict(name=knob, summary=f"set {knob}", knob=knob, value=value,
+             expected_delta_mean=0.05, expected_delta_lo=0.0, expected_delta_hi=0.1,
+             source="test")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# knob taxonomy                                                               #
+# --------------------------------------------------------------------------- #
+def test_knob_kind_classification():
+    assert knob_kind("max_num_seqs") == "scheduling"
+    assert knob_kind("max_num_batched_tokens") == "scheduling"
+    assert knob_kind("scheduling_policy") == "scheduling"
+    assert knob_kind("tensor_parallel_size") == "structural"
+    assert knob_kind("block_size") == "structural"
+    assert knob_kind("totally_unknown_knob") == "structural"  # safe default
+
+
+class _SchedCfg:
+    def __init__(self):
+        self.max_num_seqs = 32
+
+
+class _StructuredEngine:
+    def __init__(self):
+        self.scheduler_config = _SchedCfg()
+
+
+class _FlatEngine:
+    def __init__(self):
+        self.max_num_seqs = 32  # no scheduler_config — older/test layout
+
+
+def test_get_set_via_structured_path():
+    e = _StructuredEngine()
+    assert get_knob(e, "max_num_seqs") == 32
+    set_knob(e, "max_num_seqs", 256)
+    assert e.scheduler_config.max_num_seqs == 256
+
+
+def test_get_set_flat_fallback():
+    e = _FlatEngine()
+    assert get_knob(e, "max_num_seqs") == 32
+    set_knob(e, "max_num_seqs", 128)
+    assert e.max_num_seqs == 128
+
+
+def test_env_knob_round_trip(monkeypatch):
+    monkeypatch.delenv("VLLM_ATTENTION_BACKEND", raising=False)
+    assert resolve_knob("VLLM_ATTENTION_BACKEND").is_env
+    set_knob(object(), "VLLM_ATTENTION_BACKEND", "FLASHINFER")
+    assert get_knob(object(), "VLLM_ATTENTION_BACKEND") == "FLASHINFER"
+
+
+def test_unresolvable_knob_raises():
+    with pytest.raises(AttributeError):
+        set_knob(object(), "max_num_seqs", 8)  # bare object has neither path nor flat attr
+
+
+# --------------------------------------------------------------------------- #
+# LiveEngineApplicator: hot-swap vs restart-apply                             #
+# --------------------------------------------------------------------------- #
+class _TpsEngine:
+    """Engine whose throughput is a settable number; restart yields a new one."""
+
+    def __init__(self, tps: float):
+        self.scheduler_config = _SchedCfg()
+        self._tps = tps
+
+
+def _tps_of(e):
+    return e._tps
+
+
+def test_hotswap_scheduling_knob_kept():
+    e = _TpsEngine(100.0)
+    # throughput rises with max_num_seqs so the hot-swap is a measurable win.
+    app = LiveEngineApplicator(e, throughput_fn=lambda x: float(x.scheduler_config.max_num_seqs))
+    res = apply_intervention(_spec("max_num_seqs", 256), app, min_keep_delta=0.0)
+    assert res.applied and not res.rolled_back
+    assert e.scheduler_config.max_num_seqs == 256
+    assert app.last_result.via == "hot-swap"
+    assert app.last_result.speedup == pytest.approx(256 / 32)
+
+
+def test_restart_apply_structural_knob_kept_and_swaps_engine():
+    e0 = _TpsEngine(100.0)
+
+    def restart_fn(old, knob, value):
+        assert knob == "block_size" and value == 16
+        return _TpsEngine(200.0)  # the "restarted" engine is faster
+
+    app = LiveEngineApplicator(e0, throughput_fn=_tps_of, restart_fn=restart_fn)
+    res = apply_intervention(_spec("block_size", 16), app, min_keep_delta=0.0)
+    assert res.applied and not res.rolled_back
+    assert app.engine is not e0 and app.engine._tps == 200.0  # live engine replaced
+    assert app.last_result.via == "restart"
+    assert app.last_result.speedup == pytest.approx(2.0)
+
+
+def test_restart_apply_rolls_back_to_original_engine_on_regression():
+    e0 = _TpsEngine(100.0)
+    candidate = _TpsEngine(50.0)  # slower => must roll back
+
+    app = LiveEngineApplicator(e0, throughput_fn=_tps_of, restart_fn=lambda *a: candidate)
+    res = apply_intervention(_spec("tensor_parallel_size", 2), app, min_keep_delta=0.0)
+    assert res.applied and res.rolled_back
+    assert app.engine is e0  # original engine restored
+
+
+def test_structural_knob_without_restart_fn_rolls_back_cleanly():
+    e0 = _TpsEngine(100.0)
+    app = LiveEngineApplicator(e0, throughput_fn=_tps_of)  # no restart_fn
+    res = apply_intervention(_spec("quantization", "awq"), app, min_keep_delta=0.0)
+    assert not res.applied and res.rolled_back
+    assert "structural" in res.error
+    assert app.engine is e0  # nothing changed
+
+
+def test_structural_raises_typed_exception_directly():
+    app = LiveEngineApplicator(_TpsEngine(1.0), throughput_fn=_tps_of)
+    with pytest.raises(StructuralKnobRequiresRestart):
+        app.apply(_spec("pipeline_parallel_size", 2))
+
+
+# --------------------------------------------------------------------------- #
+# scheduler-stats causal attribution (feeds C)                                #
+# --------------------------------------------------------------------------- #
+def _summary(**over) -> SchedulerStatsSummary:
+    base = dict(
+        n_samples=10, duration_s=1.0, peak_queue_depth=0, mean_running=4.0,
+        peak_running=4, mean_batch_occupancy=0.9, total_preemptions=0,
+        peak_gpu_cache_usage=0.5, peak_swapped=0,
+    )
+    base.update(over)
+    return SchedulerStatsSummary(**base)
+
+
+def test_no_samples_yields_no_causes():
+    assert scheduler_causes(None) == []
+    assert scheduler_causes(_summary(n_samples=0)) == []
+
+
+def test_preemption_cause():
+    causes = scheduler_causes(_summary(total_preemptions=5))
+    assert any(c.signal == "kv_cache_preemption" for c in causes)
+    kv = next(c for c in causes if c.signal == "kv_cache_preemption")
+    assert "gpu_memory_utilization" in kv.motivates_knobs
+
+
+def test_under_filled_batch_cause():
+    causes = scheduler_causes(_summary(mean_batch_occupancy=0.1))
+    occ = next(c for c in causes if c.signal == "under_filled_batch")
+    assert "max_num_seqs" in occ.motivates_knobs
+    assert occ.severity > 0.5  # 0.1 vs 0.6 floor is a big deficit
+
+
+def test_admission_backlog_cause():
+    causes = scheduler_causes(_summary(peak_queue_depth=20, peak_running=4))
+    assert any(c.signal == "admission_backlog" for c in causes)
+
+
+def test_kv_cache_pressure_cause():
+    causes = scheduler_causes(_summary(peak_gpu_cache_usage=0.98))
+    assert any(c.signal == "kv_cache_pressure" for c in causes)
+
+
+def test_causes_sorted_by_severity_desc():
+    causes = scheduler_causes(
+        _summary(total_preemptions=10, mean_batch_occupancy=0.55,
+                 peak_queue_depth=20, peak_running=4, peak_gpu_cache_usage=0.95)
+    )
+    sevs = [c.severity for c in causes]
+    assert sevs == sorted(sevs, reverse=True)
+    assert len(causes) >= 3
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end: scheduler stats feed attribution + claim evidence (Task 2)      #
+# --------------------------------------------------------------------------- #
+class _ModelCfgBf16:
+    dtype = "torch.bfloat16"
+
+
+class _LowOccScheduler:
+    running = [0, 1]  # 2 running
+    waiting: list = []
+    swapped: list = []
+
+
+class _SchedCfg64:
+    max_num_seqs = 64  # 2/64 occupancy => under-filled-batch cause fires
+
+
+class _FullEngine:
+    """Fake engine exposing scheduler stats AND a hot-swappable max_num_seqs."""
+
+    def __init__(self):
+        self.model_config = _ModelCfgBf16()
+        self.scheduler = [_LowOccScheduler()]
+        self.scheduler_config = _SchedCfg64()
+        self.gitm_throughput_fn = lambda e: float(e.scheduler_config.max_num_seqs)
+
+    def get_num_unfinished_requests(self):
+        return 2
+
+
+def test_run_loop_scheduler_stats_feed_attribution_and_claims(tmp_path, monkeypatch):
+    import json
+    from contextlib import contextmanager
+    from pathlib import Path
+
+    import gitm.scheduler.loop as loop
+    from gitm.scheduler.loop import LoopConfig, run_loop
+
+    from .conftest import make_kernel, make_trace
+
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        kernels = [make_kernel(f"paged_attention_{i % 4}", start_ns=i * 100, end_ns=i * 100 + 80)
+                   for i in range(80)]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    engine = _FullEngine()
+    out = run_loop(LoopConfig(engine=engine, workload="vllm-decode", budget="5s",
+                              scratch=str(tmp_path), top_n_interventions=50))
+
+    run_dir = Path(out["run_dir"])
+    residuals = json.loads((run_dir / "residuals.json").read_text())
+    # The engine signal reached attribution (C): under-filled-batch cause is present.
+    signals = {c["signal"] for c in residuals["scheduler_causes"]}
+    assert "under_filled_batch" in signals
+    # And it reached the claim that it motivates (max_num_seqs), in the report.
+    assert "scheduler[under_filled_batch]" in out["report_md"]
+    # The hot-swap won and was kept.
+    assert engine.scheduler_config.max_num_seqs == 256
+    # Scheduler summary surfaced in the run summary (synchronous first sample).
+    assert out["summary"]["scheduler_stats"] is not None

--- a/tests/test_vllm_knobs_and_restart.py
+++ b/tests/test_vllm_knobs_and_restart.py
@@ -1,5 +1,5 @@
-"""Stream A finishers — knob taxonomy, restart-apply for structural knobs, and
-scheduler-stats causal attribution (the "feeds C" link).
+"""Knob taxonomy, restart-apply for structural knobs, and
+scheduler-stats causal attribution.
 
 No GPU / no vLLM: fake engines stand in. These cover the two pieces that were
 still in progress — #4 (hot-swap vs restart-apply) and #2 (stats → attribution).
@@ -148,7 +148,7 @@ def test_structural_raises_typed_exception_directly():
 
 
 # --------------------------------------------------------------------------- #
-# scheduler-stats causal attribution (feeds C)                                #
+# scheduler-stats causal attribution                                #
 # --------------------------------------------------------------------------- #
 def _summary(**over) -> SchedulerStatsSummary:
     base = dict(
@@ -254,7 +254,7 @@ def test_run_loop_scheduler_stats_feed_attribution_and_claims(tmp_path, monkeypa
 
     run_dir = Path(out["run_dir"])
     residuals = json.loads((run_dir / "residuals.json").read_text())
-    # The engine signal reached attribution (C): under-filled-batch cause is present.
+    # The engine signal reached attribution: under-filled-batch cause is present.
     signals = {c["signal"] for c in residuals["scheduler_causes"]}
     assert "under_filled_batch" in signals
     # And it reached the claim that it motivates (max_num_seqs), in the report.

--- a/tests/test_vllm_stress.py
+++ b/tests/test_vllm_stress.py
@@ -1,0 +1,248 @@
+"""Stress + edge-case coverage for the vLLM embodiment surface.
+
+Pushes the concurrency (sampler thread), the rollback gate across many
+candidates (state must not leak between them), error paths (engines that raise,
+empty/degenerate inputs), and the deviation filter's boundaries.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from gitm.kernels.spec import InterventionSpec
+from gitm.optimizer.apply import LiveEngineApplicator, apply_intervention
+from gitm.optimizer.deviation import deviating_kernel_indices, deviation_summary, deviation_trace
+from gitm.optimizer.scheduler_attribution import scheduler_causes
+from gitm.optimizer.vllm_knobs import get_knob, set_knob
+from gitm.planner.graph import predict_graph
+from gitm.tracer.vllm_stats import SchedulerStatsSampler, read_scheduler_stats, summarize
+
+from .conftest import make_kernel, make_trace
+
+
+def _spec(knob, value):
+    return InterventionSpec.model_validate(
+        dict(name=knob, summary=knob, knob=knob, value=value, expected_delta_mean=0.05,
+             expected_delta_lo=0.0, expected_delta_hi=0.1, source="t")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# applicator state must not leak across candidates (the last_result reset bug) #
+# --------------------------------------------------------------------------- #
+class _SchedCfg:
+    def __init__(self):
+        self.max_num_seqs = 32
+
+
+class _Engine:
+    def __init__(self):
+        self.scheduler_config = _SchedCfg()
+
+
+def test_failed_apply_clears_previous_ab_result():
+    """A structural-knob candidate with no restart hook must not surface the
+    *previous* hot-swap's A/B result (snapshot() resets last_result)."""
+    e = _Engine()
+    app = LiveEngineApplicator(e, throughput_fn=lambda x: float(x.scheduler_config.max_num_seqs))
+
+    r1 = apply_intervention(_spec("max_num_seqs", 256), app, min_keep_delta=0.0)
+    assert r1.applied and app.last_result is not None  # hot-swap measured
+
+    # Next: a structural knob with no restart_fn → apply raises → rolled back,
+    # measure never runs → last_result must be reset to None, not stale.
+    r2 = apply_intervention(_spec("quantization", "awq"), app, min_keep_delta=0.0)
+    assert r2.rolled_back and app.last_result is None
+
+
+def test_many_candidates_restore_is_clean():
+    """Hot-swap → rollback → hot-swap across many candidates leaves the engine at
+    the last *kept* value, never a half-applied state."""
+    e = _Engine()
+    # Throughput rises with the knob, so higher is kept, lower is rolled back.
+    app = LiveEngineApplicator(e, throughput_fn=lambda x: float(x.scheduler_config.max_num_seqs))
+
+    apply_intervention(_spec("max_num_seqs", 256), app, min_keep_delta=0.0)  # 32->256 kept
+    assert e.scheduler_config.max_num_seqs == 256
+    apply_intervention(_spec("max_num_seqs", 64), app, min_keep_delta=0.0)   # 256->64 slower, rolled back
+    assert e.scheduler_config.max_num_seqs == 256  # restored
+    apply_intervention(_spec("max_num_seqs", 512), app, min_keep_delta=0.0)  # 256->512 kept
+    assert e.scheduler_config.max_num_seqs == 512
+
+
+# --------------------------------------------------------------------------- #
+# sampler concurrency + error resilience                                      #
+# --------------------------------------------------------------------------- #
+class _RaisingEngine:
+    @property
+    def scheduler(self):
+        raise RuntimeError("engine busy")
+
+    def get_num_unfinished_requests(self):
+        raise RuntimeError("engine busy")
+
+
+def test_sampler_swallows_engine_exceptions():
+    sampler = SchedulerStatsSampler(_RaisingEngine(), interval_s=0.002)
+    sampler.start()
+    for _ in range(500):
+        pass
+    sampler.stop()  # must not raise
+    # A raising engine yields no usable samples, summary is the empty shape.
+    assert sampler.summary().n_samples == 0
+
+
+def test_sampler_repeated_start_stop_is_safe():
+    class _E:
+        def __init__(self):
+            self.scheduler_config = type("C", (), {"max_num_seqs": 8})()
+            self.scheduler = [type("S", (), {"running": [0], "waiting": [], "swapped": []})()]
+
+        def get_num_unfinished_requests(self):
+            return 1
+
+    sampler = SchedulerStatsSampler(_E(), interval_s=0.001)
+    for _ in range(5):
+        sampler.start()
+        sampler.start()  # idempotent
+        sampler.stop()
+        sampler.stop()  # idempotent
+    assert sampler.summary().n_samples >= 1  # synchronous first read each cycle... at least one
+    assert not any(t.name == "gitm-vllm-stats" and t.is_alive() for t in threading.enumerate())
+
+
+def test_read_scheduler_stats_partial_engine():
+    """An engine exposing only *some* fields yields a partial sample, not None."""
+    class _Partial:
+        scheduler = [type("S", (), {"waiting": [0, 1, 2]})()]  # only waiting, no running/swapped
+    s = read_scheduler_stats(_Partial())
+    assert s is not None and s.num_waiting == 3
+    assert s.num_running is None and s.batch_occupancy is None
+
+
+def test_summarize_single_sample():
+    s = read_scheduler_stats(
+        type("E", (), {"scheduler": [type("S", (), {"running": [0, 1], "waiting": [], "swapped": []})()],
+                       "get_num_unfinished_requests": lambda self: 2})()
+    )
+    summ = summarize([s])
+    assert summ.n_samples == 1 and summ.duration_s == 0.0
+    assert summ.peak_running == 2
+
+
+# --------------------------------------------------------------------------- #
+# scheduler_causes edge cases                                                 #
+# --------------------------------------------------------------------------- #
+def test_scheduler_causes_clamped_severity():
+    from gitm.tracer.vllm_stats import SchedulerStatsSummary
+
+    s = SchedulerStatsSummary(
+        n_samples=5, duration_s=1.0, peak_queue_depth=10_000, mean_running=1.0,
+        peak_running=1, mean_batch_occupancy=0.0, total_preemptions=10_000,
+        peak_gpu_cache_usage=1.0, peak_swapped=0,
+    )
+    causes = scheduler_causes(s)
+    assert causes and all(0.0 <= c.severity <= 1.0 for c in causes)
+
+
+# --------------------------------------------------------------------------- #
+# deviation filter boundaries                                                 #
+# --------------------------------------------------------------------------- #
+def test_deviation_all_in_band_keeps_nothing():
+    graph = predict_graph()
+    # Every observed kernel exactly matches its predicted time => 0 departures.
+    obs = [make_kernel(n.op, start_ns=i * 1000,
+                       end_ns=i * 1000 + max(int(n.prediction.t_pred_s * 1e9), 1))
+           for i, n in enumerate(graph.nodes)]
+    trace = make_trace(events=obs)
+    summ = deviation_summary(trace, graph)
+    assert summ["n_kept"] == 0 and summ["reduction"] == 1.0
+    assert deviation_trace(trace, graph).kernels() == []
+
+
+def test_deviation_empty_trace():
+    graph = predict_graph()
+    summ = deviation_summary(make_trace(events=[]), graph)
+    assert summ["n_observed"] == 0 and summ["reduction"] == 0.0
+
+
+def test_deviation_fewer_obs_than_pred():
+    graph = predict_graph()
+    obs = [make_kernel(graph.nodes[0].op, end_ns=10**9)]  # 1 grossly-slow kernel
+    dev = deviating_kernel_indices(make_trace(events=obs), graph)
+    assert dev.n_observed == 1 and 0 in dev.kept_indices
+
+
+# --------------------------------------------------------------------------- #
+# env-knob restore footgun                                                    #
+# --------------------------------------------------------------------------- #
+def test_admission_backlog_fires_when_nothing_admitted():
+    """peak_running == 0 with a non-empty queue is the worst backlog, not silence."""
+    from gitm.tracer.vllm_stats import SchedulerStatsSummary
+
+    s = SchedulerStatsSummary(
+        n_samples=5, duration_s=1.0, peak_queue_depth=50, mean_running=0.0,
+        peak_running=0, mean_batch_occupancy=0.0, total_preemptions=0,
+        peak_gpu_cache_usage=0.1, peak_swapped=0,
+    )
+    assert any(c.signal == "admission_backlog" for c in scheduler_causes(s))
+
+
+def test_occupancy_clamped_under_multiple_schedulers():
+    """Summed running across schedulers must not push occupancy above 1.0."""
+    class _Sch:
+        def __init__(self, r):
+            self.running = list(range(r))
+            self.waiting: list = []
+            self.swapped: list = []
+
+    class _Cfg:
+        max_num_seqs = 100
+
+    class _E:
+        scheduler = [_Sch(80), _Sch(80)]  # 160 running across 2 schedulers
+        scheduler_config = _Cfg()
+
+    s = read_scheduler_stats(_E())
+    assert s.num_running == 160
+    assert s.batch_occupancy is not None and 0.0 <= s.batch_occupancy <= 1.0
+
+
+def test_measure_rolls_back_on_nonpositive_baseline():
+    """An unmeasurable (zero) baseline must roll the candidate back, not keep it."""
+    class _Idle:
+        scheduler_config = _SchedCfg()
+
+    # Baseline probe returns 0 (idle engine) → measure() raises → rollback.
+    app = LiveEngineApplicator(_Idle(), throughput_fn=lambda e: 0.0)
+    res = apply_intervention(_spec("max_num_seqs", 256), app, min_keep_delta=0.0)
+    assert not res.applied and res.rolled_back
+
+
+def test_deviation_multistep_does_not_keep_everything():
+    """A multi-step decode trace (more kernels than one predicted step) must
+    compare cyclically, not label every post-step-1 kernel as unmodeled."""
+    graph = predict_graph()
+    step = graph.nodes
+    # 3 full decode steps, every kernel exactly on its predicted time => 0 departures.
+    obs = []
+    for s in range(3):
+        for j, n in enumerate(step):
+            k = s * len(step) + j
+            obs.append(make_kernel(n.op, start_ns=k * 1000,
+                                   end_ns=k * 1000 + max(int(n.prediction.t_pred_s * 1e9), 1)))
+    trace = make_trace(events=obs)
+    summ = deviation_summary(trace, graph)
+    assert summ["n_observed"] == 3 * len(step)
+    assert summ["n_kept"] == 0  # cyclic pairing: all in-band across all 3 steps
+    assert "<unpredicted>" not in summ["kept_ops"]
+
+
+def test_env_knob_restore_to_none_unsets(monkeypatch):
+    monkeypatch.delenv("VLLM_ATTENTION_BACKEND", raising=False)
+    set_knob(object(), "VLLM_ATTENTION_BACKEND", "FLASHINFER")
+    assert get_knob(object(), "VLLM_ATTENTION_BACKEND") == "FLASHINFER"
+    # Restoring the original (unset) value must remove the var, not write "None".
+    set_knob(object(), "VLLM_ATTENTION_BACKEND", None)
+    import os
+    assert "VLLM_ATTENTION_BACKEND" not in os.environ


### PR DESCRIPTION
## vLLM embodiment

Wires `vllm-decode` end-to-end through the runtime loop: launch a decode job under the tracer, sample engine scheduler stats, gate + rank the intervention library against the detected hardware, apply candidates through a rollback-gated live A/B, and record only departures from the predicted graph.

### What's included
- `vllm-decode` workload factory — launches decode inside the tracer capture window; CPU-only synthetic stand-in for GPU-less runs.
- Scheduler-stats tracer adapter (queue depth, batch occupancy, preemptions, KV-cache usage) feeding causal attribution.
- Planner gate-context (NVML SKU, dtype, KV-cache bounds) + precondition gate feeding intervention selection.
- Live-engine applicator: hot-swap scheduling knobs / restart-apply structural knobs / restore, gated by a decode-throughput A/B.
- End-to-end wire: runner → tracer → planner → monitor → attribution.
- Deviation-only tracing: record only departures from the predicted graph.

### New modules
`gitm/optimizer/{metrics,preconditions,vllm_knobs,scheduler_attribution,deviation}.py`, `gitm/planner/context.py`, `gitm/tracer/vllm_stats.py`.

### Design notes
- Degrades cleanly with no GPU/vLLM: missing deps → `no_data`, never fabricated results.
- Live A/B keep/rollback verdict comes from the authoritative `ApplyResult`; a non-positive baseline rolls back rather than silently keeping an unmeasurable change.
- Structural knobs with no `gitm_restart_fn` are reported as not-evaluable (rejected), not as a regression.
- Scheduler stats feed causal attribution and link to the specific knobs they motivate.
- Deviation pairing is cyclic (`i % len(pred)`) so multi-step decode traces aren't all labeled "unmodeled".

### Quality
- Code review (4 finder angles) + security review run; all findings fixed. Security review found no exploitable issues (knob names/values come only from the curated in-repo library; trace paths use a server-generated UUID).
- New tests: `tests/test_vllm_embodiment.py`, `test_vllm_knobs_and_restart.py`, `test_vllm_stress.py`. Lint + pytest (3.10/3.11/3.12) green.

### Open items
- `Applicator` interface pending review sign-off.
- Real-GPU / real-vLLM smoke pending hardware. A deployment supplying `gitm_restart_fn` must also supply an engine-aware `gitm_throughput_fn` (documented).
