### PR TITLE
Add stall/idle decomposition from CUPTI gaps to metrics

### DIFF
--- a/gitm/optimizer/metrics.py
+++ b/gitm/optimizer/metrics.py
@@ -6,6 +6,9 @@ captured :class:~gitm.tracer.schema.Trace plus the hardware peaks:
 
 busy_fraction — union of kernel intervals over wall time. Pure-timestamp,
   always available; the complement is GPU-idle/stall.
+stall_breakdown — that GPU-idle complement split by cause (sync-wait,
+  transfer-bound, launch-latency, idle) from overlapping sync/copy events. Pure
+  timestamps; the four fractions sum to ``stall_fraction``.
 HFU (Hardware FLOP Utilization) — achieved FLOP/s ÷ peak FLOP/s. Needs a
   per-kernel FLOP model (passed in); ``None`` without one.
 MFU (Model FLOP Utilization) — HFU with recompute/overhead removed, i.e.
@@ -20,10 +23,10 @@ busy" (high HFU) vs "the GPU is doing useful work" (high MFU) separable.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
-from gitm.tracer.schema import KernelEvent, MemcpyEvent, Trace
+from gitm.tracer.schema import KernelEvent, MemcpyEvent, SyncEvent, Trace
 
 FlopsModel = Callable[[KernelEvent], float]
 
@@ -43,6 +46,7 @@ class MetricsResult:
     wall_s: float
     busy_fraction: float
     stall_fraction: float
+    stall_breakdown: dict[str, float]  # sync_wait/transfer_bound/launch_latency/idle
     achieved_flops_per_s: float | None
     achieved_bw_bytes_s: float
     hfu: float | None
@@ -51,23 +55,86 @@ class MetricsResult:
     recompute_fraction: float
 
 
