### PR TITLE
Replaced single lumped idle stall in build_headroom 

### DIFF
--- a/gitm/optimizer/headroom.py
+++ b/gitm/optimizer/headroom.py
@@ -5,8 +5,9 @@ weights, or data access. For each run it answers three things:
 
 ceiling distance — the recoverable fraction between observed wall time and
   the predicted roofline floor (0 = already at the floor);
-gap by stall class — that recoverable fraction split across idle/stall,
-  memory-bound, and compute-bound, from the metrics module;
+gap by stall class — that recoverable fraction split across the idle causes
+  (sync-wait, transfer-bound, launch-latency, idle) plus memory-bound and
+  compute-bound, from the metrics module;
 already-optimized flag — set when the distance is within a small threshold,
   so we never bill for headroom that isn't there.
 
@@ -56,16 +57,17 @@ def build_headroom(
         ceiling_distance = 0.0
     already_optimized = ceiling_distance < optimized_threshold
 
-    # Split the recoverable distance across stall classes. Idle is the GPU-idle
-    # fraction; the busy remainder is attributed memory- vs compute-bound by which
-    # utilization dominates (MBU vs HFU). Shares scale to the ceiling distance.
-    idle = metrics.stall_fraction
+    # Split the recoverable distance across stall classes. The idle side comes
+    # straight from the metrics stall breakdown (sync_wait/transfer_bound/
+    # launch_latency/idle, which sum to stall_fraction); the busy remainder is
+    # attributed memory- vs compute-bound by which utilization dominates (MBU vs
+    # HFU). Shares scale to the ceiling distance.
     hfu = metrics.hfu or 0.0
     denom = metrics.mbu + hfu
     mem_share = (metrics.mbu / denom) if denom > 0 else 0.5
-    busy = max(0.0, 1.0 - idle)
+    busy = max(0.0, 1.0 - metrics.stall_fraction)
     shares = {
-        "idle_stall": idle,
+        **metrics.stall_breakdown,
         "memory_bound": busy * mem_share,
         "compute_bound": busy * (1.0 - mem_share),
     }

--- a/tests/test_headroom.py
+++ b/tests/test_headroom.py
@@ -35,7 +35,11 @@ def test_ceiling_distance_and_gap_split():
     assert not r.already_optimized
     # gap classes sum to the ceiling distance
     assert sum(r.gap_by_stall_class.values()) == pytest.approx(0.5, abs=1e-3)
-    assert set(r.gap_by_stall_class) == {"idle_stall", "memory_bound", "compute_bound"}
+    # idle side now comes from the real stall breakdown, not one lumped "idle_stall".
+    assert set(r.gap_by_stall_class) == {
+        "sync_wait", "transfer_bound", "launch_latency", "idle",
+        "memory_bound", "compute_bound",
+    }
 
 
 def test_already_optimized_flag_when_near_floor():


### PR DESCRIPTION
build_headroom split its recoverable gap using a single lumped `idle_stall` plus an MBU/HFU guess. Replace the idle lump with the real `metrics.stall_breakdown` (sync_wait/transfer_bound/launch_latency/idle), keeping memory_bound/compute_bound for the busy side. The classes still partition the gap and sum to the ceiling distance; structure and scaling unchanged.

Depends on the stall_breakdown field (task3-stall-decomposition).