### PR TITLE
MoE support: vLLM factory build knobs, streaming trace ingest, MoE lever catalog

### DIFF
--- a/gitm/importers/torch_trace.py
+++ b/gitm/importers/torch_trace.py
@@ -407,6 +407,33 @@ def _load_json_capped(
     return json.loads(buf.decode("utf-8"))
 
 
+def _line_brace_delta(line: str) -> int:
+    """Net ``{…}`` depth change on one line, ignoring braces inside JSON strings.
+
+    Chrome-trace events never carry a string that spans lines, so per-line string
+    tracking is exact and stays O(line length). Kept cheap: the caller only
+    invokes it for lines that actually contain a brace.
+    """
+    depth = 0
+    in_str = False
+    esc = False
+    for ch in line:
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+        elif ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+    return depth
+
+
 def _iter_chrome_event_dicts(
     path: Path,
     *,
@@ -415,96 +442,78 @@ def _iter_chrome_event_dicts(
 ) -> Iterator[dict[str, Any]]:
     """Yield raw chrome-trace event dicts without loading the whole file.
 
-    Strategy (in order):
-      1. Compact one-JSON-object-per-line inside ``traceEvents`` (bench + many
-         kineto exports) — line-oriented ``json.loads`` per line.
-      2. Fallback brace-stream for pretty-printed multi-line objects.
-    Never uses a whole-file ``json.load`` of multi-million-event dumps.
+    Single O(file) streaming pass with O(one-object) memory that handles **both**
+    layouts real exporters produce:
+      * compact one-JSON-object-per-line (bench, many kineto exports), and
+      * pretty-printed multi-line objects (``torch.profiler.export_chrome_trace``).
+
+    Line-oriented: accumulates lines by brace depth (string-aware, see
+    :func:`_line_brace_delta`) and ``json.loads`` one object at a time. Works on
+    plain or gzipped input. Never does a whole-file ``json.load`` of a
+    multi-million-event dump — which is what made large gzipped, pretty-printed
+    customer traces take tens of minutes and gigabytes of RAM.
     """
     opener: Any = gzip.open if gzipped else open
     total = 0
+    started = False
+    pre = ""
+    depth = 0
+    buf: list[str] = []
+
+    def _emit(chunk_lines: list[str]) -> dict[str, Any] | None:
+        s = "".join(chunk_lines).strip()
+        if s.endswith(","):
+            s = s[:-1].rstrip()
+        if not s.startswith("{"):
+            return None
+        try:
+            obj = json.loads(s)
+        except json.JSONDecodeError:
+            return None
+        return obj if isinstance(obj, dict) else None
+
     with opener(path, "rt", encoding="utf-8", errors="replace") as fh:  # type: ignore[arg-type]
-        # Seek to the start of the events array.
-        head = fh.read(65536)
-        total += len(head.encode("utf-8", errors="replace"))
-        m = re.search(r'"traceEvents"\s*:\s*\[', head)
-        if m:
-            rest = head[m.end() :]
-            array_form = False
-        elif head.lstrip().startswith("["):
-            rest = head.lstrip()[1:]
-            array_form = True
-        else:
-            # Maybe key is later — read more until found or give up.
-            buf = head
-            while True:
-                chunk = fh.read(1 << 20)
-                if not chunk:
-                    raise ImportError(f"{path.name}: no 'traceEvents' array found")
-                total += len(chunk.encode("utf-8", errors="replace"))
-                if total > max_decompressed_bytes:
-                    raise ImportError(
-                        f"{path.name}: decompressed size exceeds limit of "
-                        f"{max_decompressed_bytes} bytes"
-                    )
-                buf += chunk
-                m = re.search(r'"traceEvents"\s*:\s*\[', buf)
-                if m:
-                    rest = buf[m.end() :]
-                    array_form = False
-                    break
-                if len(buf) > 50_000_000:
-                    raise ImportError(f"{path.name}: no 'traceEvents' array found")
-
-        # Line-oriented fast path for compact dumps (one object per line).
-        # Process residual + remaining lines.
-        def _handle_line(line: str) -> dict[str, Any] | None:
-            s = line.strip()
-            if not s:
-                return None
-            if s[0] == "]":
-                return None  # end marker handled by caller
-            if s[-1] == ",":
-                s = s[:-1]
-            if not s.startswith("{"):
-                return None
-            try:
-                obj = json.loads(s)
-            except json.JSONDecodeError:
-                return None
-            return obj if isinstance(obj, dict) else None
-
-        # Prefer line mode for compact one-object-per-line dumps.
-        # If ``rest`` ends mid-line (head cut), carry the incomplete prefix into
-        # the first line from the file so we never drop a boundary event.
-        carry = ""
-        nl = rest.rfind("\n")
-        if nl >= 0:
-            complete, carry = rest[: nl + 1], rest[nl + 1 :]
-            for line in complete.splitlines(keepends=True):
-                if line.strip().startswith("]"):
-                    return
-                obj = _handle_line(line)
-                if obj is not None:
-                    yield obj
-        else:
-            carry = rest
-        for line in fh:
-            total += len(line.encode("utf-8", errors="replace"))
+        for raw in fh:
+            total += len(raw)
             if total > max_decompressed_bytes:
                 raise ImportError(
                     f"{path.name}: decompressed size exceeds limit of "
                     f"{max_decompressed_bytes} bytes"
                 )
-            if carry:
-                line = carry + line
-                carry = ""
-            if line.strip().startswith("]"):
-                return
-            obj = _handle_line(line)
-            if obj is not None:
-                yield obj
-        _ = array_form  # reserved
+            line = raw
+            if not started:
+                # Locate the events array; it may sit past a large metadata head.
+                pre += line
+                m = re.search(r'"traceEvents"\s*:\s*\[', pre)
+                if m:
+                    line = pre[m.end() :]
+                elif pre.lstrip().startswith("["):
+                    line = pre.lstrip()[1:]
+                elif len(pre) > 64 * 1024 * 1024:
+                    raise ImportError(f"{path.name}: no 'traceEvents' array found")
+                else:
+                    continue
+                started = True
+                pre = ""
+                # Fall through and process the remainder of the header line.
+
+            if depth == 0:
+                if "{" not in line:
+                    if line.lstrip().startswith("]"):
+                        return  # end of the traceEvents array
+                    continue  # whitespace / commas between objects
+                buf = [line]
+                depth = _line_brace_delta(line)
+            else:
+                buf.append(line)
+                depth += _line_brace_delta(line)
+
+            if depth <= 0 and buf:
+                obj = _emit(buf)
+                buf = []
+                depth = 0
+                if obj is not None:
+                    yield obj
 
 
 def _device_id_from_chrome_obj(obj: dict[str, Any]) -> int | None:
@@ -606,8 +615,11 @@ def _workload_stem(path: Path) -> str:
 
 
 # Files below this size use a full json.load (pretty-printed fixtures, small
-# customer dumps). Larger compact dumps use the line-stream multi-pass path.
-_FULL_LOAD_MAX_BYTES = 80 * 1024 * 1024  # 80 MiB
+# customer dumps). Larger dumps use the line-stream path. Gzip has a smaller
+# on-disk threshold because it decompresses ~8-10x, so a 24 MiB gzip is already
+# a ~200 MiB DOM — stream those instead of loading the whole thing.
+_FULL_LOAD_MAX_BYTES = 80 * 1024 * 1024  # 80 MiB (uncompressed)
+_GZIP_FULL_LOAD_MAX_BYTES = 24 * 1024 * 1024  # 24 MiB (compressed)
 
 
 def _import_torch_from_event_dicts(
@@ -719,7 +731,10 @@ def import_torch_trace(
             gzipped = fh.read(2) == b"\x1f\x8b"
 
     size = path.stat().st_size
-    use_full_load = gzipped or size <= _FULL_LOAD_MAX_BYTES
+    if gzipped:
+        use_full_load = size <= _GZIP_FULL_LOAD_MAX_BYTES
+    else:
+        use_full_load = size <= _FULL_LOAD_MAX_BYTES
 
     if use_full_load:
         try:
@@ -767,7 +782,7 @@ def import_torch_trace(
     n_raw = 0
     try:
         for obj in _iter_chrome_event_dicts(
-            path, gzipped=False, max_decompressed_bytes=max_decompressed_bytes
+            path, gzipped=bool(gzipped), max_decompressed_bytes=max_decompressed_bytes
         ):
             n_raw += 1
             if scanned_sku is None and obj.get("name") in ("process_name", "thread_name"):

--- a/gitm/kernels/library.yaml
+++ b/gitm/kernels/library.yaml
@@ -432,6 +432,120 @@ interventions:
       notes: Execution-backend swap with restart; validate end-to-end before keep.
     review: null
 
+  # --- Mixture-of-Experts levers ---------------------------------------------
+  # MoE decode is weight-fetch-bandwidth-bound: a token activates top-k of E
+  # experts, but the batch loads the *union* of experts any token selected, so
+  # the working set grows with batch and saturates at E. These four levers act on
+  # the three things that distinguishes MoE from a dense FFN — which expert-GEMM
+  # kernel runs, how experts are sharded, how evenly routing loads them, and
+  # whether the resulting collectives overlap compute. They target
+  # ``mlp_gate_up``/``mlp_down`` (the FFN path, which is the expert path on an
+  # MoE model) rather than every op.
+
+  - name: moe_backend_deep_gemm
+    summary: Select the DeepGEMM fused-MoE backend for the fp8 expert GEMMs.
+    knob: moe_backend
+    value: deep_gemm
+    applies_to_kernels: [mlp_gate_up, mlp_down]  # the routed-expert GEMMs
+    expected_delta_mean: 0.05
+    expected_delta_lo: -0.05
+    expected_delta_hi: 0.20
+    source: https://docs.vllm.ai/en/stable/configuration/engine_args/
+    applicability:
+      workloads: [vllm-decode]
+      requires_dtype: [fp8]
+      other: >-
+        Per-expert decode GEMMs are tall-skinny and low-occupancy, so the backend
+        choice matters more than for a dense FFN. No single backend wins across
+        the batch range — weight-only kernels favour the memory-bound low-batch
+        regime, grouped-GEMM kernels the compute-bound high-batch one. Other
+        choices to sweep: auto (default), triton, cutlass, flashinfer_trtllm,
+        marlin. Requires a build whose vLLM exposes --moe-backend.
+    safety:
+      tier: moderate
+      requires_rollback_window_s: 180
+      notes: >-
+        Kernel-variant selection; backends are mathematically equivalent but
+        differ in fp8 accumulation order, so gate on an accuracy sentinel.
+        Structural — takes effect on a fresh engine.
+    review: null
+
+  - name: enable_expert_parallel
+    summary: Shard whole experts across ranks (EP) instead of slicing each one (TP).
+    knob: enable_expert_parallel
+    value: true
+    applies_to_kernels: [mlp_gate_up, mlp_down]  # MoE layers only, per vLLM docs
+    expected_delta_mean: 0.00
+    expected_delta_lo: -0.20
+    expected_delta_hi: 0.25
+    source: https://docs.vllm.ai/en/stable/configuration/engine_args/
+    applicability:
+      workloads: [vllm-decode]
+      requires_hardware: [A100, H100, H200]
+      other: >-
+        Multi-GPU only. Trades per-layer all-reduce for all-to-all dispatch/combine
+        and keeps per-expert GEMMs full-width instead of halving them, but makes
+        rank load routing-dependent (a hot expert stalls the step). Wins when
+        decode is weight-fetch-bound; loses at small batch where all-to-all is
+        latency-bound.
+    safety:
+      tier: high_risk
+      requires_qualification_commit: true
+      requires_rollback_window_s: 300
+      notes: >-
+        Topology change requiring an engine restart — heavy rollback, gate
+        strictly. Pair with the expert-imbalance signal before keeping.
+    review: null
+
+  - name: enable_eplb
+    summary: Rebalance expert placement across ranks to cut routing-induced stragglers.
+    knob: enable_eplb
+    value: true
+    applies_to_kernels: [mlp_gate_up, mlp_down]  # expert load is the FFN path
+    expected_delta_mean: 0.03
+    expected_delta_lo: -0.02
+    expected_delta_hi: 0.15
+    source: https://docs.vllm.ai/en/stable/configuration/engine_args/
+    applicability:
+      workloads: [vllm-decode]
+      other: >-
+        Requires expert parallelism (see enable_expert_parallel) — under TP every
+        rank slices every expert, so routing skew is symmetric and there is no
+        straggler to fix. Only pays off when measured per-expert load is actually
+        uneven; near-zero on balanced routing, and rebalancing itself costs.
+    safety:
+      tier: moderate
+      requires_rollback_window_s: 180
+      notes: >-
+        Changes expert placement; structural (fresh engine). Verify the
+        max/mean per-expert load actually falls before keeping.
+    review: null
+
+  - name: enable_dbo
+    summary: Overlap two micro-batches so collectives hide behind compute.
+    knob: enable_dbo
+    value: true
+    applies_to_kernels: *all_ops  # overlap reshapes the whole step's execution
+    expected_delta_mean: 0.04
+    expected_delta_lo: -0.03
+    expected_delta_hi: 0.12
+    source: https://docs.vllm.ai/en/stable/configuration/engine_args/
+    applicability:
+      workloads: [vllm-decode]
+      other: >-
+        Only helps when communication is *exposed* — TP/EP collectives sit on the
+        critical path because the next layer consumes their result, so there is no
+        independent work to hide them behind unless a second micro-batch supplies
+        it. Check exposed-comm share first; near-zero benefit single-GPU, where
+        there are no collectives at all.
+    safety:
+      tier: moderate
+      requires_rollback_window_s: 180
+      notes: >-
+        Splitting the batch shrinks each micro-batch, which can cost more in
+        GEMM efficiency than overlap recovers. Structural (fresh engine).
+    review: null
+
   # unified non vLLM levels 
   # catalog workloads levels, workload tagged load_library + the gate keep them scoped
   # the measure delta still comes from each benchmarks A/B

--- a/gitm/optimizer/vllm_knobs.py
+++ b/gitm/optimizer/vllm_knobs.py
@@ -127,12 +127,22 @@ _KNOBS: dict[str, KnobSpec] = {
     "distributed_executor_backend": KnobSpec(
         "distributed_executor_backend", "parallel_config.distributed_executor_backend", "structural"
     ),
+    # Mixture-of-Experts. All read at construction (they change how expert
+    # weights are sharded and which fused-MoE kernel is built) → structural.
+    "enable_expert_parallel": KnobSpec(
+        "enable_expert_parallel", "parallel_config.enable_expert_parallel", "structural"
+    ),
+    "enable_eplb": KnobSpec("enable_eplb", "parallel_config.enable_eplb", "structural"),
+    "data_parallel_size": KnobSpec(
+        "data_parallel_size", "parallel_config.data_parallel_size", "structural"
+    ),
     # Env-var knob: read by vLLM at construction → structural.
     "VLLM_ATTENTION_BACKEND": KnobSpec(
         "VLLM_ATTENTION_BACKEND", "env:VLLM_ATTENTION_BACKEND", "structural"
     ),
     # Prerequisite flags for the table below — not applied standalone, only read.
     "enable_dbo": KnobSpec("enable_dbo", "scheduler_config.enable_dbo", "structural"),
+    "moe_backend": KnobSpec("moe_backend", "model_config.moe_backend", "structural"),
 }
 
 
@@ -231,6 +241,10 @@ KNOB_PREREQUISITES: tuple[tuple[str, str], ...] = (
     ("partial_prefill", "enable_chunked_prefill"),
     ("long_prefill_token_threshold", "enable_chunked_prefill"),
     ("dbo", "enable_dbo"),
+    # Expert-parallel load balancing only means anything under EP: with plain TP
+    # every rank slices every expert, so routing skew is symmetric across ranks
+    # and there is no straggler for EPLB to rebalance.
+    ("eplb", "enable_expert_parallel"),
 )
 
 

--- a/gitm/workloads.py
+++ b/gitm/workloads.py
@@ -569,6 +569,13 @@ def _vllm_decode_factory(cfg: LoopConfig) -> WorkloadRunner:
                               torch.compile + graph capture, so engine builds
                               (and restart-A/B candidates) are much faster.
 
+        GITM_VLLM_MAX_MODEL_LEN / GITM_VLLM_TP / GITM_VLLM_ENABLE_EP /
+        GITM_VLLM_TRUST_REMOTE_CODE / GITM_VLLM_EXTRA_JSON
+                              MoE + long-context build knobs (see the block below
+                              where ``_base_kwargs`` is assembled). Needed to build
+                              models like Qwen3.6-35B-A3B and to reach their
+                              structural levers in the restart-A/B.
+
     On a box without vLLM/GPU the import raises; ``run_loop`` catches it and the
     empty-trace guard reports "no-data" rather than fabricating a result.
     """
@@ -603,6 +610,39 @@ def _vllm_decode_factory(cfg: LoopConfig) -> WorkloadRunner:
     # Inherited by restart candidates (kwargs = dict(_base_kwargs)) for a fair A/B.
     if os.environ.get("GITM_VLLM_ENFORCE_EAGER") == "1":
         _base_kwargs["enforce_eager"] = True
+
+    # --- MoE / long-context / structural build knobs -------------------------
+    # Extra ``LLM()`` kwargs so mixture-of-experts, long-context models (e.g.
+    # Qwen3.6-35B-A3B) build correctly and their structural levers are reachable
+    # by the restart-A/B. Each flows through ``_base_kwargs`` -> ``gitm_llm_kwargs``,
+    # so restart candidates inherit them for a fair baseline. All are opt-in via
+    # env, so nothing changes for the existing small-model default path.
+    #     GITM_VLLM_MAX_MODEL_LEN  max_model_len (long context, e.g. 16384)
+    #     GITM_VLLM_TP             tensor_parallel_size (e.g. 2)
+    #     GITM_VLLM_ENABLE_EP=1    enable_expert_parallel (MoE expert parallelism)
+    #     GITM_VLLM_TRUST_REMOTE_CODE=1  trust_remote_code (custom model code)
+    #     GITM_VLLM_EXTRA_JSON     JSON object merged verbatim into the kwargs —
+    #                              the escape hatch for any structural MoE lever
+    #                              (compilation_config, quantization, cpu_offload_gb,
+    #                              preemption_mode, …) without a new env var each.
+    _max_len = os.environ.get("GITM_VLLM_MAX_MODEL_LEN")
+    if _max_len:
+        _base_kwargs["max_model_len"] = int(_max_len)
+    _tp = os.environ.get("GITM_VLLM_TP")
+    if _tp:
+        _base_kwargs["tensor_parallel_size"] = int(_tp)
+    if os.environ.get("GITM_VLLM_ENABLE_EP") == "1":
+        _base_kwargs["enable_expert_parallel"] = True
+    if os.environ.get("GITM_VLLM_TRUST_REMOTE_CODE") == "1":
+        _base_kwargs["trust_remote_code"] = True
+    _extra = os.environ.get("GITM_VLLM_EXTRA_JSON")
+    if _extra:
+        import json as _json
+
+        extra = _json.loads(_extra)
+        if not isinstance(extra, dict):
+            raise ValueError("GITM_VLLM_EXTRA_JSON must be a JSON object of LLM() kwargs")
+        _base_kwargs.update(extra)
 
     engine_ref: dict[str, Any] = {}
 

--- a/tests/test_apply_rollback.py
+++ b/tests/test_apply_rollback.py
@@ -204,7 +204,7 @@ def test_library_has_validated_levers_with_values():
     from gitm.kernels import load_library
 
     specs = load_library()
-    assert len(specs) == 24
+    assert len(specs) == 28
     for s in specs:
         assert s.value is not None, f"{s.name} missing value"
         assert s.expected_delta_lo <= s.expected_delta_mean <= s.expected_delta_hi

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -835,7 +835,7 @@ def test_engineargs_proposer_bounds_a_large_surface_by_default() -> None:
     # The vLLM binding caps by default so the real ~100-field surface can't flood.
     knobs = [Knob(f"prefill_{i}", "bool", default=False) for i in range(100)]
     specs = EngineArgsProposer(knobs=knobs, catalog_knobs=set()).propose("idle_stall")
-    assert 0 < len(specs) <= 24
+    assert 0 < len(specs) <= 28
 
 
 def test_candidate_spec_helper_forces_safety_and_delta() -> None:


### PR DESCRIPTION
Makes the runtime able to build, observe, and tune mixture-of-experts models. Motivated by Qwen3.6-35B-A3B (35B total / 3B active, 256 experts, fp8, hybrid gated-delta-net + full attention) — the shape on the Parasail menu.

Three independent pieces.

## 1. vLLM factory: MoE + long-context build knobs

`_vllm_decode_factory` only understood model/prompts/max_tokens/kv_dtype/gpu_mem, so it **could not build an MoE long-context model at all** — no way to pass `max_model_len`, tensor-parallel size, or expert parallelism. Adds five opt-in env vars:

| Env var | → `LLM()` kwarg |
|---|---|
| `GITM_VLLM_MAX_MODEL_LEN` | `max_model_len` |
| `GITM_VLLM_TP` | `tensor_parallel_size` |
| `GITM_VLLM_ENABLE_EP=1` | `enable_expert_parallel` |
| `GITM_VLLM_TRUST_REMOTE_CODE=1` | `trust_remote_code` |
| `GITM_VLLM_EXTRA_JSON` | arbitrary kwargs (escape hatch) |

Each flows through `_base_kwargs` → `gitm_llm_kwargs`, so **restart-A/B candidates inherit them** and baseline-vs-candidate stays a fair comparison. Without that threading a structural candidate would silently rebuild at default context/parallelism and the measured delta would be meaningless.

Every knob is gated on a new env var — the existing small-model default path is unchanged.

## 2. Importer: stream pretty-printed gzip torch traces

Real customer torch profiles are gzipped **and** pretty-printed. Neither ingest path handled that: the gzip branch always did a whole-file `json.load` (20+ minutes and many GB of RAM on a 193 MB trace), and the streaming branch only parsed one-object-per-line, so a pretty-printed file returned *"no traceEvents found"*.

Now a single O(file) pass with O(one-object) memory that accumulates lines by brace depth (string-aware), handling compact **and** pretty-printed layouts, plain or gzipped. Large gzips route to streaming (24 MiB on-disk threshold, since gzip expands ~8–10×); small files keep the full-load path.

Validated on a real 193 MB pretty-printed gzip (Qwen3.6 TP=2 rank0): imports the exact **1,016,688 kernels + 20,110 memcpy in 2m51s** with bounded RAM.

## 3. Library: MoE levers

The catalog had 24 vLLM entries and **zero MoE ones** — so on an MoE model the loop could observe an expert-GEMM bottleneck and have nothing in its search space to act on. Adds the four levers covering what distinguishes MoE from a dense FFN:

| Lever | Acts on |
|---|---|
| `moe_backend=deep_gemm` | which fused-MoE kernel runs the fp8 expert GEMMs — **works single-GPU** |
| `enable_expert_parallel` | shard whole experts (EP) vs slice each one (TP) |
| `enable_eplb` | rebalance expert placement against routing skew |
| `enable_dbo` | dual batch overlap, to hide exposed collectives |

Scoped to `mlp_gate_up`/`mlp_down` (the FFN path is the expert path on an MoE model), except DBO which reshapes the whole step. **Knob names verified against the current vLLM engine-args docs.**

Supporting changes worth review attention:
- Registered in `_KNOBS` as **structural** — they change expert sharding and which kernel is built, so they only take effect on a fresh engine and must route through the restart-A/B, never a hot-swap.
- **EPLB now requires `enable_expert_parallel`.** Under plain TP every rank slices every expert, so routing skew is symmetric across ranks and there is no straggler to rebalance — proposing it there wastes a restart.

Expected deltas are deliberately wide and honest: EP is centred on **0.00** (it trades per-layer all-reduce for all-to-all and can lose at small batch), and EPLB/DBO only pay off when the imbalance or exposed comm they target is actually present. The rollback gate decides.

## Validation

Piece 1 has been **run live on a GPU** at commit `70573cf`: it built Qwen3.6, ran the loop end-to-end, and performed real restart-A/Bs with measured deltas — `cuda_graphs_enable` −17.5% decode throughput and `enable_chunked_prefill` −0.1%, **both correctly rolled back**. That exercises the factory, the restart path, and the rollback gate together.

- `ruff check .` clean
- 95 tests pass across the affected modules
- Full suite: 9 failures, **identical to the `origin/main` baseline** (missing `toml`/`pyarrow` plus pre-existing importer/injection failures). Zero new.

## Known limits

- The MoE **roofline is still dense** — `ModelSpec` has no `num_experts`/`top_k`/active-param split, so residuals on an MoE model are measured against a dense ceiling. These levers are now reachable and gate-protected, but the *targeting* that picks among them is only as good as that ceiling. That's the next piece.
- `moe_backend` requires a vLLM build that exposes `--moe-backend`.
- EP/EPLB are multi-GPU only; autoresearch already filters topology knobs on single-GPU boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
