### PR TITLE
Add applicability gate and unified edge/HFT catalog entries

### DIFF
--- a/gitm/agents/policy.py
+++ b/gitm/agents/policy.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from gitm.kernels.spec import InterventionSpec
+from gitm.optimizer.preconditions import GateContext, applicable
 from gitm.optimizer.replay import predict_delta
 from gitm.tracer.schema import Trace
 
@@ -30,14 +31,20 @@ def select_interventions(
     library: Iterable[InterventionSpec],
     policy: Policy,
     top_n: int = 5,
+    *,
+    ctx: GateContext | None = None,
 ) -> list[RankedCandidate]:
     candidates: list[RankedCandidate] = []
 
     for spec in library:
         reason: str | None = None
-        if policy.skip_high_risk and spec.safety.tier == "high_risk":
+        if ctx is not None:
+            ok, why = applicable(spec, ctx)
+            if not ok:
+                reason = f"not_applicable: {why}"
+        if reason is None and policy.skip_high_risk and spec.safety.tier == "high_risk":
             reason = "policy.skip_high_risk"
-        elif spec.safety.requires_qualification_commit and not policy.require_qualification_commit:
+        elif reason is None and (spec.safety.requires_qualification_commit and not policy.require_qualification_commit):
             reason = "safety.requires_qualification_commit"
         delta = predict_delta(trace, spec) if reason is None else 0.0
         candidates.append(RankedCandidate(spec=spec, predicted_delta=delta, rejected_reason=reason))

--- a/gitm/kernels/library.py
+++ b/gitm/kernels/library.py
@@ -13,7 +13,7 @@ def _library_path() -> Path:
     return Path(__file__).parent / "library.yaml"
 
 
-def load_library(path: Path | str | None = None) -> list[InterventionSpec]:
+def load_library(path: Path | str | None = None, *, workload: str | None = None) -> list[InterventionSpec]:
     """Load and validate every entry in the library."""
     p = Path(path) if path is not None else _library_path()
     if not p.exists():
@@ -21,4 +21,7 @@ def load_library(path: Path | str | None = None) -> list[InterventionSpec]:
     with p.open() as fh:
         raw = yaml.safe_load(fh) or {}
     entries = raw.get("interventions", [])
-    return [InterventionSpec.model_validate(e) for e in entries]
+    specs = [InterventionSpec.model_validate(e) for e in entries]
+    if workload is not None:
+        specs = [s for s in specs if workload in s.applicability.workloads]
+    return specs

--- a/gitm/kernels/library.yaml
+++ b/gitm/kernels/library.yaml
@@ -342,3 +342,60 @@ interventions:
       requires_rollback_window_s: 300
       notes: Execution-backend swap with restart; validate end-to-end before keep.
     review: null
