### PR TITLE
fix(vllm-decode): wire live A/B measurement + predict against the rea…

### DIFF
--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -142,6 +142,55 @@ class LoopConfig:
     workload_runner: WorkloadRunner | None = None
 
 
+def _model_spec_from_engine(engine: Any):
+    """Build a ``ModelSpec`` from a live vLLM engine's HF config, or ``None``.
+
+    ``predict_graph()`` with no model defaults to Llama-2-7B (32 layers). A run
+    of a *different* model (e.g. opt-125m, 12 layers) is then scored against the
+    wrong predicted graph, which makes residuals and deviation meaningless. When
+    the loop has the live engine, read the real architecture off its HF config so
+    the predicted graph matches the model that actually ran. Duck-typed across
+    vLLM version drift; any failure returns ``None`` and the caller falls back to
+    the default graph rather than crashing.
+    """
+    if engine is None:
+        return None
+    hf: Any = None
+    for path in (
+        "llm_engine.model_config.hf_config",
+        "llm_engine.vllm_config.model_config.hf_config",
+        "model_config.hf_config",
+    ):
+        obj: Any = engine
+        for attr in path.split("."):
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if obj is not None:
+            hf = obj
+            break
+    if hf is None:
+        return None
+    try:
+        from gitm.planner.roofline import ModelSpec
+
+        hidden = int(getattr(hf, "hidden_size"))
+        n_heads = int(getattr(hf, "num_attention_heads"))
+        n_kv = int(getattr(hf, "num_key_value_heads", n_heads) or n_heads)
+        head_dim = int(getattr(hf, "head_dim", 0) or (hidden // n_heads))
+        return ModelSpec(
+            hidden=hidden,
+            n_layers=int(getattr(hf, "num_hidden_layers")),
+            n_heads=n_heads,
+            num_kv_heads=n_kv,
+            head_dim=head_dim,
+            intermediate=int(getattr(hf, "intermediate_size", 4 * hidden)),
+            vocab=int(getattr(hf, "vocab_size")),
+        )
+    except Exception:
+        return None
+
+
 def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     """Execute the 24-hour loop and return ``{summary, report_md, ...}``."""
     workload = cfg.workload or (getattr(cfg.engine, "workload_id", None) or "vllm-decode")
@@ -169,6 +218,14 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
                 runner_error = f"workload runner unavailable for {workload!r}: {exc}"
         else:
             runner_error = f"no workload runner registered for {workload!r}"
+
+    # If the workload built a live engine (e.g. vLLM), expose it so the
+    # scheduler-stats sampler AND the Phase-4 live A/B can drive it. The runner
+    # carries it as ``.engine`` (see the vllm-decode factory). Without this the
+    # loop stays predict-only (DryRunApplicator, live=False) — the engine is
+    # built but never handed to the applicator.
+    if cfg.engine is None and runner is not None:
+        cfg.engine = getattr(runner, "engine", None)
 
     # Sample the engine scheduler (queue depth, batch occupancy, preemptions)
     # over the same window as the CUPTI capture — engine-level telemetry the GPU
@@ -297,7 +354,12 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
             trace_path=trace_path,
         )
 
-    graph = predict_graph()
+    # Predict against the model that ACTUALLY ran (read from the live engine),
+    # not the Llama-2-7B default — otherwise residuals/deviation score the real
+    # kernels against the wrong graph. Falls back to the default graph when there
+    # is no engine or its config can't be read (CPU boxes, tests, dry-run).
+    _spec = _model_spec_from_engine(cfg.engine)
+    graph = predict_graph(model=_spec) if _spec is not None else predict_graph()
     (run_dir / "predicted_graph.json").write_text(
         json.dumps({"nodes": len(graph.nodes), "total_pred_s": graph.total_pred_s}, indent=2)
     )

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -174,18 +174,18 @@ def _model_spec_from_engine(engine: Any):
     try:
         from gitm.planner.roofline import ModelSpec
 
-        hidden = int(getattr(hf, "hidden_size"))
-        n_heads = int(getattr(hf, "num_attention_heads"))
+        hidden = int(hf.hidden_size)
+        n_heads = int(hf.num_attention_heads)
         n_kv = int(getattr(hf, "num_key_value_heads", n_heads) or n_heads)
         head_dim = int(getattr(hf, "head_dim", 0) or (hidden // n_heads))
         return ModelSpec(
             hidden=hidden,
-            n_layers=int(getattr(hf, "num_hidden_layers")),
+            n_layers=int(hf.num_hidden_layers),
             n_heads=n_heads,
             num_kv_heads=n_kv,
             head_dim=head_dim,
             intermediate=int(getattr(hf, "intermediate_size", 4 * hidden)),
-            vocab=int(getattr(hf, "vocab_size")),
+            vocab=int(hf.vocab_size),
         )
     except Exception:
         return None

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -569,6 +569,14 @@ def _vllm_decode_factory(cfg: LoopConfig) -> WorkloadRunner:
         produced = sum(len(o.outputs[0].token_ids) for o in outputs)
         sync_device()
         return {"prompts": len(prompts), "generated_tokens": produced, "model": model}
+
+    # Expose the live engine so the loop can (a) sample its scheduler stats and
+    # (b) run the Phase-4 decode-throughput A/B on it (LiveEngineApplicator).
+    # Without this the engine is built but never handed to the loop, so every
+    # run is predict-only (live=False). ``run.engine`` mirrors the ``.applicator``
+    # convention the hft/edge/openfold factories already use.
+    run.engine = llm
+    run.workload_id = "vllm-decode"
     return run
 
 def _vllm_synthetic_runner(n_prompts: int, max_tokens: int) -> WorkloadRunner:

--- a/tests/test_predict_graph_from_engine.py
+++ b/tests/test_predict_graph_from_engine.py
@@ -1,0 +1,66 @@
+"""The predicted graph must match the model that actually ran.
+
+`predict_graph()` defaults to Llama-2-7B (32 layers). When the loop has a live
+engine, `_model_spec_from_engine` reads the real architecture off its HF config
+so residuals/deviation score against the right model. These tests use a fake
+duck-typed engine (no vLLM/GPU) to pin the config-reading + fallback behavior.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gitm.planner.graph import predict_graph
+from gitm.scheduler.loop import _model_spec_from_engine
+
+
+def _fake_engine(**hf_fields):
+    """A stand-in vLLM engine exposing ``llm_engine.model_config.hf_config``."""
+    hf = SimpleNamespace(**hf_fields)
+    return SimpleNamespace(llm_engine=SimpleNamespace(model_config=SimpleNamespace(hf_config=hf)))
+
+
+# opt-125m: 12 layers, hidden 768, 12 heads (MHA, no GQA), intermediate 3072.
+_OPT_125M = dict(
+    num_hidden_layers=12,
+    hidden_size=768,
+    num_attention_heads=12,
+    intermediate_size=3072,
+    vocab_size=50272,
+)
+
+
+def test_reads_real_model_arch_from_engine():
+    spec = _model_spec_from_engine(_fake_engine(**_OPT_125M))
+    assert spec is not None
+    assert spec.n_layers == 12
+    assert spec.hidden == 768
+    assert spec.n_heads == 12
+    assert spec.num_kv_heads == 12  # no num_key_value_heads -> falls back to n_heads
+    assert spec.head_dim == 64  # 768 / 12
+    assert spec.intermediate == 3072
+    assert spec.vocab == 50272
+
+
+def test_predicted_graph_matches_the_real_model_not_llama():
+    """opt-125m -> 12*5+1 = 61 nodes, not the 32*5+1 = 161 Llama default."""
+    spec = _model_spec_from_engine(_fake_engine(**_OPT_125M))
+    assert len(predict_graph(model=spec).nodes) == 61
+    assert len(predict_graph().nodes) == 161  # default is still Llama-7B
+
+
+def test_gqa_uses_num_key_value_heads_when_present():
+    spec = _model_spec_from_engine(
+        _fake_engine(**{**_OPT_125M, "num_key_value_heads": 4})
+    )
+    assert spec is not None
+    assert spec.num_kv_heads == 4
+
+
+def test_falls_back_to_none_when_no_engine_or_config():
+    # No engine at all -> None (loop then uses the default graph).
+    assert _model_spec_from_engine(None) is None
+    # An engine with no readable HF config -> None, never a crash.
+    assert _model_spec_from_engine(SimpleNamespace(nope=1)) is None
+    # A config missing required fields -> None (the int() raises, caught).
+    assert _model_spec_from_engine(_fake_engine(hidden_size=768)) is None


### PR DESCRIPTION
…l model

Two root fixes for the vllm-decode loop, both verified off-GPU:

1. Live measurement (predict -> prove). The vllm-decode factory built the engine as a local and never exposed it, so cfg.engine stayed None and Phase 4 always fell to DryRunApplicator (live=False, measured_delta empty). Now the factory sets run.engine, and the loop picks it up before the capture window, so the scheduler-stats sampler AND the Phase-4 LiveEngineApplicator drive the real engine -> measured decode-throughput deltas on the scheduling knobs.

2. Predicted graph matches the model that ran. predict_graph() was called with no args -> Llama-2-7B default (32 layers, 161 nodes), so opt-125m's real kernels were scored against the wrong graph (why deviation flagged 95.5% and the residual was hardcoded 0.0). _model_spec_from_engine reads the real arch off the live engine's HF config; falls back to the default graph when no engine/config (CPU, tests, dry-run) so behavior is unchanged there.

Adds tests/test_predict_graph_from_engine.py (fake duck-typed engine, no GPU). Not yet validated on a GPU: whether vLLM honors live scheduling-knob swaps, and the exact HF-config attribute path on this vLLM version (guarded, falls back).