### PR TITLE
cupti: extract shared core + add driver-injection tracer for vLLM chi…

### DIFF
--- a/gitm/tracer/_cupti/build.py
+++ b/gitm/tracer/_cupti/build.py
@@ -1,6 +1,15 @@
-"""Compile the CUPTI shim, linking the libcupti that matches the *driver*.
+"""Compile the CUPTI targets, linking the libcupti that matches the driver.
 
     python -m gitm.tracer._cupti.build
+
+Two targets share cupti_core.c:
+
+* ``_cupti_shim<EXT>.so`` — the CPython extension. Traces only the process that
+  imports it.
+* ``libgitm_inject.so`` — a plain .so with no libpython, loaded by the CUDA driver
+  into every process that initializes CUDA (via ``$CUDA_INJECTION64_PATH``). This
+  is the one that can see vLLM's kernels, which run in a child EngineCore process
+  the parent interpreter cannot instrument.
 
 The subtlety that bit us on real hardware: CUPTI's Activity API returns
 ``CUPTI_ERROR_NOT_COMPATIBLE`` when the loaded ``libcupti`` major version doesn't
@@ -8,22 +17,17 @@ match the NVIDIA driver's CUDA version. RunPod's A100s run a CUDA-13 driver, but
 the toolkit + torch ship CUDA 12.8 — so linking the toolkit's ``libcupti.so.12``
 fails to enable. The fix: link ``libcupti.so.<driver-cuda-major>`` (e.g. the
 ``nvidia-cuda-cupti`` wheel's ``libcupti.so.13``), which ``gpu_setup.sh`` installs.
-
 So this script:
-
 1. reads the driver's CUDA major from ``nvidia-smi`` (e.g. 13),
 2. finds ``libcupti.so.<major>`` across the toolkit and the pip ``nvidia/cu*``
    wheels, preferring the driver-matched major (else the newest),
 3. compiles against the **toolkit** headers (complete — they carry ``crt/`` and
    the ``CUpti_Activity*`` structs; the records are append-compatible), and
 4. links that libcupti with an rpath so it loads at runtime.
-
 Only a host C compiler is needed — not ``nvcc``. On a host with no CUDA this
 exits non-zero and the tracer degrades to a no-op.
 """
-
 from __future__ import annotations
-
 import os
 import re
 import shlex
@@ -33,7 +37,10 @@ import sysconfig
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
+CORE = HERE / "cupti_core.c"
 SRC = HERE / "cupti_shim.c"
+INJECT_SRC = HERE / "cupti_inject.c"
+INJECT_LIB = HERE / "libgitm_inject.so"
 
 
 def _cuda_home() -> Path | None:
@@ -46,16 +53,12 @@ def _cuda_home() -> Path | None:
         if Path(cand).is_dir():
             return Path(cand)
     return None
-
-
 def _nvidia_wheel_bases() -> list[Path]:
     try:
         import nvidia  # provided by nvidia-*-cu1x wheels (PyTorch deps)
     except Exception:
         return []
     return [Path(p) for p in getattr(nvidia, "__path__", [])]
-
-
 def _driver_cuda_major() -> int | None:
     """Driver's CUDA major from ``nvidia-smi`` (the version CUPTI must match)."""
     try:
@@ -64,8 +67,6 @@ def _driver_cuda_major() -> int | None:
         return None
     m = re.search(r"CUDA Version:\s*(\d+)", out)
     return int(m.group(1)) if m else None
-
-
 def _all_libcupti(cuda: Path | None) -> list[tuple[Path, int]]:
     """Every ``libcupti.so.<major>`` on the box, as ``(dir, major)``."""
     dirs: list[Path] = []
@@ -76,7 +77,6 @@ def _all_libcupti(cuda: Path | None) -> list[tuple[Path, int]]:
         ]
     for base in _nvidia_wheel_bases():
         dirs += list(base.glob("cu*/lib")) + [base / "cuda_cupti/lib"]
-
     out: list[tuple[Path, int]] = []
     for d in dirs:
         if not d.is_dir():
@@ -86,8 +86,6 @@ def _all_libcupti(cuda: Path | None) -> list[tuple[Path, int]]:
             if m:
                 out.append((d, int(m.group(1))))
     return out
-
-
 def _pick_libcupti(cuda: Path | None) -> tuple[Path | None, int | None]:
     """Pick the libcupti dir+major matching the driver (else the newest)."""
     cands = _all_libcupti(cuda)
@@ -99,8 +97,6 @@ def _pick_libcupti(cuda: Path | None) -> tuple[Path | None, int | None]:
         if matched:
             return matched[0]
     return max(cands, key=lambda c: c[1])  # newest major