+
+  # unified non vLLM levels 
+  # catalog workloads levels, workload tagged load_library + the gate keep them scoped
+  # the measure delta still comes from each benchmarks A/B
+  - name: edge_fp16_autocast
+    summary: Run PointPillars/CenterPoint inference under fp16 autocast, gated on
+      detection-equivalence (count + sorted scores within tolerance).
+    knob: edge.inference_dtype
+    value: fp16
+    applies_to_kernels: [conv, pointpillars, centerpoint]
+    expected_delta_mean: 0.40
+    expected_delta_lo: 0.00
+    expected_delta_hi: 1.00
+    source: benchmarks/edge/optimize.py (detection-equivalence A/B)
+    applicability:
+      workloads: [edge, kitti, nuscenes]
+    safety:
+      tier: moderate
+      requires_rollback_window_s: 60
+      notes: fp16 can shift detections; keep only if detection-equivalent and faster.
+    review: null
+
+  - name: edge_frame_batching
+    summary: Run inference on batches of frames in one forward pass instead of one
+      frame at a time.
+    knob: edge.batch_size
+    value: 4
+    applies_to_kernels: [conv, pointpillars, centerpoint]
+    expected_delta_mean: 0.30
+    expected_delta_lo: 0.00
+    expected_delta_hi: 2.00
+    source: benchmarks/edge/optimize.py (detection-equivalence A/B)
+    applicability:
+      workloads: [edge, kitti, nuscenes]
+    safety:
+      tier: moderate
+      requires_rollback_window_s: 60
+      notes: Batching changes latency profile; gate on detection-equivalence.
+    review: null
+
+  - name: hft_top_of_book_fewer_scans
+    summary: Carry per-symbol top-of-book in 2 grouped scans instead of 4, gated on
+      byte-identical VWAP/microprice output.
+    knob: hft.top_of_book_grouped_scans
+    value: 2
+    applies_to_kernels: [cudf_groupby_scan, reduce, scan]
+    expected_delta_mean: 0.10
+    expected_delta_lo: 0.00
+    expected_delta_hi: 0.50
+    source: benchmarks/hft/optimize.py (byte-identical A/B)
+    applicability:
+      workloads: [hft, hft-lob]
+    safety:
+      tier: low_risk
+      requires_rollback_window_s: 30
+      notes: Pure reduction in scans; output must be byte-identical to keep.
+    review: null

--- a/gitm/kernels/spec.py
+++ b/gitm/kernels/spec.py
@@ -18,6 +18,9 @@ class Applicability(BaseModel):
     requires_hardware: list[str] | None = None  # e.g. ["A100", "H100"]
     min_kv_cache_len: int | None = None
     max_kv_cache_len: int | None = None
+    min_gpus: int | None = None
+    requires_collective: bool = False
+    requires_interconnect: bool = False
     other: str | None = None  # free-form caveat
 
 

--- a/gitm/optimizer/preconditions.py
+++ b/gitm/optimizer/preconditions.py
@@ -20,7 +20,7 @@ class GateContext:
 
 def applicable(spec: InterventionSpec, ctx: GateContext) -> tuple[bool, str]:
     """Return (True, "") if spec applies to ctx, else (False, reason)
-    
+
     All conditions are and-ed, the first failure short circuits with its reason
     Unset spec conditions are treated as "no constraint"
     """

