### PR TITLE
fix(loop): actually consume a runner's self-reported workload_id

### DIFF
--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -245,7 +245,11 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     # "vllm-decode" default regardless of what the runner actually is). Only
     # the runner's own object carries this — earlier ``cfg.engine`` is never
     # populated yet — so it must be re-checked here, after resolution, not
-    # folded into the guess above.
+    # folded into the guess above. NOTE: ``cfg.workload`` (the field) is never
+    # reassigned anywhere in this function — it stays the caller's original
+    # input for the whole call, unlike the local ``workload`` var below it,
+    # which this line progressively resolves. So this is an unambiguous
+    # "did the caller pin one explicitly" check, not a proxy for it.
     if cfg.workload is None and runner is not None:
         workload = getattr(runner, "workload_id", None) or workload
 

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -239,6 +239,16 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     if cfg.engine is None and runner is not None:
         cfg.engine = getattr(runner, "engine", None)
 
+    # A factory-built runner may know its own workload id better than the
+    # guessed/default one above (e.g. a caller passed ``workload_runner``
+    # directly with no ``cfg.workload``, so ``workload`` fell through to the
+    # "vllm-decode" default regardless of what the runner actually is). Only
+    # the runner's own object carries this — earlier ``cfg.engine`` is never
+    # populated yet — so it must be re-checked here, after resolution, not
+    # folded into the guess above.
+    if cfg.workload is None and runner is not None:
+        workload = getattr(runner, "workload_id", None) or workload
+
     # Sample the engine scheduler (queue depth, batch occupancy, preemptions)
     # over the same window as the CUPTI capture — engine-level telemetry the GPU
     # trace can't see. A no-op when no engine is attached (empty series).

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -242,14 +242,20 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     # A factory-built runner may know its own workload id better than the
     # guessed/default one above (e.g. a caller passed ``workload_runner``
     # directly with no ``cfg.workload``, so ``workload`` fell through to the
-    # "vllm-decode" default regardless of what the runner actually is). Only
-    # the runner's own object carries this — earlier ``cfg.engine`` is never
-    # populated yet — so it must be re-checked here, after resolution, not
-    # folded into the guess above. NOTE: ``cfg.workload`` (the field) is never
-    # reassigned anywhere in this function — it stays the caller's original
-    # input for the whole call, unlike the local ``workload`` var below it,
-    # which this line progressively resolves. So this is an unambiguous
-    # "did the caller pin one explicitly" check, not a proxy for it.
+    # "vllm-decode" default regardless of what the runner actually is). It
+    # must be re-checked here, after the runner is resolved, not folded into
+    # the initial guess a few lines up — at that point neither the runner nor
+    # ``cfg.engine`` (populated from it just above) exist yet.
+    #
+    # ``cfg.workload`` (the field) is never reassigned anywhere in this
+    # function — it stays exactly the caller's original input for the whole
+    # call, unlike the local ``workload`` var this line progressively
+    # resolves. So this is an unambiguous "did the caller pin one explicitly"
+    # check, not a proxy for it. Deliberately not falling back to
+    # ``cfg.engine.workload_id`` here too: no current runner sets both an
+    # engine and a top-level workload_id, so there's no real precedence
+    # question yet — the runner's own attribute is preferred as the most
+    # specific source when it exists.
     if cfg.workload is None and runner is not None:
         workload = getattr(runner, "workload_id", None) or workload
 

--- a/tests/test_run_loop_workload.py
+++ b/tests/test_run_loop_workload.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 
+import pytest
+
 from .conftest import make_kernel, make_trace
 
 # Digest of an empty kernel list — sha256(repr([]))[:16]. A real trace must not
@@ -51,9 +53,15 @@ class _Runner:
         return {"events": 1}
 
 
-def _capturing_fake_capture(captured: dict):
-    """A fake ``capture()`` that records the ``workload_id`` it was called
-    with, shared by the workload_id-relabeling tests below."""
+@pytest.fixture
+def captured_workload_id(monkeypatch):
+    """Patches ``capture``/``sync_device`` so ``run_loop`` runs without a real
+    GPU, and returns the dict that the ``workload_id`` it was called with
+    lands in. Shared by every workload_id-relabeling test below to avoid
+    repeating the same three-line monkeypatch setup six times."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
 
     @contextmanager
     def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
@@ -61,10 +69,12 @@ def _capturing_fake_capture(captured: dict):
         kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
         yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
 
-    return fake_capture
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+    return captured
 
 
-def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path: Path, monkeypatch):
+def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path, captured_workload_id):
     """A factory-built runner's own ``workload_id`` (e.g. set by
     ``_vllm_decode_factory``, see #60) must relabel the trace/capture call
     instead of being silently discarded.
