### PR TITLE
Kernel identity via NVTX correlation + fix autoresearch's +100% residual clamp

### DIFF
--- a/docs/kernel_identity.md
+++ b/docs/kernel_identity.md
@@ -1,0 +1,162 @@
+# Kernel identity: from name-substring tags to NVTX/correlation-id ranges
+
+## Problem
+
+Pairing an observed kernel to its predicted graph node (`gitm.optimizer.deviation.classify_op`)
+currently works by case-insensitive substring match against the kernel's mangled
+`name` string — `"qkv"` → `qkv_proj`, `"flash_fwd"` → `attn_score_value`, etc.
+
+This is a name *guess*, not an identity, and it fails silently on exactly the
+kernels that matter most: bare cuBLAS/cutlass GEMMs (e.g.
+`ampere_fp16_s16816gemm_fp16_128x128_...`) carry no projection tag in their
+name at all. Confirmed against a real vLLM/L4/CUPTI trace
+(`tests/test_deviation_alignment.py::test_classify_op_matches_real_vllm_kernel_names`):
+these are ~35% of launches, reused identically across qkv/out/gate_up/down/
+lm_head, and land as `<unmodeled>` — every departure on the dominant GEMM cost
+is invisible to the deviation monitor. It's also why `KernelResidual.layer` is
+hardcoded `None` today (`gitm/optimizer/monitor.py:50`): a name has no layer
+index to recover.
+
+## What correlation_id actually gives us (and what it doesn't)
+
+CUPTI's `correlationId` links a device-side `KERNEL` activity record to the
+host-side API call (`cudaLaunchKernel`/`cuLaunchKernel`) that issued it — both
+records carry the same id. **It is not, by itself, an op/layer identity.**
+Today's shim (`gitm/tracer/_cupti/cupti_shim.c`) only enables
+`CONCURRENT_KERNEL`, `MEMCPY`, `SYNCHRONIZATION` — it never enables the
+`RUNTIME` activity kind that would surface the host-side launch record, so
+`correlation_id` is currently decoded (`_cupti_decode.py:68`) but dangling:
+nothing on the host side to correlate it *against*.
+
+The actual identity source has to be a **name we control on the host side** —
+an NVTX range pushed around each op's forward call
+(`torch.cuda.nvtx.range_push(f"L{layer}/{op}")` ... `range_pop()`).
+`correlation_id` is the plumbing that lets a kernel find *which* NVTX range
+was open when it was launched; it is not the name itself. That's a scope
+correction from "just use correlation_id" — the real work is the NVTX
+instrumentation, correlation_id is how it gets attached to the kernel.
+
+## The correlation chain
+
+Three record kinds, two different clocks:
+
+```
+NVTX range   (host clock)  "L3/qkv_proj"  [range_start_ns, range_end_ns]
+     |  contains (host time)
+RUNTIME rec  (host clock)  cudaLaunchKernel  correlation_id=X  [host_start_ns, host_end_ns]
+     |  same correlation_id
+KERNEL rec   (device clock) correlation_id=X  [start_ns, end_ns]   <- what we capture today
+```
+
+**Correlation must chain kernel → RUNTIME (by `correlation_id`) → range (by
+host-timestamp containment of the RUNTIME record, not the kernel record).**
+Kernel timestamps are device-clock; range timestamps are host-clock. A kernel
+frequently finishes executing well after its enclosing range has popped
+(async launch) — testing containment of the kernel's own `[start_ns, end_ns]`
+against the range's host window will look correct on a synthetic same-clock
+test and produce silently wrong attributions on a real async trace. The
+RUNTIME record is the only one that shares a clock domain with the range.
+
+Also watch thread affinity: if the launching code is multi-threaded, ranges
+pushed on one thread must not swallow launches from another — match on the
+RUNTIME record's thread id, not just timestamp overlap.
+
+## Design
+
+### 1. Shim changes (`cupti_shim.c`) — needs a CUDA/GPU box, not buildable here
+
+- Enable `CUPTI_ACTIVITY_KIND_RUNTIME` (host-side launch-API records: name,
+  `correlationId`, host `start`/`end`, `threadId`).
+- Enable `CUPTI_ACTIVITY_KIND_MARKER` (+ `MARKER_DATA`) to capture NVTX
+  push/pop ranges as activity records (name, host timestamp, id).
+- New `gitm_record` kinds `REC_RUNTIME`, `REC_MARKER`; extend `rec_to_dict`.
+  Keep `ingest()`'s existing comment/lesson in mind — verify on real hardware
+  whether enabling these introduces the kind of duplicate/zeroed-timestamp
+  record pairing that `CONCURRENT_KERNEL` vs `KERNEL` did.
+
+### 2. Host-side range instrumentation — needs the attach mechanism verified first
+
+Register a pre/post-forward hook on each named submodule of the model
+(`model.layers.{i}.self_attn.qkv_proj`, `.o_proj`, `.mlp.gate_up_proj`, ...)
+that does `nvtx.range_push(f"L{i}/{op}")` / `range_pop()`. Near-zero overhead
+(host-side only), and the layer index falls out of the module's qualified
+name for free — the thing `classify_op` can never recover.
+
+This is trivial for the **in-process** path (`gitm/runtime_driver.py` already
+runs `work()` inside the process holding the model — hooks register directly
+on the live `nn.Module` tree before `capture()` starts). It is *not* trivial
+for the **out-of-process attach** path (`gitm/deploy/attach.py`): that module's
+docstring describes "install removable telemetry shim into the job's
+user-space env" but the actual injection mechanism into an already-running
+PID isn't implemented in what I've read — `attach_job` only resolves a PID
+and returns a plan. Land this against the in-process path first; treat attach
+injection as a separate, explicitly-scoped follow-up once that mechanism
+exists (I've asked a background research agent to confirm this reading before
+we commit to it).
+
+### 3. Decode/correlate (`_cupti_decode.py`)
+
+New function, pure Python, unit-testable without a GPU:
+
+```python
+def correlate_kernels_to_ranges(records: list[dict]) -> list[dict]:
+    """Attach range_op/range_layer to kernel dicts via correlation_id.
+
+    kernel.correlation_id -> RUNTIME record (same correlation_id) -> host
+    [start_ns, end_ns] -> innermost open MARKER range containing that host
+    window, matched on thread_id. Kernels with no match keep
+    range_op=None (falls back to name-based classify_op downstream).
+    """
+```
+
+### 4. Schema (`gitm/tracer/schema.py`)
+
+Add two optional fields to `KernelEvent`, default `None` — backward compatible
+with existing trace JSONL files:
+
+```python
+range_op: str | None = None
+range_layer: int | None = None
+```
+
+### 5. Pairing (`gitm/optimizer/deviation.py`, `gitm/optimizer/monitor.py`)
+
+`classify_op` stays as-is (it's still the fallback for unlabeled traces — HFT,
+edge, or any capture without NVTX instrumentation). Both `residuals()` and
+`deviating_kernel_indices()` change their op lookup to:
+
+```python
+op = ok.range_op or classify_op(ok.name)
+layer = ok.range_layer  # real layer index when range-identified, else None
+```
+
+This is a strict superset of current behavior: no range → identical to today.
+Range present → exact identity (recovers the ~35% unmodeled GEMMs, since
+they're inside a hooked module's forward regardless of their opaque name) and
+a real `layer`, which `KernelResidual.layer` and `Violation.layer` can finally
+carry instead of always `None`.
+
+## What's testable on this machine vs. not
+
+| Piece | Testable here (no GPU) |
+|---|---|
+| `KernelEvent.range_op`/`range_layer` schema fields | Yes |
+| `correlate_kernels_to_ranges()` — synthetic RUNTIME/MARKER dicts | Yes — extend `tests/test_deviation_alignment.py`'s `_k()` helper |
+| Pairing fallback logic in `deviation.py`/`monitor.py` | Yes |
+| CUPTI shim RUNTIME/MARKER activity kinds | No — needs CUDA toolkit + GPU |
+| NVTX forward-hook instrumentation, in-process | No — needs `torch`+CUDA to actually exercise, but the hook logic itself can be written and reviewed here |
+| Out-of-process attach injection | Blocked on confirming the attach mechanism exists at all |
+
+## Plan
+
+1. Schema fields + `correlate_kernels_to_ranges()` + pairing fallback, with
+   synthetic-record unit tests — buildable and testable on this box.
+2. NVTX forward-hook module (in-process path) — written here, exercised on a
+   GPU box.
+3. Shim `RUNTIME`/`MARKER` activity kinds — written here, built and verified
+   on a GPU box (duplicate/zeroed-timestamp check per the existing
+   `CONCURRENT_KERNEL` lesson).
+4. Attach-path injection — separate follow-up, scoped after confirming the
+   attach mechanism.
+
+Starting with (1) now.