--- a/gitm/optimizer/preconditions.py
+++ b/gitm/optimizer/preconditions.py
@@ -1,0 +1,66 @@
+"""Binary applicability gate: does this lever apply to this deployment?"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gitm.kernels.spec import InterventionSpec
+
+
+@dataclass(frozen=True)
+class GateContext:
+    workload: str
+    dtype: str | None = None
+    hardware: str | None = None
+    kv_cache_len: int | None = None
+    num_gpus: int = 1
+    has_collective: bool = False
+    has_interconnect: bool = False
+
+
+def applicable(spec: InterventionSpec, ctx: GateContext) -> tuple[bool, str]:
+    """Return (True, "") if spec applies to ctx, else (False, reason)
+    
+    All conditions are and-ed, the first failure short circuits with its reason
+    Unset spec conditions are treated as "no constraint"
+    """
+    app = spec.applicability
+    if ctx.workload not in app.workloads:
+        return False, f"workload {ctx.workload!r} not in {app.workloads}"
+
+    if app.requires_dtype:
+        if ctx.dtype is None:
+            return False, f"Requires dtype in {app.requires_dtype} but run dtype is unknown"
+        if ctx.dtype not in app.requires_dtype:
+            return False, f"dtype {ctx.dtype!r} not in {app.requires_dtype}"
+
+    if app.requires_hardware:
+        hw = (ctx.hardware or "").lower()
+        if not hw:
+            return False, f"Requires hardware in {app.requires_hardware} but SKU is unknown"
+        if not any (req.lower() in hw for req in app.requires_hardware):
+            return False, f"Hardware {ctx.hardware!r} matches none of {app.requires_hardware}"
+
+    if app.min_kv_cache_len is not None:
+        if ctx.kv_cache_len is None:
+            return False, f"Requires kv_cache_len >= {app.min_kv_cache_len} but is unknown"
+        if ctx.kv_cache_len < app.min_kv_cache_len:
+            return False, f"kv_cache_len {ctx.kv_cache_len} < min {app.min_kv_cache_len}"
+
+    if app.max_kv_cache_len is not None and ctx.kv_cache_len is not None:
+        if ctx.kv_cache_len > app.max_kv_cache_len:
+            return False, f"kv_cache_len {ctx.kv_cache_len} > max {app.max_kv_cache_len}"
+
+    # Forward-compatible: honor extended fields (min_gpus, requires_collective,
+    # requires_interconnect) if a later Applicability revision adds them, without
+    # hard-depending on them here.
+
+    min_gpus = getattr(app, "min_gpus", None)
+    if min_gpus is not None and ctx.num_gpus < min_gpus:
+        return False, f"num_gpus {ctx.num_gpus} < min {min_gpus}"
+    if getattr(app, "requires_collective", False) and not ctx.has_collective:
+        return False, "requires a collective (multi-GPU) but run is single-GPU/no-collective"
+    if getattr(app, "requires_interconnect", False) and not ctx.has_interconnect:
+        return False, "requires interconnect (NVLink/IB) but none reported"
+
+    return True, ""

--- a/tests/test_apply_rollback.py
+++ b/tests/test_apply_rollback.py
@@ -129,18 +129,18 @@ def test_apply_from_file_with_config(tmp_path):
     assert yaml.safe_load(target.read_text())["block_size"] == 16
 
 
-# --- library now carries the 18 curated levers ------------------------------
+# --- library now carries the 21 curated levers ------------------------------
 
 
 def test_library_has_18_validated_levers_with_values():
     from gitm.kernels import load_library
 
     specs = load_library()
-    assert len(specs) == 18
+    assert len(specs) == 21
     for s in specs:
         assert s.value is not None, f"{s.name} missing value"
         assert s.expected_delta_lo <= s.expected_delta_mean <= s.expected_delta_hi
-        assert s.source.startswith("http")
+        assert s.source.startswith(("http://", "https://", "benchmarks/"))
 
 
 # --- overhead measurement ---------------------------------------------------

--- a/tests/test_catalog_unify.py
+++ b/tests/test_catalog_unify.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from gitm.kernels.library import load_library
+from gitm.kernels.spec import Applicability, InterventionSpec
+from gitm.optimizer.preconditions import GateContext, applicable
+
+
+def _spec(**app_kw) -> InterventionSpec:
+    return InterventionSpec(
+        name="lever", summary="s", knob="k", value=1,
+        expected_delta_mean=0.05, expected_delta_lo=0.0, expected_delta_hi=0.1,
+        source="t", applicability=Applicability(**app_kw),
+    )
+
+
+def test_min_gpus_gate():
+    spec = _spec(workloads=["vllm-decode"], min_gpus=2)
+    assert not applicable(spec, GateContext(workload="vllm-decode", num_gpus=1))[0]
+    assert applicable(spec, GateContext(workload="vllm-decode", num_gpus=4))[0]
+
+
+def test_requires_collective_and_interconnect():
+    spec = _spec(workloads=["vllm-decode"], requires_collective=True, requires_interconnect=True)
+    ok_ctx = GateContext(workload="vllm-decode", num_gpus=2, has_collective=True,
+                         has_interconnect=True)
+    assert applicable(spec, ok_ctx)[0]
+    no_ic = GateContext(workload="vllm-decode", num_gpus=2, has_collective=True)
+    ok, reason = applicable(spec, no_ic)
+    assert not ok and "interconnect" in reason
+
+
+def test_unified_library_scopes_by_workload():
+    vllm = {s.name for s in load_library(workload="vllm-decode")}
+    edge = {s.name for s in load_library(workload="kitti")}
+    hft = {s.name for s in load_library(workload="hft")}
+
+    assert "edge_fp16_autocast" in edge
+    assert "hft_top_of_book_fewer_scans" in hft
+    # vLLM run must not see edge/hft levers (cross-workload bug stays fixed)
+    assert "edge_fp16_autocast" not in vllm
+    assert "hft_top_of_book_fewer_scans" not in vllm
+    assert any(s.startswith("kv_cache") or "batched_tokens" in s for s in vllm)
+
+
+def test_full_library_loads_and_validates():
+    # every entry (including the new unified ones) validates against the schema
+    specs = load_library()
+    assert len(specs) >= 3
+    names = {s.name for s in specs}
+    assert {"edge_fp16_autocast", "hft_top_of_book_fewer_scans"} <= names

--- a/tests/test_gate_wiring.py
+++ b/tests/test_gate_wiring.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from gitm.agents.policy import Policy, select_interventions
+from gitm.kernels.spec import Applicability, InterventionSpec, SafetyGate
+from gitm.optimizer.preconditions import GateContext
+from gitm.tracer.schema import Trace
+
+
+def _trace() -> Trace:
+    return Trace(
+        workload_id="vllm-decode", fingerprint="fp", run_id="r", device_count=1,
+        vendor="nvidia", captured_at_ns=0, duration_ns=1000, events=[],
+    )
+
+
+def _spec(name, workloads, *, tier="moderate") -> InterventionSpec:
+    return InterventionSpec(
+        name=name, summary="s", knob="k", value=1,
+        expected_delta_mean=0.05, expected_delta_lo=0.0, expected_delta_hi=0.1,
+        source="t", applicability=Applicability(workloads=workloads),
+        safety=SafetyGate(tier=tier),
+    )
+
+
+def test_gate_rejects_cross_workload_lever_first():
+    lib = [_spec("vllm_lever", ["vllm-decode"]), _spec("edge_lever", ["edge"])]
+    ctx = GateContext(workload="vllm-decode", dtype="fp16")
+    ranked = select_interventions(_trace(), lib, Policy(), top_n=5, ctx=ctx)
+
+    by_name = {c.spec.name: c for c in ranked}
+    assert by_name["edge_lever"].rejected_reason.startswith("not_applicable")
+    assert by_name["vllm_lever"].rejected_reason is None
+
+
+def test_without_ctx_no_applicability_filtering():
+    lib = [_spec("edge_lever", ["edge"])]
+    ranked = select_interventions(_trace(), lib, Policy(), top_n=5)
+    # No ctx -> gate skipped; only safety prefilter applies (none here).
+    assert ranked[0].rejected_reason is None
+
+
+def test_load_library_filters_by_workload(tmp_path):
+    import yaml
+
+    from gitm.kernels.library import load_library
+
+    p = tmp_path / "library.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "interventions": [
+                    {**_spec("v", ["vllm-decode"]).model_dump()},
+                    {**_spec("e", ["edge"]).model_dump()},
+                ]
+            }
+        )
+    )
+    assert [s.name for s in load_library(p, workload="vllm-decode")] == ["v"]
+    assert {s.name for s in load_library(p)} == {"v", "e"}  # unfiltered

--- a/tests/test_preconditions.py
+++ b/tests/test_preconditions.py
@@ -1,0 +1,59 @@
+"""Applicability gate: AND of workload/dtype/hardware/kv-cache conditions."""
+
+from __future__ import annotations
+
+from gitm.kernels.spec import Applicability, InterventionSpec
+from gitm.optimizer.preconditions import GateContext, applicable
+
+
+def _spec(**app_kw) -> InterventionSpec:
+    return InterventionSpec(
+        name="lever",
+        summary="test lever",
+        knob="max_num_batched_tokens",
+        value=4096,
+        expected_delta_mean=0.05,
+        expected_delta_lo=0.01,
+        expected_delta_hi=0.09,
+        source="unit-test",
+        applicability=Applicability(**app_kw),
+    )
+
+
+def test_applies_when_all_conditions_met():
+    spec = _spec(
+        workloads=["vllm-decode"], requires_dtype=["fp16"], requires_hardware=["H100"]
+    )
+    ctx = GateContext(workload="vllm-decode", dtype="fp16", hardware="NVIDIA H100 80GB")
+    ok, reason = applicable(spec, ctx)
+    assert ok and reason == ""
+
+
+def test_rejects_wrong_workload():
+    ok, reason = applicable(_spec(workloads=["vllm-decode"]), GateContext(workload="edge"))
+    assert not ok and "workload" in reason
+
+
+def test_rejects_wrong_dtype():
+    spec = _spec(workloads=["vllm-decode"], requires_dtype=["bf16"])
+    ok, reason = applicable(spec, GateContext(workload="vllm-decode", dtype="fp16"))
+    assert not ok and "dtype" in reason
+
+
+def test_rejects_unknown_dtype_when_required():
+    spec = _spec(workloads=["vllm-decode"], requires_dtype=["bf16"])
+    ok, reason = applicable(spec, GateContext(workload="vllm-decode"))
+    assert not ok and "unknown" in reason
+
+
+def test_hardware_substring_match():
+    spec = _spec(workloads=["vllm-decode"], requires_hardware=["A100", "H100"])
+    ok, _ = applicable(spec, GateContext(workload="vllm-decode", hardware="NVIDIA A100-SXM4-40GB"))
+    assert ok
+
+
+def test_kv_cache_bounds():
+    spec = _spec(workloads=["vllm-decode"], min_kv_cache_len=1024, max_kv_cache_len=8192)
+    assert applicable(spec, GateContext(workload="vllm-decode", kv_cache_len=4096))[0]
+    assert not applicable(spec, GateContext(workload="vllm-decode", kv_cache_len=512))[0]
+    assert not applicable(spec, GateContext(workload="vllm-decode", kv_cache_len=9000))[0]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -49,7 +49,7 @@ def test_intervention_library_loads_and_validates():
     assert len(specs) >= 2
     for spec in specs:
         assert spec.expected_delta_lo <= spec.expected_delta_mean <= spec.expected_delta_hi
-        assert spec.source.startswith(("http://", "https://"))
+        assert spec.source.startswith(("http://", "https://", "benchmarks/"))
 
 
 def test_qualification_returns_diagnostic_on_empty_trace():


### PR DESCRIPTION
**Summary:**

- Adds gitm/optimizer/preconditions.py with a GateContext dataclass and applicable() function — a binary AND-gate that short-circuits on the first failed condition across workload, dtype, hardware, kv_cache length, GPU count, collective, and interconnect constraints
- Wires the gate into select_interventions via an optional ctx: GateContext kwarg; without a context the behavior is unchanged, so existing callers are unaffected
- Adds load_library(workload=...) to pre-filter the catalog by workload at load time rather than downstream
- Extends Applicability in spec.py with three new optional fields: min_gpus, requires_collective, requires_interconnect
- Adds 3 new catalog entries to library.yaml scoped to non-vLLM workloads: edge_fp16_autocast, edge_frame_batching (edge/lidar inference), and hft_top_of_book_fewer_scans (HFT LOB)

**Tests:**

- test_preconditions.py — unit tests for each gate condition (workload, dtype, hardware substring match, kv_cache bounds)
- test_gate_wiring.py — verifies gate rejections surface as rejected_reason in select_interventions output
- test_catalog_unify.py — verifies workload scoping via load_library(workload=...) and that new entries pass schema validation
- Updated test_apply_rollback.py and test_smoke.py to reflect the expanded catalog (18 → 21 entries, benchmarks/ allowed as a source prefix)