+# Gaps shorter than this with no overlapping sync or copy are attributed to
+# CPU-side kernel-launch/dispatch latency rather than genuine device idle. ~20 µs
+# comfortably covers CUDA launch/enqueue latency without swallowing real idle
+# stretches; a heuristic, kept as a named knob.
+_LAUNCH_LATENCY_NS = 20_000
+
+
+def _merge_intervals(spans: Iterable[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Merge overlapping [start, end) intervals into a sorted, disjoint list."""
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
 def _merged_busy_ns(kernels: list[KernelEvent]) -> int:
     """Union length of kernel [start, end) intervals across all streams."""
-    spans = sorted((k.start_ns, k.end_ns) for k in kernels)
-    total = 0
-    cur_start: int | None = None
-    cur_end = 0
-    for start, end in spans:
-        if cur_start is None:
-            cur_start, cur_end = start, end
-        elif start <= cur_end:
-            cur_end = max(cur_end, end)
-        else:
-            total += cur_end - cur_start
-            cur_start, cur_end = start, end
-    if cur_start is not None:
-        total += cur_end - cur_start
-    return total
+    return sum(e - s for s, e in _merge_intervals((k.start_ns, k.end_ns) for k in kernels))
+
+
+def _idle_gaps(kernels: list[KernelEvent], duration_ns: int) -> list[tuple[int, int]]:
+    """GPU-idle intervals: complement of merged kernel-busy time in [0, duration).
+
+    Sibling of :func:`_merged_busy_ns` (which returns only the total busy length)
+    — here we keep the gap boundaries so each idle stretch can be attributed to a
+    stall cause. Covers the leading gap before the first kernel, the gaps between
+    kernel clusters, and the trailing gap after the last kernel. Intervals are
+    clipped to ``[0, duration_ns)``.
+    """
+    if duration_ns <= 0:
+        return []
+    gaps: list[tuple[int, int]] = []
+    cursor = 0
+    for start, end in _merge_intervals((k.start_ns, k.end_ns) for k in kernels):
+        s = min(max(start, 0), duration_ns)
+        if s > cursor:
+            gaps.append((cursor, s))
+        cursor = max(cursor, min(max(end, 0), duration_ns))
+        if cursor >= duration_ns:
+            break
+    if cursor < duration_ns:
+        gaps.append((cursor, duration_ns))
+    return gaps
+
+
+def _clip_union_ns(spans: list[tuple[int, int]], lo: int, hi: int) -> int:
+    """Total length of ``spans`` clipped to [lo, hi), overlaps counted once."""
+    clipped = [(max(s, lo), min(e, hi)) for s, e in spans if min(e, hi) > max(s, lo)]
+    return sum(e - s for s, e in _merge_intervals(clipped))
+
+
+def _classify_stalls(
+    gaps: list[tuple[int, int]],
+    memcpys: list[MemcpyEvent],
+    syncs: list[SyncEvent],
+    wall_ns: int,
+) -> dict[str, float]:
+    """Attribute each idle gap to a stall cause, as fractions of wall time.
+
+    Per gap: time overlapped by a memcpy is ``transfer_bound`` (copy engine busy,
+    compute idle); time overlapped by a sync but not a copy is ``sync_wait``; the
+    uncovered remainder is ``launch_latency`` for short gaps (dispatch latency),
+    else ``idle``. The four fractions sum to ``stall_fraction``.
+    """
+    cp = [(e.start_ns, e.end_ns) for e in memcpys]
+    sy = [(e.start_ns, e.end_ns) for e in syncs]
+    ns = {"sync_wait": 0, "transfer_bound": 0, "launch_latency": 0, "idle": 0}
+    for g0, g1 in gaps:
+        transfer = _clip_union_ns(cp, g0, g1)
+        transfer_or_sync = _clip_union_ns(cp + sy, g0, g1)
+        ns["transfer_bound"] += transfer
+        ns["sync_wait"] += transfer_or_sync - transfer  # sync time not already a copy
+        residual = (g1 - g0) - transfer_or_sync
+        ns["launch_latency" if (g1 - g0) <= _LAUNCH_LATENCY_NS else "idle"] += residual
+    if wall_ns <= 0:
+        return {k: 0.0 for k in ns}
+    return {k: v / wall_ns for k, v in ns.items()}
 
 
 def compute_metrics(
@@ -87,8 +154,12 @@ def compute_metrics(
         raise ValueError(f"recompute_fraction must be in [0, 1), got {recompute_fraction}")
 
     kernels = trace.kernels()
+    memcpys = [e for e in trace.events if isinstance(e, MemcpyEvent)]
+    syncs = [e for e in trace.events if isinstance(e, SyncEvent)]
     wall_s = trace.duration_ns / 1e9
     busy_fraction = (_merged_busy_ns(kernels) / trace.duration_ns) if trace.duration_ns else 0.0
+    gaps = _idle_gaps(kernels, trace.duration_ns)
+    stall_breakdown = _classify_stalls(gaps, memcpys, syncs, trace.duration_ns)
 
     achieved_flops: float | None = None
     hfu: float | None = None
@@ -100,7 +171,7 @@ def compute_metrics(
             hfu = achieved_flops / peak.peak_flops
             mfu = hfu * (1.0 - recompute_fraction)
 
-    bytes_moved = sum(e.bytes for e in trace.events if isinstance(e, MemcpyEvent))
+    bytes_moved = sum(e.bytes for e in memcpys)
     for k in kernels:
         bytes_moved += (k.bytes_read or 0) + (k.bytes_written or 0)
     achieved_bw = bytes_moved / wall_s if wall_s else 0.0
@@ -111,6 +182,7 @@ def compute_metrics(
         wall_s=wall_s,
         busy_fraction=busy_fraction,
         stall_fraction=max(0.0, 1.0 - busy_fraction),
+        stall_breakdown=stall_breakdown,
         achieved_flops_per_s=achieved_flops,
         achieved_bw_bytes_s=achieved_bw,
         hfu=hfu,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from gitm.optimizer.metrics import HardwarePeak, compute_metrics
-from gitm.tracer.schema import KernelEvent, MemcpyEvent, Trace
+from gitm.tracer.schema import KernelEvent, MemcpyEvent, SyncEvent, Trace
 
 US = 1000 # ns per microsecond
 PEAK = HardwarePeak(name="TEST", peak_flops=1e14, peak_bw_bytes_s=1e10)
@@ -63,6 +63,43 @@ def test_hfu_none_without_flops_model():
 def test_rejects_bad_recompute_fraction():
     with pytest.raises(ValueError):
         compute_metrics(_trace(), PEAK, recompute_fraction=1.0)
+
+
+def test_stall_breakdown_transfer_and_idle():
+    # _trace() gaps: [50,100]us and [150,200]us; the memcpy [60,65]us sits in the
+    # first gap -> 5us transfer-bound, the remaining 95us of idle is a long stall.
+    m = compute_metrics(_trace(), PEAK)
+    b = m.stall_breakdown
+    assert b["transfer_bound"] == pytest.approx(0.025)  # 5us / 200us
+    assert b["idle"] == pytest.approx(0.475)            # 95us / 200us
+    assert b["sync_wait"] == 0
+    assert b["launch_latency"] == 0
+    # the four causes reconstruct the total stall exactly.
+    assert sum(b.values()) == pytest.approx(m.stall_fraction)
+
+
+def _trace_with_sync() -> Trace:
+    # Two 10us kernels with a 2us gap (launch latency), then a long idle gap
+    # holding a 10us stream sync; 100us wall.
+    return Trace(
+        workload_id="w", fingerprint="fp", run_id="r", device_count=1, vendor="nvidia",
+        captured_at_ns=0, duration_ns=100 * US,
+        events=[
+            KernelEvent(start_ns=0, end_ns=10 * US, stream_id=0, device_id=0, name="k0"),
+            KernelEvent(start_ns=12 * US, end_ns=22 * US, stream_id=0, device_id=0, name="k1"),
+            SyncEvent(start_ns=30 * US, end_ns=40 * US, stream_id=0, device_id=0, sync_kind="stream"),
+        ],
+    )
+
+
+def test_stall_breakdown_sync_and_launch():
+    m = compute_metrics(_trace_with_sync(), PEAK)
+    b = m.stall_breakdown
+    assert b["launch_latency"] == pytest.approx(0.02)  # 2us gap < 20us threshold
+    assert b["sync_wait"] == pytest.approx(0.10)       # 10us sync inside the long gap
+    assert b["idle"] == pytest.approx(0.68)            # remaining 68us of the long gap
+    assert b["transfer_bound"] == 0
+    assert sum(b.values()) == pytest.approx(m.stall_fraction)
 
 
 


### PR DESCRIPTION
Decompose the single GPU-idle `stall_fraction` into causes attributed from the trace timeline:

- `_idle_gaps`: sibling of `_merged_busy_ns` returning the GPU-idle intervals (complement of merged kernel-busy time), so each gap can be classified.
- `_classify_stalls`: per gap, time overlapped by a memcpy is `transfer_bound`, time overlapped by a sync (not already a copy) is `sync_wait`, short unexplained gaps are `launch_latency`, the rest is `idle`. The four buckets are non-overlapping and sum to `stall_fraction`.
- New `MetricsResult.stall_breakdown: dict[str, float]`.

Event-backed causes (transfer/sync) are claimed first; the residual falls to a 20us launch-latency heuristic and an honest `idle` catch-all. headroom.py is left untouched; rewiring its faked gap split to consume `stall_breakdown` is a follow-up.