--- a/gitm/optimizer/deviation.py
+++ b/gitm/optimizer/deviation.py
@@ -140,7 +140,7 @@ def deviating_kernel_indices(
 
     kept: list[int] = []
     for i, ok in enumerate(obs):
-        op = classify_op(ok.name)
+        op = ok.range_op or classify_op(ok.name)
         pn = by_op.get(op) if op is not None else None
         if pn is None:
             kept.append(i)  # unmodeled op → keep as a departure
@@ -172,15 +172,17 @@ def deviation_summary(
 ) -> dict:
     """Compact summary of the deviation filter — for the run dir / report.
 
-    ``kept_ops`` counts departures per *classified* op (the observed kernel's own
-    op, via :func:`classify_op`), so the report says which ops actually departed —
-    ``<unmodeled>`` for kernels that map to no predicted op.
+    ``kept_ops`` counts departures per op — the kernel's NVTX-range identity
+    when the capture has it, else its :func:`classify_op` name guess — so the
+    report says which ops actually departed. ``<unmodeled>`` for kernels that
+    map to no predicted op either way.
     """
     obs = trace.kernels()
     dev = deviating_kernel_indices(trace, graph, invariants)
     kept_ops: dict[str, int] = {}
     for i in dev.kept_indices:
-        op = classify_op(obs[i].name) or "<unmodeled>"
+        ok = obs[i]
+        op = ok.range_op or classify_op(ok.name) or "<unmodeled>"
         kept_ops[op] = kept_ops.get(op, 0) + 1
     return {
         "n_observed": dev.n_observed,

--- a/gitm/optimizer/monitor.py
+++ b/gitm/optimizer/monitor.py
@@ -44,12 +44,14 @@ def residuals(trace: Trace, graph: Graph) -> Residuals:
 
     The old ordinal pairing matched a handful of early kernels against
     unrelated ops (orders of magnitude fewer predicted nodes than real
-    kernels), producing runaway r_kt ratios. Each kernel is now classified by
-    name (:func:`gitm.optimizer.deviation.classify_op`) against one
-    representative node per op (per-layer nodes share a prediction);
-    unmodeled kernels get no residual, and ``layer`` is always ``None``
-    (unrecoverable from name-based classification). Carries the matched op's
-    roofline ``bound`` for bottleneck classification.
+    kernels), producing runaway r_kt ratios. Each kernel is classified by its
+    NVTX-range identity when the capture has one (``range_op``/``range_layer``
+    — see :mod:`gitm.tracer.nvtx_correlate`), else by name
+    (:func:`gitm.optimizer.deviation.classify_op`) against one representative
+    node per op (per-layer nodes share a prediction); unmodeled kernels get no
+    residual. ``layer`` is the real per-kernel layer index when range-
+    identified, else ``None`` (unrecoverable from a name guess alone). Carries
+    the matched op's roofline ``bound`` for bottleneck classification.
     """
     obs = trace.kernels()
     pred = graph.nodes
@@ -60,7 +62,7 @@ def residuals(trace: Trace, graph: Graph) -> Residuals:
         by_op.setdefault(pn.op, pn)
 
     for ok in obs:
-        op = classify_op(ok.name)
+        op = ok.range_op or classify_op(ok.name)
         pn = by_op.get(op) if op is not None else None
         if pn is None:
             continue
@@ -76,7 +78,7 @@ def residuals(trace: Trace, graph: Graph) -> Residuals:
 
         res.per_kernel.append(
             KernelResidual(
-                op=pn.op, layer=None, r_kt=r_kt, r_mt=r_mt,
+                op=pn.op, layer=ok.range_layer, r_kt=r_kt, r_mt=r_mt,
                 t_obs_s=t_obs, t_pred_s=t_pred, bound=pn.prediction.bound,
             )
         )

--- a/gitm/planner/context.py
+++ b/gitm/planner/context.py
@@ -19,9 +19,13 @@ from typing import Any
 
 from gitm.optimizer.metrics import HardwarePeak
 from gitm.optimizer.preconditions import GateContext
+from gitm.planner.roofline import HardwareSpec
 
 # Dense fp16/bf16 tensor-core peaks (FLOP/s) and HBM bandwidth (bytes/s) by SKU
-# substring. Conservative vendor figures; used for HFU/MFU/MBU denominators.
+# substring. Conservative vendor figures; used for HFU/MFU/MBU denominators
+# (below) and, via :func:`hardware_spec_for`, for the roofline prediction
+# itself. "L40" must stay ordered before "L4" (see peak_for_sku) since "l4" is
+# a substring of "l40" and the first substring match wins.
 _PEAKS: dict[str, tuple[float, float]] = {
     "H100": (989e12, 3350e9),
     "H200": (989e12, 4800e9),
@@ -29,6 +33,7 @@ _PEAKS: dict[str, tuple[float, float]] = {
     "A100": (312e12, 1555e9),  # PCIe / 40GB fallback
     "L40": (181e12, 864e9),
     "L4": (121e12, 300e9),
+    "T4": (65e12, 320e9),  # the common free-tier Colab GPU
     "V100": (125e12, 900e9),
 }
 
@@ -77,6 +82,26 @@ def peak_for_sku(sku: str | None) -> HardwarePeak | None:
         if key.lower() in sku.lower():
             return HardwarePeak(name=sku, peak_flops=flops, peak_bw_bytes_s=bw)
     return None
+
+
+def hardware_spec_for(peak: HardwarePeak | None) -> HardwareSpec:
+    """Roofline :class:`HardwareSpec` for the detected GPU peak.
+
+    Falls back to ``HardwareSpec()`` (A100-SXM4-80GB) when the SKU wasn't
+    recognized (unknown NVML name, ``GITM_GPU_SKU`` unset, no GPU) — the same
+    default ``predict_graph`` silently used everywhere before this existed.
+    ``peak_flops`` covers fp16/bf16 (the only dtypes the decode graph
+    predicts); fp32 peak isn't in the catalogue and stays at the dataclass
+    default since nothing currently predicts fp32 kernels.
+    """
+    if peak is None:
+        return HardwareSpec()
+    return HardwareSpec(
+        name=peak.name,
+        peak_flops_fp16_per_s=peak.peak_flops,
+        peak_flops_bf16_per_s=peak.peak_flops,
+        peak_mem_bw_bytes_per_s=peak.peak_bw_bytes_s,
+    )
 
 
 def _engine_dtype(engine: Any) -> str | None:

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -47,7 +47,7 @@ from gitm.optimizer.vllm_knobs import (
     knob_kind,
     unmet_prerequisite,
 )
-from gitm.planner.context import build_planner_context
+from gitm.planner.context import build_planner_context, hardware_spec_for
 from gitm.planner.graph import predict_graph
 from gitm.safety.audit import AuditLog, _write_report
 from gitm.tracer.capture import capture
@@ -405,10 +405,22 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     # not the Llama-2-7B default — otherwise residuals/deviation score the real
     # kernels against the wrong graph. Falls back to the default graph when there
     # is no engine or its config can't be read (CPU boxes, tests, dry-run).
+    #
+    # Same for hardware: predict_graph's own default is A100-SXM4-80GB peaks,
+    # which silently over-predicts on anything weaker (T4/L4/...) and
+    # produces a run-level kernel-time residual that saturates the report's
+    # +/-100% clamp on every claim. pctx is built here (moved up from Phase 3)
+    # so its NVML-detected SKU peak feeds the graph before residuals are ever
+    # computed against it.
+    pctx = build_planner_context(cfg.engine, workload=workload)
     _spec = _model_spec_from_engine(cfg.engine)
-    graph = predict_graph(model=_spec) if _spec is not None else predict_graph()
+    _hw = hardware_spec_for(pctx.peak)
+    graph = predict_graph(model=_spec, hw=_hw) if _spec is not None else predict_graph(hw=_hw)
     (run_dir / "predicted_graph.json").write_text(
-        json.dumps({"nodes": len(graph.nodes), "total_pred_s": graph.total_pred_s}, indent=2)
+        json.dumps(
+            {"nodes": len(graph.nodes), "total_pred_s": graph.total_pred_s, "hardware": _hw.name},
+            indent=2,
+        )
     )
 
     # Phase 2 — residuals + attribution
@@ -472,7 +484,7 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
         write_deviation_jsonl(deviation_trace(trace, graph), run_dir / "deviation_trace.jsonl")
 
     # Phase 3 — library + counterfactual replay ranking
-    pctx = build_planner_context(cfg.engine, workload = workload)
+    # pctx was built earlier (Phase 1) so its hardware peak could feed predict_graph.
     # Relative/swept levers resolve against the live engine here, once, before
     # ranking. See expand_relative_candidates.
     library = [

--- a/gitm/tracer/_cupti_decode.py
+++ b/gitm/tracer/_cupti_decode.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from gitm.tracer.nvtx_correlate import correlate_kernels_to_ranges
 from gitm.tracer.schema import KernelEvent, MemcpyEvent, SyncEvent, TraceEvent
 
 Endpoint = Literal["host", "device", "unified"]
@@ -71,6 +72,8 @@ def decode_kernel(d: dict) -> KernelEvent:
         block_x=int(block[0]), block_y=int(block[1]), block_z=int(block[2]),
         shared_mem_bytes=int(d.get("static_shared_mem", 0)) + int(d.get("dynamic_shared_mem", 0)),
         registers_per_thread=int(d.get("registers_per_thread", 0)),
+        range_op=d.get("range_op"),
+        range_layer=_opt_int(d.get("range_layer")),
     )
 
 
@@ -111,10 +114,24 @@ def decode_record(d: dict) -> TraceEvent | None:
 def decode_records(records: list[dict]) -> list[TraceEvent]:
     """Decode a shim record batch, dropping unmodeled kinds, sorted by start.
 
+    Kernel dicts are first run through :func:`correlate_kernels_to_ranges` so
+    ``range_op``/``range_layer`` are populated whenever the capture carries
+    NVTX range instrumentation (``runtime``/``marker`` records) — a no-op
+    today since the shim doesn't emit those kinds yet, and harmless on any
+    trace that doesn't have them (``decode_kernel`` just sees ``None``).
+    ``runtime``/``marker`` records themselves are consumed by correlation and
+    never reach ``_DECODERS`` — GITM doesn't model them as events.
+
     Sorting by ``start_ns`` gives a stable timeline regardless of the order
     CUPTI flushed buffers (concurrent kernels on multiple streams interleave).
     """
-    events = [ev for d in records if (ev := decode_record(d)) is not None]
+    enriched_kernels = iter(correlate_kernels_to_ranges(records))
+    events: list[TraceEvent] = []
+    for d in records:
+        if d.get("kind") == "kernel":
+            events.append(decode_kernel(next(enriched_kernels)))
+        elif (ev := decode_record(d)) is not None:
+            events.append(ev)
     events.sort(key=lambda e: e.start_ns)
     return events
 

--- a/gitm/tracer/nvtx_correlate.py
+++ b/gitm/tracer/nvtx_correlate.py
@@ -1,0 +1,105 @@
+"""Kernel identity via NVTX range correlation — see ``docs/kernel_identity.md``.
+
+Attaches an exact ``op``/``layer`` to a kernel dict when the capture has NVTX
+range instrumentation, instead of guessing from the mangled kernel name
+(:func:`gitm.optimizer.deviation.classify_op`).
+
+The chain uses three record kinds on two different clocks — a kernel's own
+timestamps are device-clock and must never be compared directly against a
+range's host-clock window (async execution means a kernel routinely finishes
+long after its range popped):
+
+    kernel   (device clock)  correlation_id=X            [start_ns, end_ns]
+        |  same correlation_id
+    runtime  (host clock)    cudaLaunchKernel  id=X       [start_ns, end_ns], thread_id
+        |  host-timestamp containment, same thread_id
+    marker   (host clock)    NVTX range "L{layer}/{op}"   [start_ns, end_ns], thread_id
+
+Dict contract this module expects (not yet emitted by ``cupti_shim.c`` — the
+shim today only emits ``kernel``/``memcpy``/``sync``; ``runtime``/``marker``
+are the pending CUPTI activity kinds ``RUNTIME`` and ``MARKER``):
+
+    runtime  {kind:"runtime", correlation_id:int, start_ns:int, end_ns:int,
+              thread_id:int}
+    marker   {kind:"marker", name:str, start_ns:int, end_ns:int, thread_id:int}
+
+A ``marker`` record here is one fully-resolved push/pop range (start/end
+already paired) — folding raw NVTX push/pop activity records into ranges is
+shim/decoder work tracked separately in the design doc.
+"""
+
+from __future__ import annotations
+
+import re
+
+_RANGE_NAME_RE = re.compile(r"^L(\d+)/(.+)$")
+
+
+def parse_range_name(name: str) -> tuple[str, int | None]:
+    """Parse an NVTX range name into ``(op, layer)``.
+
+    ``"L3/qkv_proj"`` -> ``("qkv_proj", 3)``. A range with no layer prefix
+    (e.g. ``"lm_head"``, which runs once, not per-layer) -> ``(name, None)``.
+    """
+    m = _RANGE_NAME_RE.match(name)
+    if m:
+        return m.group(2), int(m.group(1))
+    return name, None
+
+
+def correlate_kernels_to_ranges(records: list[dict]) -> list[dict]:
+    """Return every ``kind == "kernel"`` dict from ``records``, enriched.
+
+    Each returned dict is a shallow copy of the input kernel dict with
+    ``range_op``/``range_layer`` keys added (both ``None`` when no match is
+    found — no runtime record for the kernel's ``correlation_id``, or no
+    marker range whose host window contains that runtime record). Order is
+    preserved. ``runtime``/``marker`` records are consumed only to build the
+    correlation index; they are not returned.
+
+    Containment is checked on the *runtime* record's host window against the
+    marker's host window, matched on ``thread_id`` — never the kernel's own
+    (device-clock) window, and never across threads. When multiple markers
+    contain the runtime window (nested ranges), the innermost (smallest span)
+    wins.
+    """
+    runtime_by_corr: dict[int, dict] = {}
+    markers: list[dict] = []
+    kernels: list[dict] = []
+
+    for r in records:
+        kind = r.get("kind")
+        if kind == "kernel":
+            kernels.append(r)
+        elif kind == "runtime":
+            cid = r.get("correlation_id")
+            if cid is not None:
+                runtime_by_corr[cid] = r
+        elif kind == "marker":
+            markers.append(r)
+
+    out: list[dict] = []
+    for k in kernels:
+        enriched = dict(k)
+        enriched["range_op"] = None
+        enriched["range_layer"] = None
+
+        rt = runtime_by_corr.get(k.get("correlation_id"))
+        if rt is not None:
+            best: dict | None = None
+            best_span = None
+            for m in markers:
+                if m.get("thread_id") != rt.get("thread_id"):
+                    continue
+                if m["start_ns"] <= rt["start_ns"] and rt["end_ns"] <= m["end_ns"]:
+                    span = m["end_ns"] - m["start_ns"]
+                    if best_span is None or span < best_span:
+                        best, best_span = m, span
+            if best is not None:
+                op, layer = parse_range_name(best["name"])
+                enriched["range_op"] = op
+                enriched["range_layer"] = layer
+
+        out.append(enriched)
+
+    return out

--- a/gitm/tracer/schema.py
+++ b/gitm/tracer/schema.py
@@ -35,6 +35,12 @@ class KernelEvent(_TraceEventBase):
     registers_per_thread: int = 0
     bytes_read: int | None = None  # filled by attribution layer when available
     bytes_written: int | None = None
+    # Exact op/layer identity recovered from an enclosing NVTX range (see
+    # gitm.tracer.nvtx_correlate), when the capture had range instrumentation.
+    # None means no range was found — callers fall back to name-based
+    # classify_op(). Never guessed or backfilled; only set by correlation.
+    range_op: str | None = None
+    range_layer: int | None = None
 
 
 class MemcpyEvent(_TraceEventBase):

--- a/tests/test_deviation_alignment.py
+++ b/tests/test_deviation_alignment.py
@@ -16,9 +16,13 @@ from gitm.planner.graph import predict_graph
 from gitm.tracer.schema import KernelEvent, Trace
 
 
-def _k(name: str, dur_s: float, t0: int = 0) -> KernelEvent:
+def _k(
+    name: str, dur_s: float, t0: int = 0,
+    range_op: str | None = None, range_layer: int | None = None,
+) -> KernelEvent:
     return KernelEvent(
-        name=name, start_ns=t0, end_ns=t0 + int(dur_s * 1e9), stream_id=0, device_id=0
+        name=name, start_ns=t0, end_ns=t0 + int(dur_s * 1e9), stream_id=0, device_id=0,
+        range_op=range_op, range_layer=range_layer,
     )
 
 
@@ -80,6 +84,39 @@ def test_summary_keys_by_the_observed_kernels_op():
     ])
     summary = deviation_summary(tr, g)
     assert summary["kept_ops"] == {"attn_score_value": 1, "<unmodeled>": 1}
+
+
+def test_range_identity_classifies_a_bare_gemm_that_name_matching_cannot():
+    """The dominant real-world gap: bare cuBLAS/cutlass GEMMs carry no
+    projection tag in their name (test_classify_op_matches_real_vllm_kernel_names
+    above), so classify_op alone always calls them unmodeled. An NVTX range
+    identity sidesteps the name entirely."""
+    g = predict_graph()
+    t_qkv = next(n.prediction.t_pred_s for n in g.nodes if n.op == "qkv_proj")
+    bare_gemm = "ampere_fp16_s16816gemm_fp16_128x128_ldg8_relu_f2f_stages_32x5_tn"
+    assert classify_op(bare_gemm) is None  # unattributable by name alone
+
+    tr = _trace([_k(bare_gemm, t_qkv * 8, range_op="qkv_proj", range_layer=1)])
+    dev = deviating_kernel_indices(tr, g)
+    assert dev.kept_indices == [0]  # correctly identified and flagged as a departure
+
+    summary = deviation_summary(tr, g)
+    assert summary["kept_ops"] == {"qkv_proj": 1}  # not "<unmodeled>"
+
+
+def test_range_identity_takes_priority_over_name_classification():
+    """Name says attention (would classify to attn_score_value); the range
+    identity says qkv_proj -- range wins, and recovers the real layer, which
+    name-based classification can never do."""
+    from gitm.optimizer.monitor import residuals
+
+    g = predict_graph()
+    t_qkv = next(n.prediction.t_pred_s for n in g.nodes if n.op == "qkv_proj")
+    tr = _trace([_k("flash_attn_kernel", t_qkv, range_op="qkv_proj", range_layer=5)])
+    res = residuals(tr, g)
+    assert len(res.per_kernel) == 1
+    assert res.per_kernel[0].op == "qkv_proj"
+    assert res.per_kernel[0].layer == 5
 
 
 def test_no_predicted_graph_keeps_everything():

--- a/tests/test_nvtx_correlate.py
+++ b/tests/test_nvtx_correlate.py
@@ -1,0 +1,103 @@
+"""correlate_kernels_to_ranges: kernel -> runtime (by correlation_id) -> NVTX
+range (by host-timestamp containment on the runtime record, never the
+kernel's own device-clock window). See docs/kernel_identity.md.
+"""
+
+from __future__ import annotations
+
+from gitm.tracer.nvtx_correlate import correlate_kernels_to_ranges, parse_range_name
+
+
+def _kernel(name: str, corr_id: int, dev_start: int, dev_end: int) -> dict:
+    return {
+        "kind": "kernel", "name": name, "correlation_id": corr_id,
+        "start_ns": dev_start, "end_ns": dev_end,
+    }
+
+
+def _runtime(corr_id: int, thread_id: int, host_start: int, host_end: int) -> dict:
+    return {
+        "kind": "runtime", "correlation_id": corr_id, "thread_id": thread_id,
+        "start_ns": host_start, "end_ns": host_end,
+    }
+
+
+def _marker(name: str, thread_id: int, start: int, end: int) -> dict:
+    return {"kind": "marker", "name": name, "thread_id": thread_id, "start_ns": start, "end_ns": end}
+
+
+def test_parse_range_name():
+    assert parse_range_name("L3/qkv_proj") == ("qkv_proj", 3)
+    assert parse_range_name("L0/attn_out_proj") == ("attn_out_proj", 0)
+    assert parse_range_name("lm_head") == ("lm_head", None)
+
+
+def test_full_chain_correlates_by_correlation_id_and_host_containment():
+    # Device-clock kernel window (100..900) is *outside* the host-clock range
+    # window (1000..1100) on purpose -- async execution. Containment must go
+    # through the runtime record's host window (1000..1050), not the kernel's.
+    records = [
+        _marker("L2/qkv_proj", thread_id=1, start=1000, end=1100),
+        _runtime(corr_id=7, thread_id=1, host_start=1000, host_end=1050),
+        _kernel("ampere_fp16_s16816gemm_128x128", corr_id=7, dev_start=100, dev_end=900),
+    ]
+    out = correlate_kernels_to_ranges(records)
+    assert len(out) == 1
+    assert out[0]["range_op"] == "qkv_proj"
+    assert out[0]["range_layer"] == 2
+    # original kernel fields preserved
+    assert out[0]["name"] == "ampere_fp16_s16816gemm_128x128"
+
+
+def test_no_runtime_record_leaves_range_unset():
+    records = [_kernel("mystery_kernel", corr_id=1, dev_start=0, dev_end=10)]
+    out = correlate_kernels_to_ranges(records)
+    assert out[0]["range_op"] is None
+    assert out[0]["range_layer"] is None
+
+
+def test_runtime_outside_every_marker_leaves_range_unset():
+    records = [
+        _marker("L0/qkv_proj", thread_id=1, start=0, end=100),
+        _runtime(corr_id=1, thread_id=1, host_start=200, host_end=250),  # after the range closed
+        _kernel("k", corr_id=1, dev_start=200, dev_end=300),
+    ]
+    out = correlate_kernels_to_ranges(records)
+    assert out[0]["range_op"] is None
+
+
+def test_different_thread_marker_is_not_matched():
+    records = [
+        _marker("L0/qkv_proj", thread_id=2, start=0, end=1000),  # different thread
+        _runtime(corr_id=1, thread_id=1, host_start=100, host_end=150),
+        _kernel("k", corr_id=1, dev_start=100, dev_end=150),
+    ]
+    out = correlate_kernels_to_ranges(records)
+    assert out[0]["range_op"] is None
+
+
+def test_nested_ranges_pick_innermost():
+    records = [
+        _marker("L1/mlp_gate_up", thread_id=1, start=0, end=1000),   # outer
+        _marker("silu_and_mul", thread_id=1, start=100, end=200),     # inner, no layer prefix
+        _runtime(corr_id=1, thread_id=1, host_start=120, host_end=150),
+        _kernel("k", corr_id=1, dev_start=120, dev_end=150),
+    ]
+    out = correlate_kernels_to_ranges(records)
+    assert out[0]["range_op"] == "silu_and_mul"
+    assert out[0]["range_layer"] is None
+
+
+def test_multiple_kernels_preserve_order_and_independent_matches():
+    records = [
+        _marker("L0/qkv_proj", thread_id=1, start=0, end=100),
+        _runtime(corr_id=1, thread_id=1, host_start=10, host_end=20),
+        _kernel("first", corr_id=1, dev_start=10, dev_end=20),
+        _marker("L0/attn_out_proj", thread_id=1, start=100, end=200),
+        _runtime(corr_id=2, thread_id=1, host_start=110, host_end=120),
+        _kernel("second", corr_id=2, dev_start=110, dev_end=120),
+    ]
+    out = correlate_kernels_to_ranges(records)
+    assert [o["name"] for o in out] == ["first", "second"]
+    assert out[0]["range_op"] == "qkv_proj"
+    assert out[1]["range_op"] == "attn_out_proj"

--- a/tests/test_vllm_embodiment.py
+++ b/tests/test_vllm_embodiment.py
@@ -90,6 +90,62 @@ def test_unknown_sku_yields_no_peak(monkeypatch):
     assert pctx.peak is None  # unknown => unreported, never wrong
 
 
+def test_t4_and_l4_skus_resolve_distinct_peaks(monkeypatch):
+    """The two common free/cheap Colab GPUs must not collide (T4 is weaker in
+    both compute and bandwidth than L4) and must not match the L40 entry."""
+    from gitm.planner.context import build_planner_context
+
+    monkeypatch.setenv("GITM_GPU_SKU", "Tesla T4")
+    t4 = build_planner_context(engine=None, num_gpus=1).peak
+    assert t4 is not None and t4.peak_flops == 65e12 and t4.peak_bw_bytes_s == 320e9
+
+    monkeypatch.setenv("GITM_GPU_SKU", "NVIDIA L4")
+    l4 = build_planner_context(engine=None, num_gpus=1).peak
+    assert l4 is not None and l4.peak_flops == 121e12 and l4.peak_bw_bytes_s == 300e9
+
+    monkeypatch.setenv("GITM_GPU_SKU", "NVIDIA L40S")
+    l40 = build_planner_context(engine=None, num_gpus=1).peak
+    assert l40 is not None and l40.peak_flops == 181e12  # not the L4 entry
+
+
+def test_hardware_spec_for_uses_detected_peak_not_default():
+    from gitm.optimizer.metrics import HardwarePeak
+    from gitm.planner.context import hardware_spec_for
+
+    l4_peak = HardwarePeak(name="NVIDIA L4", peak_flops=121e12, peak_bw_bytes_s=300e9)
+    hw = hardware_spec_for(l4_peak)
+    assert hw.name == "NVIDIA L4"
+    assert hw.peak_flops_fp16_per_s == 121e12
+    assert hw.peak_flops_bf16_per_s == 121e12
+    assert hw.peak_mem_bw_bytes_per_s == 300e9
+
+
+def test_hardware_spec_for_falls_back_to_default_on_unknown_sku():
+    from gitm.planner.context import hardware_spec_for
+    from gitm.planner.roofline import HardwareSpec
+
+    assert hardware_spec_for(None) == HardwareSpec()
+
+
+def test_predict_graph_on_l4_predicts_slower_than_default_a100():
+    """The actual bug this closes: without a real hw peak, predict_graph
+    silently assumes A100-SXM4-80GB and drastically over-predicts throughput
+    on a weaker GPU, which is what pushed the run-level kernel-time residual
+    past the report's +/-100% clamp on every claim (see docs/kernel_identity.md
+    -- gitm/scheduler/loop.py wiring)."""
+    from gitm.optimizer.metrics import HardwarePeak
+    from gitm.planner.context import hardware_spec_for
+    from gitm.planner.graph import predict_graph
+
+    l4_peak = HardwarePeak(name="NVIDIA L4", peak_flops=121e12, peak_bw_bytes_s=300e9)
+    default_graph = predict_graph()
+    l4_graph = predict_graph(hw=hardware_spec_for(l4_peak))
+    # L4 has ~6.8x less memory bandwidth than the A100-SXM default, and decode
+    # is memory-traffic dominated -- predicted time on L4 must be materially
+    # higher (never equal, never lower) for every predicted node.
+    assert l4_graph.total_pred_s > default_graph.total_pred_s * 2
+
+
 # --------------------------------------------------------------------------- #
 # library + policy: workload filter and gate-driven selection                 #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Two related fixes to how kernel time/identity is tracked, from investigating why the autoresearch pathway showed +100% kernel-time residual on every suggestion:

- **Kernel identity (NVTX range correlation).** `classify_op()` pairs an observed kernel to its predicted graph node by substring-matching the mangled kernel name. Confirmed against a real vLLM/L4/CUPTI trace, this misses ~35% of launches — bare cuBLAS/cutlass GEMMs shared across every projection carry no name tag and land as unmodeled work. Adds a second identity path: an NVTX range pushed on the host around each op's forward call, correlated to its kernel via CUPTI's `correlation_id` (kernel → host launch-API record → enclosing range, matched on host clock + thread — never the kernel's own device-clock window, which would silently misattribute under async execution). `KernelEvent` gains optional `range_op`/`range_layer`; `deviation.py`/`monitor.py` prefer the range identity when present and fall back to `classify_op()` otherwise — a strict no-op on any trace without range instrumentation. Also recovers a real per-kernel layer index, which name classification could never do. The CUPTI shim (`RUNTIME`/`MARKER` activity kinds) and the NVTX host instrumentation itself need a GPU box to build/exercise and aren't included — full design and remaining steps in `docs/kernel_identity.md`.

- **The actual root cause of "+100% on every suggestion."** `predict_graph()` defaulted to `HardwareSpec()`'s A100-SXM4-80GB peaks regardless of the GPU actually running the workload. On an L4 (real GPU in play here — 121 TFLOPS vs A100's 312, 300 GB/s vs 2039 GB/s), every kernel's predicted time was far too optimistic, pushing the run-level kernel-time residual (broadcast to every claim in the report) past the ±100% clamp uniformly. `build_planner_context()` already NVML-detects the GPU SKU and its peak FLOPs/bandwidth, but that peak only fed the precondition gate, computed *after* `predict_graph` had already run with the default. Moved it earlier and added `hardware_spec_for()` to convert the detected peak into a roofline `HardwareSpec`, so any cataloged SKU corrects the prediction going forward — not just L4. Added a `T4` catalogue entry (the common free-tier Colab GPU, previously missing); L4 was already cataloged but unused.

Ordinal (positional) kernel pairing was considered and rejected — it was already tried and removed from this codebase (see `deviation.py`'s docstring) specifically because it flagged ~everything uniformly under CUDA graphs, which is the same failure mode as the bug this PR fixes, not a solution to it.

**Known caveat, not fixed here:** `roofline()` predicts off theoretical peak with no efficiency factor (`HardwareSpec.eff_lo`/`eff_hi` are defined but never applied). If real decode kernels only achieve a fraction of a GPU's peak bandwidth, the residual could still approach the clamp even with correct hardware now wired in. Flagged for a follow-up once we can confirm against a real run whether this is still needed.

## Test plan

- [x] `pytest tests/` — full suite passes except 6 pre-existing failures unrelated to this change (missing `pyarrow`/`toml` in this dev environment, all in HFT benchmark tests)
- [x] New tests: `tests/test_nvtx_correlate.py` (correlation chain, async-clock trap, cross-thread rejection, range nesting), extended `tests/test_deviation_alignment.py` (range identity beats name classification, recovers the real GEMM-identity gap), extended `tests/test_vllm_embodiment.py` (T4/L4/L40 SKU resolution, `hardware_spec_for` conversion, L4 predicts materially slower than the old A100 default)
- [x] `ruff check` clean on all changed files
- [x] `mypy` — no new errors beyond the pre-existing baseline (verified via `git stash` diff)
- [ ] Not verified on real hardware: NVTX/shim pieces need a GPU box; the hardware-peak fix itself should be re-run on the reporting Colab L4 to confirm the +100% clamp clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)