### PR TITLE
Support vLLM V1 scheduler stats in read_scheduler_stats

### DIFF
--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -90,11 +90,50 @@ def _len_or_none(x: Any) -> int | None:
 def _schedulers(engine: Any) -> list[Any]:
     """Resolve the engine's scheduler(s) as a list (vLLM may keep one per PP stage)."""
     sched = _first_attr(
-        engine, "scheduler", "engine.scheduler", "llm_engine.scheduler"
+        engine,
+        # vLLM V0.
+        "scheduler",
+        "engine.scheduler",
+        "llm_engine.scheduler",
+        # vLLM V1 (in-process, VLLM_ENABLE_V1_MULTIPROCESSING=0): the scheduler
+        # lives inside the EngineCore, not on the LLMEngine. Paths vary across
+        # v0.2x point releases — GPU-validate the exact one on the target build.
+        "llm_engine.engine_core.engine_core.scheduler",
+        "llm_engine.engine_core.scheduler",
+        "engine_core.engine_core.scheduler",
+        "engine_core.scheduler",
     )
     if sched is None:
         return []
     return list(sched) if isinstance(sched, list | tuple) else [sched]
+
+
+def _v1_scheduler_stats(scheduler: Any) -> dict[str, Any]:
+    """vLLM V1 stats via ``scheduler.make_stats()`` — V1 doesn't keep the V0
+    running/waiting deques in the same shape, but exposes a stats object with
+    ``num_running_reqs`` / ``num_waiting_reqs`` / ``kv_cache_usage``. Best-effort;
+    returns only the fields it actually found. GPU-validate the attr names on the
+    target vLLM build (they've shifted across v0.2x).
+    """
+    make = getattr(scheduler, "make_stats", None)
+    if not callable(make):
+        return {}
+    try:
+        stats = make()
+    except Exception:
+        return {}
+    if stats is None:
+        return {}
+    out: dict[str, Any] = {}
+    for field_name, attr in (("num_running", "num_running_reqs"),
+                             ("num_waiting", "num_waiting_reqs")):
+        v = getattr(stats, attr, None)
+        if isinstance(v, int):
+            out[field_name] = v
+    ku = getattr(stats, "kv_cache_usage", None)
+    if isinstance(ku, int | float):
+        out["gpu_cache_usage"] = float(ku)
+    return out
 
 
 def _max_num_seqs(engine: Any) -> int | None:
@@ -142,11 +181,19 @@ def read_scheduler_stats(engine: Any, *, t_ns: int = 0) -> SchedulerSample | Non
             setattr(sample, field_name, val)
             saw_any = True
 
-        # KV-cache usage off the first scheduler's block manager (best-effort).
+        # KV-cache usage off the first scheduler's block manager (best-effort, V0).
         usage = _gpu_cache_usage(schedulers[0])
         if usage is not None:
             sample.gpu_cache_usage = usage
             saw_any = True
+            
+        # vLLM V1: fill running / waiting / cache from the scheduler's stat object
+        # where the VO deques weren't exposed (they read empty on V1)
+        for sch in schedulers:
+            for field_name, val in _v1_scheduler_stats(sch).items():
+                if getattr(sample, field_name) is None:
+                    setattr(sample, field_name, val)
+                    saw_any = True
 
     # Total unfinished — a stable public method on LLMEngine across versions.
     getter = _first_attr(

--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -186,7 +186,7 @@ def read_scheduler_stats(engine: Any, *, t_ns: int = 0) -> SchedulerSample | Non
         if usage is not None:
             sample.gpu_cache_usage = usage
             saw_any = True
-            
+
         # vLLM V1: fill running / waiting / cache from the scheduler's stat object
         # where the VO deques weren't exposed (they read empty on V1)
         for sch in schedulers:

--- a/tests/test_vllm_stats_v1.py
+++ b/tests/test_vllm_stats_v1.py
@@ -1,0 +1,50 @@
+"""Read scheduler stats from a vLLM V1-shaped engine.
+
+V1 keeps the scheduler inside EngineCore and exposes a stats object via
+make_stats() (num_running_reqs / num_waiting_reqs / kv_cache_usage) instead of
+the V0 running/waiting deques. Fake that shape to pin the read path off-GPU; the
+exact attr names still need GPU validation on the target vLLM build.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gitm.tracer.vllm_stats import read_scheduler_stats
+
+
+def _v1_engine(running: int, waiting: int, cache: float, max_seqs: int = 256):
+    stats = SimpleNamespace(
+        num_running_reqs=running, num_waiting_reqs=waiting, kv_cache_usage=cache
+    )
+    scheduler = SimpleNamespace(make_stats=lambda: stats)
+    # llm.llm_engine.engine_core.engine_core.scheduler (in-process V1)
+    return SimpleNamespace(
+        llm_engine=SimpleNamespace(
+            engine_core=SimpleNamespace(engine_core=SimpleNamespace(scheduler=scheduler))
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=max_seqs),
+    )
+
+
+def test_reads_v1_stats_object():
+    s = read_scheduler_stats(_v1_engine(running=3, waiting=12, cache=0.87), t_ns=0)
+    assert s is not None
+    assert s.num_running == 3
+    assert s.num_waiting == 12
+    assert s.gpu_cache_usage == 0.87
+    assert s.batch_occupancy == 3 / 256  # occupancy derived from V1 num_running
+
+
+def test_none_engine_still_none():
+    assert read_scheduler_stats(None) is None
+
+
+def test_v1_engine_without_stats_is_none():
+    # a V1-shaped engine whose scheduler exposes nothing readable -> None, no crash.
+    empty = SimpleNamespace(
+        llm_engine=SimpleNamespace(
+            engine_core=SimpleNamespace(engine_core=SimpleNamespace(scheduler=object()))
+        )
+    )
+    assert read_scheduler_stats(empty) is None


### PR DESCRIPTION
## Summary
- vLLM V1 moves the scheduler off `LLMEngine` and onto `EngineCore`, so
  `_schedulers()` now resolves the additional V1 attribute paths
  (`llm_engine.engine_core.engine_core.scheduler`, etc.) alongside the
  existing V0 ones.
- V1 doesn't expose the V0 running/waiting deques or block-manager cache
  usage in the same shape, so add `_v1_scheduler_stats()`, which calls the
  scheduler's `make_stats()` and best-effort maps `num_running_reqs` /
  `num_waiting_reqs` / `kv_cache_usage` onto the sample, filling only
  fields the V0 path didn't already populate.
- Added tests/test_vllm_stats_v1.py, pinning the read path off-GPU against
  a faked V1 engine shape (running/waiting/cache populated, occupancy
  derived correctly, and a scheduler with no readable stats returns None
  instead of crashing).

## Test plan
- [x] `python -m pytest tests/test_vllm_stats_v1.py -v` (3 passed)
- [ ] GPU-validate the V1 attribute paths and `make_stats()` field names
      against the target vLLM build — noted as best-effort/unverified in
      code comments since this was written off-GPU.