@@ -76,27 +86,15 @@ def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path: Path, m
     ``workload_runner`` with no explicit ``cfg.workload`` always fell back to
     the hardcoded "vllm-decode" default regardless of what it actually was.
     """
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner("custom-workload"))
 
-    assert captured["workload_id"] == "custom-workload"
+    assert captured_workload_id["workload_id"] == "custom-workload"
 
 
-def test_runner_workload_id_does_not_override_explicit_workload(tmp_path: Path, monkeypatch):
+def test_runner_workload_id_does_not_override_explicit_workload(tmp_path, captured_workload_id):
     """An explicit ``cfg.workload`` always wins over the runner's self-reported id."""
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-
     from gitm import optimize
 
     optimize(
@@ -104,82 +102,57 @@ def test_runner_workload_id_does_not_override_explicit_workload(tmp_path: Path, 
         workload_runner=_Runner("custom-workload"),
     )
 
-    assert captured["workload_id"] == "hft"
+    assert captured_workload_id["workload_id"] == "hft"
 
 
-def test_runner_workload_id_none_falls_back_to_default(tmp_path: Path, monkeypatch):
+def test_runner_workload_id_none_falls_back_to_default(tmp_path, captured_workload_id):
     """A factory that didn't populate ``workload_id`` (explicit ``None``, a
     plausible real-world state) falls back to the guessed/default label
     rather than relabeling to "None"."""
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner(None))
 
-    assert captured["workload_id"] == "vllm-decode"
+    assert captured_workload_id["workload_id"] == "vllm-decode"
 
 
-def test_runner_without_workload_id_attribute_falls_back_to_default(
-    tmp_path: Path, monkeypatch
-):
+def test_runner_without_workload_id_attribute_falls_back_to_default(tmp_path, captured_workload_id):
     """A plain runner with no ``workload_id`` attribute at all (the common case
     for a directly-passed callable, not a registry factory) exercises the
     ``getattr(..., "workload_id", None)`` default path, not just the explicit
     ``None`` case above."""
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner())
 
-    assert captured["workload_id"] == "vllm-decode"
+    assert captured_workload_id["workload_id"] == "vllm-decode"
 
 
-def test_runner_workload_id_empty_string_falls_back_to_default(tmp_path: Path, monkeypatch):
+def test_runner_workload_id_empty_string_falls_back_to_default(tmp_path, captured_workload_id):
     """An empty-string ``workload_id`` is treated the same as unset/None, not
     as a real (if unusual) label — ``getattr(...) or workload`` falls back on
     any falsy value, by design, not just ``None``. Documented explicitly here
     since it's a plausible footgun otherwise."""
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner(""))
 
-    assert captured["workload_id"] == "vllm-decode"
+    assert captured_workload_id["workload_id"] == "vllm-decode"
 
 
-def test_no_runner_and_no_explicit_workload_uses_default(tmp_path: Path, monkeypatch):
+def test_no_runner_and_no_explicit_workload_uses_default(tmp_path, captured_workload_id):
     """With nothing to read from at all (no runner, no cfg.workload, no
     cfg.engine), the simplest path still resolves to the hardcoded default —
-    the relabeling guard must not require a runner to be present."""
-    import gitm.scheduler.loop as loop
-
-    captured: dict = {}
-    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
-    monkeypatch.setattr(loop, "sync_device", lambda: None)
-    # No registered factory for "vllm-decode" resolves a runner in this test
-    # environment (no vLLM installed), so runner stays None throughout.
-    monkeypatch.setattr(loop, "get_factory", lambda _workload: None)
-
+    the relabeling guard must not require a runner to be present. Relies on
+    the same "no vLLM installed" test-environment fact
+    ``test_no_data_guard_does_not_fabricate_claims`` already depends on
+    (rather than monkeypatching ``get_factory``, which would silently stop
+    exercising this path if the lookup ever moved or gained a second site)."""
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path))
 
-    assert captured["workload_id"] == "vllm-decode"
+    assert captured_workload_id["workload_id"] == "vllm-decode"
 
 
 def test_runner_runs_inside_capture_and_produces_real_trace(tmp_path: Path, monkeypatch):

--- a/tests/test_run_loop_workload.py
+++ b/tests/test_run_loop_workload.py
@@ -32,6 +32,35 @@ def test_no_data_guard_does_not_fabricate_claims(tmp_path: Path):
     assert "NO DATA" in result["report_md"]
 
 
+class _Runner:
+    """A minimal workload_runner double — explicit about whether/what
+    ``workload_id`` it carries, instead of monkey-patching a plain function
+    (which silently loses the attribute if ever wrapped, e.g. functools.partial)."""
+
+    def __init__(self, workload_id: object = "unset") -> None:
+        # "unset" (the sentinel) means: don't set the attribute at all, so
+        # getattr(..., "workload_id", None) exercises its own default path
+        # rather than reading an attribute that happens to be None.
+        if workload_id != "unset":
+            self.workload_id = workload_id
+
+    def __call__(self) -> dict:
+        return {"events": 1}
+
+
+def _capturing_fake_capture(captured: dict):
+    """A fake ``capture()`` that records the ``workload_id`` it was called
+    with, shared by the workload_id-relabeling tests below."""
+
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        captured["workload_id"] = workload_id
+        kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    return fake_capture
+
+
 def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path: Path, monkeypatch):
     """A factory-built runner's own ``workload_id`` (e.g. set by
     ``_vllm_decode_factory``, see #60) must relabel the trace/capture call
