### PR TITLE
fix: derive tensor-parallel size from GPUs / DP, and check the world size

### DIFF
--- a/scripts/serve_capture.py
+++ b/scripts/serve_capture.py
@@ -320,25 +320,54 @@ def check_serve_args(serve_argv: list[str]) -> list[Check]:
     return [Check("serve-args", "fail", f"vLLM rejects these flags:\n{out[-800:]}")]
 
 
-def resolve_tp(serve_argv: list[str], devices: Devices, override: int | None) -> int:
-    """Tensor-parallel size for this run: explicit wins, else the whole box.
+def resolve_dp(serve_argv: list[str]) -> int:
+    """Data-parallel size from the serve command (1 when unset)."""
+    raw = _arg_of(serve_argv, "--data-parallel-size") or _arg_of(serve_argv, "-dp")
+    return int(raw) if raw and raw.isdigit() else 1
 
-    Defaulting to every visible GPU is what makes one command correct on a 2x and a
-    4x pod. Falls back to 1 rather than 0 when no GPU is visible, so the preflight
-    reports "no GPUs" instead of a nonsense TP.
+
+def resolve_tp(serve_argv: list[str], devices: Devices, override: int | None) -> int:
+    """Tensor-parallel size for this run: explicit wins, else the box divided by DP.
+
+    vLLM's world size is TP x DP, so "default to every visible GPU" is only right
+    when DP=1. With ``--data-parallel-size 4`` on a 4-GPU box the correct TP is 1;
+    filling in 4 would ask for 16 GPUs and die in distributed init. Falls back to 1
+    rather than 0 so a CPU box reports "no GPUs" instead of a nonsense TP.
     """
     explicit = _arg_of(serve_argv, "--tensor-parallel-size") or _arg_of(serve_argv, "-tp")
     if explicit and explicit.isdigit():
         return int(explicit)
     if override:
         return override
-    return max(devices.count, 1)
+    return max(devices.count // max(resolve_dp(serve_argv), 1), 1)
+
+
+def check_world(tp: int, dp: int, devices: Devices) -> list[Check]:
+    """vLLM needs exactly TP x DP GPUs. Catch the mismatch before distributed init.
+
+    Asking for more ranks than exist fails somewhere deep in NCCL bootstrap with a
+    message that does not mention either flag. Asking for fewer silently leaves GPUs
+    idle, which is worse: the run succeeds and the throughput number is quietly wrong.
+    """
+    world = tp * dp
+    if devices.count == 0:
+        return []
+    if world > devices.count:
+        return [Check("world-size", "fail",
+                      f"TP={tp} x DP={dp} needs {world} GPUs, only {devices.count} visible")]
+    if world < devices.count:
+        return [Check("world-size", "warn",
+                      f"TP={tp} x DP={dp} uses {world} of {devices.count} GPUs — "
+                      f"{devices.count - world} idle, so per-GPU throughput is not "
+                      f"comparable with a run that uses the whole box")]
+    return [Check("world-size", "pass", f"TP={tp} x DP={dp} = {world} GPUs")]
 
 
 def preflight(serve_argv: list[str], devices: Devices, tp: int,
               *, skip_args: bool = False) -> list[Check]:
     checks: list[Check] = []
     checks += check_gpus(tp, devices)
+    checks += check_world(tp, resolve_dp(serve_argv), devices)
     checks += check_nvlink(tp, devices)
     checks += check_driver_stack()
     checks += check_injection_lib()
@@ -579,7 +608,8 @@ def main(argv: list[str] | None = None) -> int:
         serve_argv += ["--tensor-parallel-size", str(tp)]
 
     print(f"==> out dir: {out_dir}")
-    print(f"==> {devices.count} GPU(s) via {devices.source} -> tensor-parallel-size {tp}")
+    print(f"==> {devices.count} GPU(s) via {devices.source} -> "
+          f"TP={tp} x DP={resolve_dp(serve_argv)}")
     print("==> preflight")
     checks = [] if args.skip_preflight else preflight(serve_argv, devices, tp, skip_args=False)
     print_checks(checks)

--- a/tests/test_serve_capture.py
+++ b/tests/test_serve_capture.py
@@ -314,6 +314,27 @@ def test_explicit_tp_in_the_serve_command_wins():
     assert sc.resolve_tp(["vllm", "serve", "m"], dev, 2) == 2   # --tp when unset
 
 
+def test_tp_accounts_for_data_parallel_size():
+    """vLLM's world is TP x DP. On a 4-GPU box `--data-parallel-size 4` means TP=1;
+    defaulting TP to the whole box would request 16 GPUs and die in NCCL bootstrap."""
+    dev = sc.Devices(indices=[0, 1, 2, 3], count=4, source="nvidia-smi")
+    assert sc.resolve_tp(["vllm", "serve", "m", "--data-parallel-size", "4"], dev, None) == 1
+    assert sc.resolve_tp(["vllm", "serve", "m", "--data-parallel-size", "2"], dev, None) == 2
+    assert sc.resolve_tp(["vllm", "serve", "m"], dev, None) == 4
+
+
+def test_world_size_must_match_the_box():
+    dev = sc.Devices(indices=[0, 1, 2, 3], count=4, source="nvidia-smi")
+    assert sc.check_world(2, 2, dev)[0].status == "pass"
+    assert sc.check_world(1, 4, dev)[0].status == "pass"
+
+    over = sc.check_world(4, 4, dev)[0]
+    assert over.status == "fail" and "needs 16 GPUs" in over.detail
+
+    under = sc.check_world(2, 1, dev)[0]
+    assert under.status == "warn" and "2 idle" in under.detail
+
+
 def test_tp_never_resolves_to_zero_on_a_cpu_box():
     dev = sc.Devices(indices=[], count=0, source="nvidia-smi unavailable")
     assert sc.resolve_tp(["vllm", "serve", "m"], dev, None) == 1


### PR DESCRIPTION
vLLM's world size is TP x DP. The auto-detected TP defaulted to every visible GPU, so --data-parallel-size 4 on a 4-GPU
box resolved to TP=4 and requested 16 GPUs — failing deep in NCCL bootstrap with a message naming neither flag.

TP now defaults to gpus // dp. A world-size preflight check fails when TP x DP exceeds the visible GPUs, and warns when it is short of them: idle GPUs are the worse case, because the run succeeds and the per-GPU throughput number is quietly wrong. This is what makes the DP=4 vs TP=2 x DP=2 comparison runnable at all — without it the DP=4 leg cannot start.