-
-
 def _cupti_include(cuda: Path | None) -> Path | None:
     if cuda:
         for c in (cuda / "include", cuda / "extras/CUPTI/include",
@@ -112,8 +108,6 @@ def _cupti_include(cuda: Path | None) -> Path | None:
         if (c / "cupti.h").exists():
             return c
     return None
-
-
 def _cudart(cuda: Path | None) -> tuple[Path | None, Path | None]:
     """cuda_runtime.h include (must carry ``crt/``) + libcudart dir."""
     inc = lib = None
@@ -127,22 +121,17 @@ def _cudart(cuda: Path | None) -> tuple[Path | None, Path | None]:
                 lib = c
                 break
     return inc, lib
-
-
 def _output_path() -> Path:
     suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
     return HERE / f"_cupti_shim{suffix}"
 
 
-def build() -> Path:
-    if not SRC.exists():
-        raise SystemExit(f"missing source: {SRC}")
-
+def _toolchain() -> tuple[Path, Path, int, Path, Path]:
+    """Locate CUPTI/cudart headers + the driver-matched libcupti, or exit."""
     cuda = _cuda_home()
     cupti_inc = _cupti_include(cuda)
     cupti_lib, cupti_major = _pick_libcupti(cuda)
     cudart_inc, cudart_lib = _cudart(cuda)
-
     missing = [n for n, v in (
         ("cupti.h headers", cupti_inc),
         ("libcupti", cupti_lib),
@@ -158,16 +147,20 @@ def build() -> Path:
             "  apt-get install -y build-essential   # a C compiler\n"
             "On CPU-only hosts the tracer is a no-op and this build is skipped."
         )
+    assert cupti_inc and cupti_lib and cupti_major and cudart_inc and cudart_lib
+    return cupti_inc, cupti_lib, cupti_major, cudart_inc, cudart_lib
 
-    py_inc = sysconfig.get_path("include")
-    out = _output_path()
+
+def _compile(sources: list[Path], out: Path, extra_includes: list[str], label: str) -> Path:
+    cupti_inc, cupti_lib, cupti_major, cudart_inc, cudart_lib = _toolchain()
     cc = os.environ.get("CC", "cc")
     cmd = [
         cc, "-shared", "-fPIC", "-O2",
-        f"-I{py_inc}",
+        *[f"-I{i}" for i in extra_includes],
+        f"-I{HERE}",
         f"-I{cupti_inc}",
         f"-I{cudart_inc}",
-        str(SRC),
+        *[str(s) for s in sources],
         f"-L{cupti_lib}",
         f"-L{cudart_lib}",
         f"-l:libcupti.so.{cupti_major}",
@@ -176,7 +169,7 @@ def build() -> Path:
         f"-Wl,-rpath,{cudart_lib}",
         "-o", str(out),
     ]
-    print("compiling cupti shim:\n  " + " ".join(shlex.quote(c) for c in cmd))
+    print(f"compiling {label}:\n  " + " ".join(shlex.quote(c) for c in cmd))
     print(f"  driver CUDA major: {_driver_cuda_major()}  ->  libcupti.so.{cupti_major}")
     print(f"  cupti lib:  {cupti_lib}")
     print(f"  headers:    {cupti_inc} | {cudart_inc}")
@@ -185,9 +178,32 @@ def build() -> Path:
     return out
 
 
+def build() -> Path:
+    """Build the CPython extension (_cupti_shim). Traces this process only."""
+    for src in (CORE, SRC):
+        if not src.exists():
+            raise SystemExit(f"missing source: {src}")
+    return _compile(
+        [CORE, SRC], _output_path(), [sysconfig.get_path("include")], "cupti shim"
+    )
+
+
+def build_injection() -> Path:
+    """Build libgitm_inject.so — the driver-injected, no-libpython collector.
+    Deliberately does NOT link libpython: the CUDA driver dlopens this into
+    arbitrary processes at CUDA init, and dragging an interpreter into that path
+    would be both unnecessary and unsafe.
+    """
+    for src in (CORE, INJECT_SRC):
+        if not src.exists():
+            raise SystemExit(f"missing source: {src}")
+    return _compile([CORE, INJECT_SRC], INJECT_LIB, [], "cupti injection lib")
+
+
 if __name__ == "__main__":
     try:
         build()
+        build_injection()
     except subprocess.CalledProcessError as exc:
         print(f"compile failed (exit {exc.returncode})", file=sys.stderr)
         raise SystemExit(exc.returncode) from exc

--- a/gitm/tracer/_cupti/build.py
+++ b/gitm/tracer/_cupti/build.py
@@ -28,6 +28,7 @@ Only a host C compiler is needed — not ``nvcc``. On a host with no CUDA this
 exits non-zero and the tracer degrades to a no-op.
 """
 from __future__ import annotations
+
 import os
 import re
 import shlex

--- a/gitm/tracer/_cupti/cupti_core.c
+++ b/gitm/tracer/_cupti/cupti_core.c
@@ -1,0 +1,192 @@
+/*
+ * cupti_core — see cupti_core.h.
+ *
+ * Struct versions are pinned to CUDA 12.x/13.x (Kernel9 / Memcpy5 / Sync). If the
+ * deployed CUPTI drops a versioned struct name the compile fails loudly — bump the
+ * version in the cast, never guess offsets.
+ */
+
+#include "cupti_core.h"
+
+#include <cuda_runtime.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BUF_SIZE (8 * 1024 * 1024)   /* 8 MiB activity buffers */
+#define BUF_ALIGN 8
+
+#define ALIGN_BUFFER(p, a) \
+    (((uintptr_t)(p) % (a)) ? ((p) + (a) - ((uintptr_t)(p) % (a))) : (p))
+
+static gitm_sink_fn   g_sink = NULL;
+static void          *g_sink_user = NULL;
+static gitm_buffer_fn g_buffer_hook = NULL;
+static void          *g_buffer_user = NULL;
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static int g_enabled = 0;
+
+/* Enable CONCURRENT_KERNEL only, not also CUPTI_ACTIVITY_KIND_KERNEL. Enabling
+ * both yields two records per kernel, and the duplicate set comes back with
+ * zeroed timestamps (verified on an A100 / CUDA 13). CONCURRENT_KERNEL is the
+ * correct kind for async workloads and carries valid start/end. */
+static const CUpti_ActivityKind ENABLED_KINDS[] = {
+    CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL,
+    CUPTI_ACTIVITY_KIND_MEMCPY,
+    CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
+};
+#define N_ENABLED_KINDS (sizeof(ENABLED_KINDS) / sizeof(ENABLED_KINDS[0]))
+
+void gitm_set_sink(gitm_sink_fn sink, void *user) {
+    pthread_mutex_lock(&g_lock);
+    g_sink = sink;
+    g_sink_user = user;
+    pthread_mutex_unlock(&g_lock);
+}
+
+void gitm_set_buffer_hook(gitm_buffer_fn hook, void *user) {
+    pthread_mutex_lock(&g_lock);
+    g_buffer_hook = hook;
+    g_buffer_user = user;
+    pthread_mutex_unlock(&g_lock);
+}
+
+static void copy_name(gitm_record *r, const char *name) {
+    if (!name) { r->name[0] = '\0'; return; }
+    strncpy(r->name, name, GITM_NAME_MAX);
+    r->name[GITM_NAME_MAX] = '\0';
+}
+
+/* Decode one CUPTI record into a normalized gitm_record and hand it to the sink.
+ * Called with g_lock held. */
+static void ingest(CUpti_Activity *rec) {
+    gitm_record r;
+    memset(&r, 0, sizeof(r));
+
+    switch (rec->kind) {
+        case CUPTI_ACTIVITY_KIND_KERNEL:
+        case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL: {
+            CUpti_ActivityKernel9 *k = (CUpti_ActivityKernel9 *)rec;
+            r.kind = GITM_REC_KERNEL;
+            copy_name(&r, k->name);
+            r.start_ns = k->start;
+            r.end_ns = k->end;
+            r.device_id = k->deviceId;
+            r.context_id = k->contextId;
+            r.stream_id = k->streamId;
+            r.correlation_id = k->correlationId;
+            r.grid[0] = k->gridX; r.grid[1] = k->gridY; r.grid[2] = k->gridZ;
+            r.block[0] = k->blockX; r.block[1] = k->blockY; r.block[2] = k->blockZ;
+            r.static_shared_mem = k->staticSharedMemory;
+            r.dynamic_shared_mem = k->dynamicSharedMemory;
+            r.registers_per_thread = k->registersPerThread;
+            break;
+        }
+        case CUPTI_ACTIVITY_KIND_MEMCPY: {
+            CUpti_ActivityMemcpy5 *m = (CUpti_ActivityMemcpy5 *)rec;
+            r.kind = GITM_REC_MEMCPY;
+            r.start_ns = m->start;
+            r.end_ns = m->end;
+            r.device_id = m->deviceId;
+            r.context_id = m->contextId;
+            r.stream_id = m->streamId;
+            r.correlation_id = m->correlationId;
+            r.copy_kind = m->copyKind;
+            r.bytes = m->bytes;
+            break;
+        }
+        case CUPTI_ACTIVITY_KIND_SYNCHRONIZATION: {
+            CUpti_ActivitySynchronization *s = (CUpti_ActivitySynchronization *)rec;
+            r.kind = GITM_REC_SYNC;
+            r.start_ns = s->start;
+            r.end_ns = s->end;
+            r.context_id = s->contextId;
+            r.stream_id = s->streamId;
+            r.correlation_id = s->correlationId;
+            r.sync_type = s->type;
+            break;
+        }
+        default:
+            return;  /* kinds GITM doesn't model */
+    }
+
+    if (g_sink) g_sink(&r, g_sink_user);
+}
+
+static void CUPTIAPI buffer_requested(uint8_t **buffer, size_t *size,
+                                      size_t *maxNumRecords) {
+    uint8_t *raw = (uint8_t *)malloc(BUF_SIZE + BUF_ALIGN);
+    *buffer = (uint8_t *)ALIGN_BUFFER(raw, BUF_ALIGN);
+    *size = BUF_SIZE;
+    *maxNumRecords = 0;  /* fill as many as fit */
+}
+
+static void CUPTIAPI buffer_completed(CUcontext ctx, uint32_t streamId,
+                                      uint8_t *buffer, size_t size, size_t validSize) {
+    (void)ctx; (void)streamId; (void)size;
+    CUpti_Activity *record = NULL;
+
+    pthread_mutex_lock(&g_lock);
+    if (g_buffer_hook) g_buffer_hook(g_buffer_user);
+    if (validSize > 0) {
+        for (;;) {
+            CUptiResult st = cuptiActivityGetNextRecord(buffer, validSize, &record);
+            if (st == CUPTI_SUCCESS) {
+                ingest(record);
+            } else {
+                break;  /* MAX_LIMIT_REACHED = end of buffer; anything else, stop */
+            }
+        }
+    }
+    pthread_mutex_unlock(&g_lock);
+    free(buffer);  /* matches malloc in buffer_requested (aligned within) */
+}
+
+CUptiResult gitm_cupti_start(void) {
+    if (g_enabled) return CUPTI_SUCCESS;
+
+    CUptiResult st = cuptiActivityRegisterCallbacks(buffer_requested, buffer_completed);
+    if (st != CUPTI_SUCCESS) return st;
+
+    for (size_t i = 0; i < N_ENABLED_KINDS; i++) {
+        st = cuptiActivityEnable(ENABLED_KINDS[i]);
+        if (st != CUPTI_SUCCESS) return st;
+    }
+    g_enabled = 1;
+    return CUPTI_SUCCESS;
+}
+
+CUptiResult gitm_cupti_flush(void) {
+    return cuptiActivityFlushAll(1 /* FORCE */);
+}
+
+CUptiResult gitm_cupti_stop(void) {
+    if (!g_enabled) return CUPTI_SUCCESS;
+    for (size_t i = 0; i < N_ENABLED_KINDS; i++) {
+        cuptiActivityDisable(ENABLED_KINDS[i]);
+    }
+    g_enabled = 0;
+    return gitm_cupti_flush();
+}
+
+CUptiResult gitm_cupti_set_flush_period(uint32_t ms) {
+    return cuptiActivityFlushPeriod(ms);
+}
+
+uint64_t gitm_cupti_timestamp(void) {
+    uint64_t ts = 0;
+    if (cuptiGetTimestamp(&ts) != CUPTI_SUCCESS) return 0;
+    return ts;
+}
+
+int gitm_cuda_device_count(void) {
+    int n = 0;
+    if (cudaGetDeviceCount(&n) != cudaSuccess) return 0;
+    return n;
+}
+
+const char *gitm_cupti_errstr(CUptiResult status) {
+    const char *msg = NULL;
+    cuptiGetResultString(status, &msg);
+    return msg ? msg : "?";
+}

--- a/gitm/tracer/_cupti/cupti_core.h
+++ b/gitm/tracer/_cupti/cupti_core.h
@@ -1,0 +1,107 @@
+/*
+ * cupti_core — CUPTI Activity ingestion, with no opinion about where records go.
+ *
+ * Shared by the two build targets that need it:
+ *
+ *   cupti_shim.c    -> _cupti_shim<EXT>.so   CPython extension; sink appends to
+ *                                            an in-memory list, marshalled on stop().
+ *   cupti_inject.c  -> libgitm_inject.so     plain .so with no libpython, loaded
+ *                                            into EVERY CUDA process by the driver
+ *                                            via $CUDA_INJECTION64_PATH; sink writes
+ *                                            JSONL straight to a per-pid file.
+ *
+ * The injection target is what lets us trace vLLM: its V1 engine runs the model in
+ * a child process (EngineCore), so a tracer that only ever loads in the parent
+ * interpreter sees zero kernels. The driver dlopens this library in the child at
+ * CUDA init and calls InitializeInjection(), which is the only way in without
+ * making vLLM disable its own process model.
+ *
+ * Everything unsafe lives here: buffer management, walking records with
+ * cuptiActivityGetNextRecord, and reading fields off the real CUPTI structs whose
+ * layout the compiler resolves against the installed cupti_activity.h. Callers only
+ * ever see the normalized gitm_record below.
+ *
+ * Threading: CUPTI invokes buffer_completed on its own internal threads. The core
+ * holds a mutex across a whole buffer and calls the sink under it, so sinks may be
+ * written as if single-threaded — but they must not call back into Python without
+ * taking the GIL, and they must not block.
+ */
+
+#ifndef GITM_CUPTI_CORE_H
+#define GITM_CUPTI_CORE_H
+
+#include <cupti.h>
+#include <stdint.h>
+
+#define GITM_NAME_MAX 255
+
+#define GITM_REC_KERNEL 0
+#define GITM_REC_MEMCPY 1
+#define GITM_REC_SYNC 2
+
+/** Normalized record - only the fields GITM consumes.
+ * Field-for-field contract documented in gitm/tracer/_cupti_decode.py
+ * both sinks emit exactly these keys so one decoder serves both targets. */
+typedef struct {
+    int      kind;
+    char     name[GITM_NAME_MAX + 1];
+    uint64_t start_ns;
+    uint64_t end_ns;
+    uint32_t device_id;
+    uint32_t context_id;
+    uint32_t stream_id;
+    uint32_t correlation_id;
+    int32_t  grid[3];
+    int32_t  block[3];
+    int32_t  static_shared_mem;
+    int32_t  dynamic_shared_mem;
+    int32_t  registers_per_thread;
+    int      copy_kind;
+    uint64_t bytes;
+    int      sync_type;
+} gitm_record;
+
+/** Called once per decoded record, under the core's lock. */
+typedef void (*gitm_sink_fn)(const gitm_record *rec, void *user);
+
+/* Called once at the top of each completed CUPTI buffer, under the core's lock,
+ * before any records from that buffer are sunk. The injection sink uses this to
+ * refresh its armed/disarmed state with one stat() per buffer instead of one per
+ * kernel. */
+typedef void (*gitm_buffer_fn)(void *user);
+
+void gitm_set_sink(gitm_sink_fn sink, void *user);
+void gitm_set_buffer_hook(gitm_buffer_fn hook, void *user);
+
+/* Register callbacks and enable the activity kinds GITM models. Idempotent. */
+CUptiResult gitm_cupti_start(void);
+
+/* Disable the activity kinds and force a final flush. Idempotent. */
+CUptiResult gitm_cupti_stop(void);
+
+/* Force a flush of all pending buffers (records arrive via the sink). */
+CUptiResult gitm_cupti_flush(void);
+
+/* Ask CUPTI to flush completed buffers every ms milliseconds.
+ *
+ * Load-bearing for injection: the parent process closes its capture window while
+ * the child still holds partially-filled buffers, and the parent cannot reach into
+ * the child to force a flush. A periodic flush bounds how much of the tail is
+ * still in flight when the window closes; capture.py then waits out one period
+ * before merging. */
+CUptiResult gitm_cupti_set_flush_period(uint32_t ms);
+
+/* A timestamp in the SAME clock domain as the activity records' start/end.
+ *
+ * This is what makes cross-process merging correct. CUPTI normalizes activity
+ * timestamps to one driver-global clock, so a bound read in the parent is directly
+ * comparable to a kernel timestamp recorded in a child — unlike wall-clock, which
+ * is per-process. capture() reads this at window open/close and filters merged
+ * shards to the window, which is how the 80s of engine build and CUDA-graph capture
+ * that precede the decode stay out of the trace. */
+uint64_t gitm_cupti_timestamp(void);
+
+int gitm_cuda_device_count(void);
+const char *gitm_cupti_errstr(CUptiResult status);
+
+#endif /* GITM_CUPTI_CORE_H */

--- a/gitm/tracer/_cupti/cupti_inject.c
+++ b/gitm/tracer/_cupti/cupti_inject.c
@@ -1,0 +1,168 @@
+/*
+ * cupti_inject — CUPTI collection for processes we don't control.
+ *
+ * Built as libgitm_inject.so: a plain shared library with NO libpython. Point the
+ * CUDA driver at it with
+ *
+ *     export CUDA_INJECTION64_PATH=/abs/path/to/libgitm_inject.so
+ *     export GITM_TRACE_OUT=/abs/path/to/trace.jsonl
+ *
+ * and the driver dlopens it inside every process that initializes CUDA — the
+ * parent AND any child it forks or spawns — calling InitializeInjection() before
+ * that process runs a single kernel. Because CUDA_INJECTION64_PATH is an ordinary
+ * environment variable it is inherited across fork/spawn, which is the whole point:
+ * vLLM's V1 engine runs the model in a separate EngineCore process, so a tracer
+ * that only loads in the parent interpreter captures nothing. This is the same
+ * mechanism nsys uses to follow children, and it needs no cooperation from vLLM —
+ * its process model is untouched.
+ *
+ * Each process writes its own shard, $GITM_TRACE_OUT.<pid>, one JSON record per
+ * line in exactly the dict shape gitm/tracer/_cupti_decode.py already consumes.
+ * capture() merges the shards. Per-pid files because parent and child both load
+ * this library and appending both to one file would interleave partial lines.
+ *
+ * Durability: records are written from the sink as CUPTI hands buffers back,
+ * rather than accumulated and dumped at exit. A child that is SIGKILLed — or that
+ * dies in its own shutdown path, which vLLM's EngineCore has been observed to do —
+ * still leaves everything up to the last flush on disk. atexit() catches the tail
+ * on a clean exit. We deliberately install NO signal handler: EngineCore installs
+ * its own SIGTERM handler for orderly shutdown, and clobbering it from a library
+ * the driver injected underneath the application would be a hostile thing to do.
+ *
+ * Arming: capture() creates $GITM_TRACE_OUT.arm on window open and removes it on
+ * close, and this library only writes while it exists. Without that gate every
+ * CUDA process on the box would stream records for its entire lifetime — for vLLM
+ * that means ~80s of weight load, torch.compile and CUDA-graph capture before the
+ * decode even starts, and an unbounded file on a 24h run. The check is one stat()
+ * per completed buffer (8 MiB), not per kernel.
+ */
+
+#include "cupti_core.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define DEFAULT_FLUSH_MS 100
+
+static FILE *g_fp = NULL;
+static char  g_arm_path[PATH_MAX];
+static int   g_armed = 0;
+
+/* JSON-escape a kernel name. Mangled C++ template names routinely carry quotes,
+ * backslashes and control bytes; an unescaped one would corrupt the shard and take
+ * the whole trace down at parse time. */
+static void write_json_string(FILE *fp, const char *s) {
+    fputc('"', fp);
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+        switch (*p) {
+            case '"':  fputs("\\\"", fp); break;
+            case '\\': fputs("\\\\", fp); break;
+            case '\n': fputs("\\n", fp);  break;
+            case '\r': fputs("\\r", fp);  break;
+            case '\t': fputs("\\t", fp);  break;
+            default:
+                if (*p < 0x20) fprintf(fp, "\\u%04x", *p);
+                else fputc(*p, fp);
+        }
+    }
+    fputc('"', fp);
+}
+
+/* One stat() per completed buffer, refreshing the armed flag for the records that
+ * buffer is about to yield. */
+static void refresh_armed(void *user) {
+    (void)user;
+    g_armed = (access(g_arm_path, F_OK) == 0);
+}
+
+static void file_sink(const gitm_record *r, void *user) {
+    (void)user;
+    if (!g_fp || !g_armed) return;
+
+    if (r->kind == GITM_REC_KERNEL) {
+        fputs("{\"kind\":\"kernel\",\"name\":", g_fp);
+        write_json_string(g_fp, r->name);
+        fprintf(g_fp,
+                ",\"start_ns\":%llu,\"end_ns\":%llu,\"device_id\":%u,\"context_id\":%u,"
+                "\"stream_id\":%u,\"correlation_id\":%u,\"grid\":[%d,%d,%d],"
+                "\"block\":[%d,%d,%d],\"static_shared_mem\":%d,"
+                "\"dynamic_shared_mem\":%d,\"registers_per_thread\":%d}\n",
+                (unsigned long long)r->start_ns, (unsigned long long)r->end_ns,
+                r->device_id, r->context_id, r->stream_id, r->correlation_id,
+                r->grid[0], r->grid[1], r->grid[2],
+                r->block[0], r->block[1], r->block[2],
+                r->static_shared_mem, r->dynamic_shared_mem, r->registers_per_thread);
+    } else if (r->kind == GITM_REC_MEMCPY) {
+        fprintf(g_fp,
+                "{\"kind\":\"memcpy\",\"copy_kind\":%d,\"bytes\":%llu,"
+                "\"start_ns\":%llu,\"end_ns\":%llu,\"device_id\":%u,\"context_id\":%u,"
+                "\"stream_id\":%u,\"correlation_id\":%u}\n",
+                r->copy_kind, (unsigned long long)r->bytes,
+                (unsigned long long)r->start_ns, (unsigned long long)r->end_ns,
+                r->device_id, r->context_id, r->stream_id, r->correlation_id);
+    } else {
+        fprintf(g_fp,
+                "{\"kind\":\"sync\",\"sync_type\":%d,"
+                "\"start_ns\":%llu,\"end_ns\":%llu,\"device_id\":%u,\"context_id\":%u,"
+                "\"stream_id\":%u,\"correlation_id\":%u}\n",
+                r->sync_type,
+                (unsigned long long)r->start_ns, (unsigned long long)r->end_ns,
+                r->device_id, r->context_id, r->stream_id, r->correlation_id);
+    }
+}
+
+static void finish(void) {
+    if (!g_fp) return;
+    gitm_cupti_stop();   /* disable + force flush; the sink drains into g_fp */
+    fflush(g_fp);
+    fclose(g_fp);
+    g_fp = NULL;
+}
+
+/* The driver's entry point. Must return non-zero; returning 0 tells CUDA the
+ * injection failed. We always report success — a tracer that cannot open its
+ * output has no business taking down the workload it was injected into, so on any
+ * error we simply stay dormant. */
+int InitializeInjection(void) {
+    static int initialized = 0;
+    if (initialized) return 1;
+    initialized = 1;
+
+    const char *out = getenv("GITM_TRACE_OUT");
+    if (!out || !*out) return 1;  /* not a GITM run — stay dormant */
+
+    char shard[PATH_MAX];
+    if (snprintf(shard, sizeof(shard), "%s.%d", out, (int)getpid()) >= (int)sizeof(shard)) {
+        return 1;
+    }
+    if (snprintf(g_arm_path, sizeof(g_arm_path), "%s.arm", out) >= (int)sizeof(g_arm_path)) {
+        return 1;
+    }
+
+    g_fp = fopen(shard, "a");
+    if (!g_fp) return 1;
+    setvbuf(g_fp, NULL, _IOFBF, 1 << 20);
+
+    gitm_set_sink(file_sink, NULL);
+    gitm_set_buffer_hook(refresh_armed, NULL);
+
+    if (gitm_cupti_start() != CUPTI_SUCCESS) {
+        fclose(g_fp);
+        g_fp = NULL;
+        return 1;
+    }
+
+    const char *ms = getenv("GITM_TRACE_FLUSH_MS");
+    gitm_cupti_set_flush_period(ms && *ms ? (uint32_t)strtoul(ms, NULL, 10)
+                                          : (uint32_t)DEFAULT_FLUSH_MS);
+
+    atexit(finish);
+    return 1;
+}

--- a/gitm/tracer/_cupti/cupti_shim.c
+++ b/gitm/tracer/_cupti/cupti_shim.c
@@ -1,217 +1,69 @@
 /*
- * cupti_shim — a minimal CUPTI Activity API consumer exposed to Python.
+ * cupti_shim — the CPython face of cupti_core.
  *
  * Why a C shim instead of ctypes: the CUPTI activity record structs
  * (CUpti_ActivityKernel*, CUpti_ActivityMemcpy*, ...) change layout between
- * CUDA versions. Letting the compiler read the *installed* cupti_activity.h
+ * CUDA versions. Letting the compiler read the installed cupti_activity.h
  * means field offsets are always correct — never hand-mirrored in Python where
- * a wrong pad would silently corrupt every kernel timing. The shim copies only
- * primitives into a normalized C record, then Python (gitm.tracer._cupti_decode)
- * turns those into validated trace events.
+ * a wrong pad would silently corrupt every kernel timing. The core copies only
+ * primitives into a normalized C record; this file turns those into dicts, and
+ * gitm.tracer._cupti_decode turns the dicts into validated trace events.
  *
  * Threading: CUPTI may invoke the buffer-completed callback on its own internal
  * threads during cuptiActivityFlushAll. We therefore do NO Python work in the
- * callbacks — records are appended to a mutex-guarded C array — and only build
- * Python objects in stop(), on the calling thread, holding the GIL.
+ * sink — records are appended to a C array the core already guards with its
+ * mutex — and only build Python objects in stop(), on the calling thread,
+ * holding the GIL.
  *
- * Build: python -m gitm.tracer._cupti.build  (needs the CUDA toolkit + CUPTI).
+ * This target traces only the process it is imported into. For vLLM, whose V1
+ * engine runs the model in a child process, use the injection target instead
+ * (cupti_inject.c). See cupti_core.h.
  *
- * Struct versions below are pinned to CUDA 12.x (Kernel9 / Memcpy5 / Sync).
- * If the deployed CUPTI is older/newer and a versioned struct name is missing,
- * the compile fails loudly — bump the version in the cast, do not guess offsets.
+ * Build: python -m gitm.tracer._cupti.build  (needs CUPTI headers + libcupti).
  */
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-#include <cupti.h>
-#include <cuda_runtime.h>
-#include <pthread.h>
-#include <stdint.h>
-#include <string.h>
+#include "cupti_core.h"
+
 #include <stdlib.h>
+#include <string.h>
 
-#define BUF_SIZE (8 * 1024 * 1024)   /* 8 MiB activity buffers */
-#define BUF_ALIGN 8
-#define NAME_MAX_LEN 255
-
-/* Normalized record — only the fields GITM consumes. */
-typedef struct {
-    int      kind;        /* 0 kernel, 1 memcpy, 2 sync */
-    char     name[NAME_MAX_LEN + 1];
-    uint64_t start_ns;
-    uint64_t end_ns;
-    uint32_t device_id;
-    uint32_t context_id;
-    uint32_t stream_id;
-    uint32_t correlation_id;
-    int32_t  grid[3];
-    int32_t  block[3];
-    int32_t  static_shared_mem;
-    int32_t  dynamic_shared_mem;
-    int32_t  registers_per_thread;
-    int      copy_kind;
-    uint64_t bytes;
-    int      sync_type;
-} gitm_record;
-
-#define REC_KERNEL 0
-#define REC_MEMCPY 1
-#define REC_SYNC   2
-
-/* Growable, mutex-guarded record store filled during CUPTI callbacks. */
+/* Growable record store, appended from the core's sink (called under the core's
+ * lock, so no additional locking here). */
 static gitm_record *g_records = NULL;
 static size_t g_count = 0;
 static size_t g_cap = 0;
-static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
-static int g_enabled = 0;
 
-#define ALIGN_BUFFER(p, a) \
-    (((uintptr_t)(p) % (a)) ? ((p) + (a) - ((uintptr_t)(p) % (a))) : (p))
-
-static gitm_record *store_next(void) {
+static void store_sink(const gitm_record *rec, void *user) {
+    (void)user;
     if (g_count == g_cap) {
         size_t ncap = g_cap ? g_cap * 2 : 4096;
         gitm_record *n = (gitm_record *)realloc(g_records, ncap * sizeof(gitm_record));
-        if (!n) return NULL;
+        if (!n) return;  /* drop the record rather than abort the workload */
         g_records = n;
         g_cap = ncap;
     }
-    gitm_record *r = &g_records[g_count++];
-    memset(r, 0, sizeof(*r));
-    return r;
+    g_records[g_count++] = *rec;
 }
-
-static void copy_name(gitm_record *r, const char *name) {
-    if (!name) { r->name[0] = '\0'; return; }
-    strncpy(r->name, name, NAME_MAX_LEN);
-    r->name[NAME_MAX_LEN] = '\0';
-}
-
-static void ingest(CUpti_Activity *rec) {
-    switch (rec->kind) {
-        case CUPTI_ACTIVITY_KIND_KERNEL:
-        case CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL: {
-            CUpti_ActivityKernel9 *k = (CUpti_ActivityKernel9 *)rec;
-            gitm_record *r = store_next();
-            if (!r) return;
-            r->kind = REC_KERNEL;
-            copy_name(r, k->name);
-            r->start_ns = k->start;
-            r->end_ns = k->end;
-            r->device_id = k->deviceId;
-            r->context_id = k->contextId;
-            r->stream_id = k->streamId;
-            r->correlation_id = k->correlationId;
-            r->grid[0] = k->gridX; r->grid[1] = k->gridY; r->grid[2] = k->gridZ;
-            r->block[0] = k->blockX; r->block[1] = k->blockY; r->block[2] = k->blockZ;
-            r->static_shared_mem = k->staticSharedMemory;
-            r->dynamic_shared_mem = k->dynamicSharedMemory;
-            r->registers_per_thread = k->registersPerThread;
-            break;
-        }
-        case CUPTI_ACTIVITY_KIND_MEMCPY: {
-            CUpti_ActivityMemcpy5 *m = (CUpti_ActivityMemcpy5 *)rec;
-            gitm_record *r = store_next();
-            if (!r) return;
-            r->kind = REC_MEMCPY;
-            r->start_ns = m->start;
-            r->end_ns = m->end;
-            r->device_id = m->deviceId;
-            r->context_id = m->contextId;
-            r->stream_id = m->streamId;
-            r->correlation_id = m->correlationId;
-            r->copy_kind = m->copyKind;
-            r->bytes = m->bytes;
-            break;
-        }
-        case CUPTI_ACTIVITY_KIND_SYNCHRONIZATION: {
-            CUpti_ActivitySynchronization *s = (CUpti_ActivitySynchronization *)rec;
-            gitm_record *r = store_next();
-            if (!r) return;
-            r->kind = REC_SYNC;
-            r->start_ns = s->start;
-            r->end_ns = s->end;
-            r->context_id = s->contextId;
-            r->stream_id = s->streamId;
-            r->correlation_id = s->correlationId;
-            r->sync_type = s->type;
-            break;
-        }
-        default:
-            break;  /* kinds GITM doesn't model */
-    }
-}
-
-static void CUPTIAPI buffer_requested(uint8_t **buffer, size_t *size,
-                                      size_t *maxNumRecords) {
-    uint8_t *raw = (uint8_t *)malloc(BUF_SIZE + BUF_ALIGN);
-    *buffer = (uint8_t *)ALIGN_BUFFER(raw, BUF_ALIGN);
-    *size = BUF_SIZE;
-    *maxNumRecords = 0;  /* fill as many as fit */
-}
-
-static void CUPTIAPI buffer_completed(CUcontext ctx, uint32_t streamId,
-                                      uint8_t *buffer, size_t size, size_t validSize) {
-    (void)ctx; (void)streamId; (void)size;
-    CUpti_Activity *record = NULL;
-    pthread_mutex_lock(&g_lock);
-    if (validSize > 0) {
-        for (;;) {
-            CUptiResult st = cuptiActivityGetNextRecord(buffer, validSize, &record);
-            if (st == CUPTI_SUCCESS) {
-                ingest(record);
-            } else if (st == CUPTI_ERROR_MAX_LIMIT_REACHED) {
-                break;
-            } else {
-                break;
-            }
-        }
-    }
-    pthread_mutex_unlock(&g_lock);
-    free(buffer);  /* matches malloc in buffer_requested (aligned within) */
-}
-
-/* ---- Python interface ---- */
 
 static PyObject *set_cupti_error(CUptiResult st, const char *where) {
-    const char *msg = NULL;
-    cuptiGetResultString(st, &msg);
-    PyErr_Format(PyExc_RuntimeError, "CUPTI %s failed: %s", where, msg ? msg : "?");
+    PyErr_Format(PyExc_RuntimeError, "CUPTI %s failed: %s", where, gitm_cupti_errstr(st));
     return NULL;
 }
 
-/* Enable CONCURRENT_KERNEL only, not also CUPTI_ACTIVITY_KIND_KERNEL. Enabling
- * both yields two records per kernel, and the duplicate set comes back with
- * zeroed timestamps (verified on an A100 / CUDA 13). CONCURRENT_KERNEL is the
- * correct kind for async workloads and carries valid start/end. */
-static const CUpti_ActivityKind ENABLED_KINDS[] = {
-    CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL,
-    CUPTI_ACTIVITY_KIND_MEMCPY,
-    CUPTI_ACTIVITY_KIND_SYNCHRONIZATION,
-};
-
 static PyObject *py_start(PyObject *self, PyObject *args) {
     (void)self; (void)args;
-    if (g_enabled) Py_RETURN_NONE;
-
-    CUptiResult st = cuptiActivityRegisterCallbacks(buffer_requested, buffer_completed);
-    if (st != CUPTI_SUCCESS) return set_cupti_error(st, "RegisterCallbacks");
-
-    pthread_mutex_lock(&g_lock);
     g_count = 0;  /* fresh trace */
-    pthread_mutex_unlock(&g_lock);
-
-    for (size_t i = 0; i < sizeof(ENABLED_KINDS) / sizeof(ENABLED_KINDS[0]); i++) {
-        st = cuptiActivityEnable(ENABLED_KINDS[i]);
-        if (st != CUPTI_SUCCESS) return set_cupti_error(st, "Enable");
-    }
-    g_enabled = 1;
+    gitm_set_sink(store_sink, NULL);
+    CUptiResult st = gitm_cupti_start();
+    if (st != CUPTI_SUCCESS) return set_cupti_error(st, "start");
     Py_RETURN_NONE;
 }
 
 static PyObject *rec_to_dict(const gitm_record *r) {
-    if (r->kind == REC_KERNEL) {
+    if (r->kind == GITM_REC_KERNEL) {
         return Py_BuildValue(
             "{s:s, s:s, s:K, s:K, s:I, s:I, s:I, s:I, s:[iii], s:[iii], s:i, s:i, s:i}",
             "kind", "kernel", "name", r->name,
@@ -224,7 +76,7 @@ static PyObject *rec_to_dict(const gitm_record *r) {
             "static_shared_mem", r->static_shared_mem,
             "dynamic_shared_mem", r->dynamic_shared_mem,
             "registers_per_thread", r->registers_per_thread);
-    } else if (r->kind == REC_MEMCPY) {
+    } else if (r->kind == GITM_REC_MEMCPY) {
         return Py_BuildValue(
             "{s:s, s:i, s:K, s:K, s:K, s:I, s:I, s:I, s:I}",
             "kind", "memcpy", "copy_kind", r->copy_kind,
@@ -246,40 +98,40 @@ static PyObject *rec_to_dict(const gitm_record *r) {
 
 static PyObject *py_stop(PyObject *self, PyObject *args) {
     (void)self; (void)args;
-    if (g_enabled) {
-        for (size_t i = 0; i < sizeof(ENABLED_KINDS) / sizeof(ENABLED_KINDS[0]); i++) {
-            cuptiActivityDisable(ENABLED_KINDS[i]);
-        }
-        CUptiResult st = cuptiActivityFlushAll(1 /* FORCE */);
-        if (st != CUPTI_SUCCESS) return set_cupti_error(st, "FlushAll");
-        g_enabled = 0;
-    }
+    CUptiResult st = gitm_cupti_stop();
+    if (st != CUPTI_SUCCESS) return set_cupti_error(st, "stop");
 
-    pthread_mutex_lock(&g_lock);
     PyObject *list = PyList_New((Py_ssize_t)g_count);
-    if (!list) { pthread_mutex_unlock(&g_lock); return NULL; }
+    if (!list) return NULL;
     for (size_t i = 0; i < g_count; i++) {
         PyObject *d = rec_to_dict(&g_records[i]);
-        if (!d) { Py_DECREF(list); pthread_mutex_unlock(&g_lock); return NULL; }
+        if (!d) { Py_DECREF(list); return NULL; }
         PyList_SET_ITEM(list, (Py_ssize_t)i, d);  /* steals ref */
     }
     g_count = 0;
-    pthread_mutex_unlock(&g_lock);
     return list;
 }
 
 static PyObject *py_device_count(PyObject *self, PyObject *args) {
     (void)self; (void)args;
-    int n = 0;
-    cudaError_t err = cudaGetDeviceCount(&n);
-    if (err != cudaSuccess) n = 0;  /* no CUDA devices visible */
-    return PyLong_FromLong(n);
+    return PyLong_FromLong(gitm_cuda_device_count());
+}
+
+/* Exposed so capture() can bound its window in the SAME clock domain as the
+ * activity records — the only way to tell which records from an injected child
+ * process fall inside the capture window. Safe to call without start(): reading
+ * the CUPTI clock does not register callbacks, so the parent can call this while
+ * the injection library owns collection. */
+static PyObject *py_timestamp(PyObject *self, PyObject *args) {
+    (void)self; (void)args;
+    return PyLong_FromUnsignedLongLong((unsigned long long)gitm_cupti_timestamp());
 }
 
 static PyMethodDef methods[] = {
     {"start", py_start, METH_NOARGS, "Enable CUPTI activity collection."},
     {"stop", py_stop, METH_NOARGS, "Flush and return the record dicts."},
     {"device_count", py_device_count, METH_NOARGS, "Number of CUPTI devices."},
+    {"timestamp", py_timestamp, METH_NOARGS, "CUPTI clock now (activity time base)."},
     {NULL, NULL, 0, NULL},
 };
 
@@ -288,7 +140,6 @@ static struct PyModuleDef moddef = {
     "CUPTI activity collection shim for GITM.", -1, methods,
     NULL, NULL, NULL, NULL,
 };
-
 PyMODINIT_FUNC PyInit__cupti_shim(void) {
     return PyModule_Create(&moddef);
 }


### PR DESCRIPTION
cupti_core.{c,h} (new) — shared, sink-agnostic CUPTI ingestion: buffer management, record walking, normalized gitm_record.
cupti_shim.c — trimmed to the CPython face; sink builds dicts. Adds timestamp().
cupti_inject.c (new) — no-libpython .so the CUDA driver injects into every process; writes per-pid JSONL shards. Lets us trace vLLM's child EngineCore.
build.py — shared _compile() helper; builds both the extension and libgitm_inject.so.