@@ -47,24 +76,12 @@ def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path: Path, m
     import gitm.scheduler.loop as loop
 
     captured: dict = {}
-
-    @contextmanager
-    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
-        captured["workload_id"] = workload_id
-        kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
-        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
-
-    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
     monkeypatch.setattr(loop, "sync_device", lambda: None)
-
-    def runner():
-        return {"events": 1}
-
-    runner.workload_id = "custom-workload"
 
     from gitm import optimize
 
-    optimize(budget="1s", scratch=str(tmp_path), workload_runner=runner)
+    optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner("custom-workload"))
 
     assert captured["workload_id"] == "custom-workload"
 
@@ -74,26 +91,54 @@ def test_runner_workload_id_does_not_override_explicit_workload(tmp_path: Path, 
     import gitm.scheduler.loop as loop
 
     captured: dict = {}
-
-    @contextmanager
-    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
-        captured["workload_id"] = workload_id
-        kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
-        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
-
-    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
     monkeypatch.setattr(loop, "sync_device", lambda: None)
-
-    def runner():
-        return {"events": 1}
-
-    runner.workload_id = "custom-workload"
 
     from gitm import optimize
 
-    optimize(workload="hft", budget="1s", scratch=str(tmp_path), workload_runner=runner)
+    optimize(
+        workload="hft", budget="1s", scratch=str(tmp_path),
+        workload_runner=_Runner("custom-workload"),
+    )
 
     assert captured["workload_id"] == "hft"
+
+
+def test_runner_workload_id_none_falls_back_to_default(tmp_path: Path, monkeypatch):
+    """A factory that didn't populate ``workload_id`` (explicit ``None``, a
+    plausible real-world state) falls back to the guessed/default label
+    rather than relabeling to "None"."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    from gitm import optimize
+
+    optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner(None))
+
+    assert captured["workload_id"] == "vllm-decode"
+
+
+def test_runner_without_workload_id_attribute_falls_back_to_default(
+    tmp_path: Path, monkeypatch
+):
+    """A plain runner with no ``workload_id`` attribute at all (the common case
+    for a directly-passed callable, not a registry factory) exercises the
+    ``getattr(..., "workload_id", None)`` default path, not just the explicit
+    ``None`` case above."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    from gitm import optimize
+
+    optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner())
+
+    assert captured["workload_id"] == "vllm-decode"
 
 
 def test_runner_runs_inside_capture_and_produces_real_trace(tmp_path: Path, monkeypatch):

--- a/tests/test_run_loop_workload.py
+++ b/tests/test_run_loop_workload.py
@@ -32,6 +32,70 @@ def test_no_data_guard_does_not_fabricate_claims(tmp_path: Path):
     assert "NO DATA" in result["report_md"]
 
 
+def test_runner_workload_id_relabels_trace_when_workload_unset(tmp_path: Path, monkeypatch):
+    """A factory-built runner's own ``workload_id`` (e.g. set by
+    ``_vllm_decode_factory``, see #60) must relabel the trace/capture call
+    instead of being silently discarded.
+
+    Regression guard: ``run_loop`` computed its ``workload`` label from
+    ``cfg.engine.workload_id`` before the runner (and ``cfg.engine``) were even
+    resolved — the runner's own attribute was set on the wrong object at the
+    wrong time and was never actually read, so a runner passed via
+    ``workload_runner`` with no explicit ``cfg.workload`` always fell back to
+    the hardcoded "vllm-decode" default regardless of what it actually was.
+    """
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        captured["workload_id"] = workload_id
+        kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    def runner():
+        return {"events": 1}
+
+    runner.workload_id = "custom-workload"
+
+    from gitm import optimize
+
+    optimize(budget="1s", scratch=str(tmp_path), workload_runner=runner)
+
+    assert captured["workload_id"] == "custom-workload"
+
+
+def test_runner_workload_id_does_not_override_explicit_workload(tmp_path: Path, monkeypatch):
+    """An explicit ``cfg.workload`` always wins over the runner's self-reported id."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+
+    @contextmanager
+    def fake_capture(out_path, *, workload_id="w", fingerprint="f", run_id=None):
+        captured["workload_id"] = workload_id
+        kernels = [make_kernel("k", start_ns=i * 100, end_ns=i * 100 + 90) for i in range(10)]
+        yield make_trace(events=kernels, vendor="nvidia", run_id=run_id or "r")
+
+    monkeypatch.setattr(loop, "capture", fake_capture)
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    def runner():
+        return {"events": 1}
+
+    runner.workload_id = "custom-workload"
+
+    from gitm import optimize
+
+    optimize(workload="hft", budget="1s", scratch=str(tmp_path), workload_runner=runner)
+
+    assert captured["workload_id"] == "hft"
+
+
 def test_runner_runs_inside_capture_and_produces_real_trace(tmp_path: Path, monkeypatch):
     """An injected runner is invoked inside the capture window; with kernels in
     the trace the loop proceeds to real claims with a non-empty fingerprint."""

--- a/tests/test_run_loop_workload.py
+++ b/tests/test_run_loop_workload.py
@@ -32,16 +32,19 @@ def test_no_data_guard_does_not_fabricate_claims(tmp_path: Path):
     assert "NO DATA" in result["report_md"]
 
 
+_UNSET = object()  # identity sentinel — a real workload_id could legitimately be any string
+
+
 class _Runner:
     """A minimal workload_runner double — explicit about whether/what
     ``workload_id`` it carries, instead of monkey-patching a plain function
     (which silently loses the attribute if ever wrapped, e.g. functools.partial)."""
 
-    def __init__(self, workload_id: object = "unset") -> None:
-        # "unset" (the sentinel) means: don't set the attribute at all, so
+    def __init__(self, workload_id: object = _UNSET) -> None:
+        # _UNSET means: don't set the attribute at all, so
         # getattr(..., "workload_id", None) exercises its own default path
         # rather than reading an attribute that happens to be None.
-        if workload_id != "unset":
+        if workload_id is not _UNSET:
             self.workload_id = workload_id
 
     def __call__(self) -> dict:
@@ -137,6 +140,44 @@ def test_runner_without_workload_id_attribute_falls_back_to_default(
     from gitm import optimize
 
     optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner())
+
+    assert captured["workload_id"] == "vllm-decode"
+
+
+def test_runner_workload_id_empty_string_falls_back_to_default(tmp_path: Path, monkeypatch):
+    """An empty-string ``workload_id`` is treated the same as unset/None, not
+    as a real (if unusual) label — ``getattr(...) or workload`` falls back on
+    any falsy value, by design, not just ``None``. Documented explicitly here
+    since it's a plausible footgun otherwise."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+
+    from gitm import optimize
+
+    optimize(budget="1s", scratch=str(tmp_path), workload_runner=_Runner(""))
+
+    assert captured["workload_id"] == "vllm-decode"
+
+
+def test_no_runner_and_no_explicit_workload_uses_default(tmp_path: Path, monkeypatch):
+    """With nothing to read from at all (no runner, no cfg.workload, no
+    cfg.engine), the simplest path still resolves to the hardcoded default —
+    the relabeling guard must not require a runner to be present."""
+    import gitm.scheduler.loop as loop
+
+    captured: dict = {}
+    monkeypatch.setattr(loop, "capture", _capturing_fake_capture(captured))
+    monkeypatch.setattr(loop, "sync_device", lambda: None)
+    # No registered factory for "vllm-decode" resolves a runner in this test
+    # environment (no vLLM installed), so runner stays None throughout.
+    monkeypatch.setattr(loop, "get_factory", lambda _workload: None)
+
+    from gitm import optimize
+
+    optimize(budget="1s", scratch=str(tmp_path))
 
     assert captured["workload_id"] == "vllm-decode"
 


### PR DESCRIPTION
## Summary
- #60 added `run.workload_id = "vllm-decode"` to `_vllm_decode_factory`'s returned runner, but nothing ever reads it — `run_loop`'s only lookup, `getattr(cfg.engine, "workload_id", None)`, checks the wrong object (`cfg.engine`, the raw engine handle) at the wrong time (before `cfg.engine` is even populated from the runner, several lines later). The attribute was dead code.
- Practical effect: a `workload_runner` passed without an explicit `cfg.workload` always fell back to the hardcoded `"vllm-decode"` label for trace/report purposes, regardless of what the runner actually represents.
- Fix: re-check the runner's own `workload_id` once it has actually resolved, only when the caller didn't pin one explicitly (`cfg.workload` still wins).

## Test plan
- [x] `pytest tests/test_run_loop_workload.py -q` — 10 passed, including 2 new regression tests (override case + explicit-`cfg.workload`-wins precedence case)
- [x] Full suite green (excluding pre-existing `pyarrow`-dependent failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)