### PR TITLE
MoE roofline: batch-dependent expert fetch, layer placement, hybrid attention, observed batch

### DIFF
--- a/gitm/planner/graph.py
+++ b/gitm/planner/graph.py
@@ -17,8 +17,70 @@ from gitm.planner.roofline import (
     HardwareSpec,
     ModelSpec,
     RooflinePrediction,
+    distinct_experts,
     roofline,
 )
+
+
+def _ffn_terms(model: ModelSpec, b: int) -> tuple[float, float, float, float]:
+    """``(gate_up_flops, gate_up_bytes, down_flops, down_bytes)`` for one layer.
+
+    Dense (``num_experts == 0``) reproduces the original single-FFN arithmetic
+    exactly. For MoE the two costs are driven by *different* counts, which is the
+    whole point of the mixture:
+
+    * **flops** scale with the experts each token activates — ``b * top_k``
+      routed (plus every shared expert for every token), so compute grows
+      linearly with batch;
+    * **weight bytes** scale with the *distinct* experts the batch touches
+      (:func:`distinct_experts`), because an expert's weights are read once per
+      step however many tokens route to it — so traffic grows sublinearly and
+      saturates at ``num_experts``.
+
+    Weights use ``model.w_bytes`` and activations ``model.dtype_bytes``, so a
+    quantized MoE checkpoint (fp8 weights, bf16 activations) is modeled with the
+    right width on the term that dominates.
+
+    The router GEMM (``[b, hidden] @ [hidden, num_experts]``) is folded into
+    gate_up rather than given its own node: it is real but ~1% of expert-GEMM
+    cost, and adding an op would change the canonical vocabulary that
+    ``classify_op`` and ``library.yaml``'s ``applies_to_kernels`` key off.
+    """
+    h = model.hidden
+    dt = model.dtype_bytes  # activations
+    wb = model.w_bytes  # weights (may be narrower, e.g. fp8)
+
+    if not model.is_moe:
+        # Dense: one FFN, weights fetched once, every token through all of it.
+        ff = model.intermediate
+        gate_up_flops = 2 * 2 * b * h * ff
+        gate_up_bytes = dt * (b * h + 2 * b * ff) + wb * (2 * h * ff)
+        down_flops = 2 * b * ff * h
+        down_bytes = dt * (b * ff + b * h) + wb * (ff * h)
+        return gate_up_flops, gate_up_bytes, down_flops, down_bytes
+
+    k = model.top_k
+    ff = model.expert_intermediate
+    n_shared = model.shared_experts
+    sff = model.shared_intermediate
+    # Expected distinct routed experts whose weights this step must fetch.
+    distinct = distinct_experts(b, model.num_experts, k)
+
+    # Compute: every token pays k routed experts plus all shared ones.
+    gate_up_flops = 2 * 2 * b * (k * h * ff + n_shared * h * sff)
+    down_flops = 2 * b * (k * ff * h + n_shared * sff * h)
+    # Router: [b, h] @ [h, num_experts], folded in above.
+    gate_up_flops += 2 * b * h * model.num_experts
+
+    # Weight traffic: distinct routed experts once each, plus the shared experts
+    # (always resident in the step) and the router matrix.
+    gate_up_weight_bytes = wb * (distinct * 2 * h * ff + n_shared * 2 * h * sff + h * model.num_experts)
+    down_weight_bytes = wb * (distinct * ff * h + n_shared * sff * h)
+    # Activations: in [b, h], out [b, k*ff] (+ shared) for gate_up; mirrored for down.
+    act_out = b * (k * ff + n_shared * sff)
+    gate_up_bytes = dt * (b * h + 2 * act_out) + gate_up_weight_bytes
+    down_bytes = dt * (act_out + b * h) + down_weight_bytes
+    return gate_up_flops, gate_up_bytes, down_flops, down_bytes
 
 
 @dataclass
@@ -93,18 +155,17 @@ def predict_graph(
             PredictedNode("attn_out_proj", layer, roofline("attn_out_proj", flops, bytes_moved, hw))
         )
 
-        # MLP gate+up
-        flops = 2 * 2 * b * h * model.intermediate
-        bytes_moved = dt * (b * h + 2 * h * model.intermediate + 2 * b * model.intermediate)
+        # MLP gate+up / down. On an MoE model these two ops carry the expert
+        # GEMMs, so their flops/bytes come from the mixture model instead of a
+        # single dense FFN (see _ffn_terms).
+        gate_up_flops, gate_up_bytes, down_flops, down_bytes = _ffn_terms(model, b)
         g.nodes.append(
-            PredictedNode("mlp_gate_up", layer, roofline("mlp_gate_up", flops, bytes_moved, hw))
+            PredictedNode(
+                "mlp_gate_up", layer, roofline("mlp_gate_up", gate_up_flops, gate_up_bytes, hw)
+            )
         )
-
-        # MLP down
-        flops = 2 * b * model.intermediate * h
-        bytes_moved = dt * (b * model.intermediate + model.intermediate * h + b * h)
         g.nodes.append(
-            PredictedNode("mlp_down", layer, roofline("mlp_down", flops, bytes_moved, hw))
+            PredictedNode("mlp_down", layer, roofline("mlp_down", down_flops, down_bytes, hw))
         )
 
     # Final vocab projection

--- a/gitm/planner/graph.py
+++ b/gitm/planner/graph.py
@@ -142,10 +142,21 @@ def predict_graph(
             PredictedNode("qkv_proj", layer, roofline("qkv_proj", flops, bytes_moved, hw))
         )
 
-        # Attention scores + softmax + value: KV-cache traffic dominates at decode.
-        # Reads: K, V over kv_len tokens, grouped to n_kv heads.
-        kv_bytes = dt * 2 * kv_len * n_kv * head_dim * b
-        attn_flops = 2 * b * n_h * head_dim * kv_len * 2  # qk + sv
+        # Attention scores + softmax + value. Full-attention layers re-read a KV
+        # cache that grows with context; linear/recurrent layers (gated DeltaNet,
+        # Mamba) carry a fixed-size state instead, so their traffic is flat in
+        # sequence length. Pricing the latter as KV overstates traffic by roughly
+        # kv_len / head_dim — over 100x at 16k context.
+        if model.is_full_attention_layer(layer):
+            # Reads: K, V over kv_len tokens, grouped to n_kv heads.
+            kv_bytes = dt * 2 * kv_len * n_kv * head_dim * b
+            attn_flops = 2 * b * n_h * head_dim * kv_len * 2  # qk + sv
+        else:
+            # Read the recurrent state, update it, write it back: 2x state per
+            # sequence. FLOPs are the state-sized matmuls, also context-free.
+            state = model.linear_attn_state_elems
+            kv_bytes = dt * 2 * state * b
+            attn_flops = 2 * b * state * 2  # state-vector product + state update
         g.nodes.append(
             PredictedNode(
                 "attn_score_value",

--- a/gitm/planner/graph.py
+++ b/gitm/planner/graph.py
@@ -22,8 +22,14 @@ from gitm.planner.roofline import (
 )
 
 
-def _ffn_terms(model: ModelSpec, b: int) -> tuple[float, float, float, float]:
+def _ffn_terms(model: ModelSpec, b: int, *, moe_layer: bool = True) -> tuple[
+    float, float, float, float
+]:
     """``(gate_up_flops, gate_up_bytes, down_flops, down_bytes)`` for one layer.
+
+    ``moe_layer`` selects the mixture arithmetic for *this* layer. MoE
+    checkpoints are not uniformly sparse (see :meth:`ModelSpec.is_moe_layer`), so
+    a dense block inside an MoE model is priced as a dense FFN.
 
     Dense (``num_experts == 0``) reproduces the original single-FFN arithmetic
     exactly. For MoE the two costs are driven by *different* counts, which is the
@@ -50,7 +56,7 @@ def _ffn_terms(model: ModelSpec, b: int) -> tuple[float, float, float, float]:
     dt = model.dtype_bytes  # activations
     wb = model.w_bytes  # weights (may be narrower, e.g. fp8)
 
-    if not model.is_moe:
+    if not (model.is_moe and moe_layer):
         # Dense: one FFN, weights fetched once, every token through all of it.
         ff = model.intermediate
         gate_up_flops = 2 * 2 * b * h * ff
@@ -158,7 +164,9 @@ def predict_graph(
         # MLP gate+up / down. On an MoE model these two ops carry the expert
         # GEMMs, so their flops/bytes come from the mixture model instead of a
         # single dense FFN (see _ffn_terms).
-        gate_up_flops, gate_up_bytes, down_flops, down_bytes = _ffn_terms(model, b)
+        gate_up_flops, gate_up_bytes, down_flops, down_bytes = _ffn_terms(
+            model, b, moe_layer=model.is_moe_layer(layer)
+        )
         g.nodes.append(
             PredictedNode(
                 "mlp_gate_up", layer, roofline("mlp_gate_up", gate_up_flops, gate_up_bytes, hw)

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -80,6 +80,11 @@ class ModelSpec:
     #: Among the remaining layers, every ``moe_layer_step``-th one is MoE and the
     #: rest stay dense (Qwen ``decoder_sparse_step``). 1 = every layer is MoE.
     moe_layer_step: int = 1
+    #: Hybrid attention: every ``full_attn_layer_step``-th layer uses softmax
+    #: attention over a growing KV cache; the rest use linear/recurrent attention
+    #: (gated DeltaNet, Mamba) whose state is *constant* in sequence length.
+    #: 1 = every layer is full attention, i.e. a conventional transformer.
+    full_attn_layer_step: int = 1
 
     @property
     def is_moe(self) -> bool:
@@ -104,6 +109,51 @@ class ModelSpec:
     def n_moe_layers(self) -> int:
         """How many layers actually carry the mixture FFN."""
         return sum(1 for i in range(self.n_layers) if self.is_moe_layer(i))
+
+    def is_full_attention_layer(self, layer: int) -> bool:
+        """Whether layer ``layer`` uses softmax attention over a KV cache.
+
+        Hybrid models (Qwen3-Next-style gated DeltaNet, Mamba/Jamba) interleave a
+        few full-attention layers among many linear-attention ones. The two have
+        fundamentally different memory behaviour at decode:
+
+        * **full attention** re-reads a KV cache that grows with context, so its
+          traffic scales with ``kv_cache_len``;
+        * **linear attention** carries a fixed-size recurrent state per sequence,
+          so its traffic is *constant* in sequence length.
+
+        Modeling every layer as full attention overstates KV traffic by the ratio
+        of context length to state size — at 16k context that is over an order of
+        magnitude, and it is why a hybrid model can serve long contexts with only
+        a few percent of KV-cache utilisation.
+        """
+        step = max(self.full_attn_layer_step, 1)
+        return layer % step == 0
+
+    @property
+    def n_full_attention_layers(self) -> int:
+        """How many layers use softmax attention over a growing KV cache."""
+        return sum(1 for i in range(self.n_layers) if self.is_full_attention_layer(i))
+
+    @property
+    def is_hybrid_attention(self) -> bool:
+        """True when some layers use linear/recurrent attention instead of KV."""
+        return max(self.full_attn_layer_step, 1) > 1
+
+    @property
+    def linear_attn_state_elems(self) -> int:
+        """Recurrent-state elements per sequence for one linear-attention layer.
+
+        Gated DeltaNet (and linear attention generally) keeps a ``[head_dim,
+        head_dim]`` state matrix per head instead of a per-token KV cache, so the
+        state is ``n_heads * head_dim^2`` and does **not** grow with context.
+
+        An approximation: architectures vary in whether the linear-attention
+        heads share the softmax heads' dimensions. It is the right *shape* — flat
+        in sequence length rather than linear in it — which is what makes the
+        prediction directionally correct where treating it as KV does not.
+        """
+        return self.n_heads * self.head_dim * self.head_dim
 
     @property
     def w_bytes(self) -> int:

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -73,11 +73,37 @@ class ModelSpec:
     #: are the common case, and MoE decode is dominated by weight traffic — using
     #: the activation width for weights would overstate it by 2x or more.
     weight_dtype_bytes: int | None = None
+    #: Leading layers that keep a *dense* FFN (DeepSeek ``first_k_dense_replace``).
+    #: MoE models commonly leave the first block(s) dense; modeling them as MoE
+    #: overstates both their weight footprint and their traffic.
+    first_dense_layers: int = 0
+    #: Among the remaining layers, every ``moe_layer_step``-th one is MoE and the
+    #: rest stay dense (Qwen ``decoder_sparse_step``). 1 = every layer is MoE.
+    moe_layer_step: int = 1
 
     @property
     def is_moe(self) -> bool:
-        """True when the FFN should be modeled as a mixture of experts."""
+        """True when *any* layer's FFN should be modeled as a mixture of experts."""
         return self.num_experts > 0 and self.experts_per_token > 0
+
+    def is_moe_layer(self, layer: int) -> bool:
+        """Whether layer index ``layer`` uses the mixture FFN rather than a dense one.
+
+        Real MoE checkpoints are not uniformly sparse: DeepSeek keeps the first
+        ``first_k_dense_replace`` layers dense, and Qwen places MoE blocks every
+        ``decoder_sparse_step`` layers. Treating every layer as MoE inflates the
+        predicted weight footprint (and therefore the ceiling) by whatever
+        fraction is actually dense.
+        """
+        if not self.is_moe or layer < self.first_dense_layers:
+            return False
+        step = max(self.moe_layer_step, 1)
+        return (layer - self.first_dense_layers) % step == 0
+
+    @property
+    def n_moe_layers(self) -> int:
+        """How many layers actually carry the mixture FFN."""
+        return sum(1 for i in range(self.n_layers) if self.is_moe_layer(i))
 
     @property
     def w_bytes(self) -> int:
@@ -93,6 +119,64 @@ class ModelSpec:
     def shared_intermediate(self) -> int:
         """Per-shared-expert FFN width (falls back to the routed width)."""
         return self.shared_expert_intermediate or self.expert_intermediate
+
+    # --- parameter accounting -------------------------------------------------
+    # The "35B-A3B" naming convention: total parameters vs the ones a single
+    # token actually multiplies against. FLOPs follow *active*, checkpoint size
+    # and (at saturation) weight traffic follow *total* — conflating them is the
+    # 10x error that makes an MoE ceiling meaningless.
+
+    @property
+    def _attn_params_per_layer(self) -> int:
+        qkv = self.hidden * (self.n_heads + 2 * self.num_kv_heads) * self.head_dim
+        out = self.n_heads * self.head_dim * self.hidden
+        return qkv + out
+
+    def _dense_ffn_params(self, width: int) -> int:
+        """gate + up + down for an FFN of the given intermediate width."""
+        return 3 * self.hidden * width
+
+    @property
+    def total_params(self) -> int:
+        """Every weight in the checkpoint, including all experts.
+
+        Embedding and LM head are counted separately (untied); a tied-embedding
+        model has ``vocab * hidden`` fewer, which is under a percent for the
+        large-vocab models this matters for.
+        """
+        n_moe = self.n_moe_layers
+        n_dense = self.n_layers - n_moe
+        total = self.n_layers * self._attn_params_per_layer
+        total += n_dense * self._dense_ffn_params(self.intermediate)
+        if n_moe:
+            per_moe = (
+                self.num_experts * self._dense_ffn_params(self.expert_intermediate)
+                + self.shared_experts * self._dense_ffn_params(self.shared_intermediate)
+                + self.hidden * self.num_experts  # router
+            )
+            total += n_moe * per_moe
+        return total + 2 * self.vocab * self.hidden  # embedding + lm_head
+
+    @property
+    def active_params(self) -> int:
+        """Weights one token actually multiplies against on a decode step.
+
+        For a dense model this equals :attr:`total_params`. For a mixture only
+        ``top_k`` of ``num_experts`` participate per token (plus shared experts),
+        which is what makes a 35B model cost 3B of compute per token.
+        """
+        n_moe = self.n_moe_layers
+        n_dense = self.n_layers - n_moe
+        active = self.n_layers * self._attn_params_per_layer
+        active += n_dense * self._dense_ffn_params(self.intermediate)
+        if n_moe:
+            per_moe = (
+                self.top_k * self._dense_ffn_params(self.expert_intermediate)
+                + self.shared_experts * self._dense_ffn_params(self.shared_intermediate)
+                + self.hidden * self.num_experts  # router runs for every token
+            )
+            active += n_moe * per_moe
+        return active + 2 * self.vocab * self.hidden
 
     @property
     def top_k(self) -> int:

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -36,7 +36,13 @@ class HardwareSpec:
 class ModelSpec:
     """Model shape relevant to the decode roofline.
 
-    Defaults match Llama-2-7B. GQA modeled via ``num_kv_heads``.
+    Defaults match Llama-2-7B (dense). GQA modeled via ``num_kv_heads``.
+
+    Mixture-of-experts is opt-in: leave ``num_experts`` at 0 and every field
+    below behaves exactly as a dense model, so existing callers are unaffected.
+    Set it (with ``experts_per_token``) and the FFN switches to the MoE model
+    described in :func:`distinct_experts` — compute scaling with the *activated*
+    experts, weight traffic with the *distinct* ones.
     """
 
     name: str = "llama-2-7b"
@@ -46,8 +52,95 @@ class ModelSpec:
     num_kv_heads: int = 32  # < n_heads when GQA
     head_dim: int = 128
     intermediate: int = 11008
-    dtype_bytes: int = 2  # fp16 / bf16
+    dtype_bytes: int = 2  # fp16 / bf16 — activations
     vocab: int = 32000
+
+    # --- Mixture-of-experts (0 experts => dense FFN, i.e. unchanged) ---------
+    #: Routed experts per MoE layer. 0 disables every MoE term below.
+    num_experts: int = 0
+    #: Experts each token is routed to (top-k). Clamped to ``num_experts``.
+    experts_per_token: int = 0
+    #: Per-expert FFN width. ``None`` falls back to ``intermediate`` — MoE models
+    #: usually make each expert much narrower than a dense FFN of the same size.
+    moe_intermediate: int | None = None
+    #: Always-active experts (Qwen/DeepSeek-style shared expert). Their weights
+    #: are fetched every step regardless of routing, and every token pays them.
+    shared_experts: int = 0
+    #: Width of one shared expert; ``None`` falls back to ``moe_intermediate``.
+    shared_expert_intermediate: int | None = None
+    #: Bytes per *weight* element. ``None`` falls back to ``dtype_bytes``. Split
+    #: out because quantized MoE checkpoints (fp8/int4 weights, bf16 activations)
+    #: are the common case, and MoE decode is dominated by weight traffic — using
+    #: the activation width for weights would overstate it by 2x or more.
+    weight_dtype_bytes: int | None = None
+
+    @property
+    def is_moe(self) -> bool:
+        """True when the FFN should be modeled as a mixture of experts."""
+        return self.num_experts > 0 and self.experts_per_token > 0
+
+    @property
+    def w_bytes(self) -> int:
+        """Bytes per weight element (falls back to the activation dtype)."""
+        return self.weight_dtype_bytes or self.dtype_bytes
+
+    @property
+    def expert_intermediate(self) -> int:
+        """Per-routed-expert FFN width (falls back to the dense width)."""
+        return self.moe_intermediate or self.intermediate
+
+    @property
+    def shared_intermediate(self) -> int:
+        """Per-shared-expert FFN width (falls back to the routed width)."""
+        return self.shared_expert_intermediate or self.expert_intermediate
+
+    @property
+    def top_k(self) -> int:
+        """Routed experts per token, clamped to what actually exists."""
+        return min(self.experts_per_token, self.num_experts) if self.is_moe else 0
+
+
+def distinct_experts(batch: int, num_experts: int, top_k: int) -> float:
+    """Expected number of *distinct* experts a batch of ``batch`` tokens activates.
+
+    This is the term that makes MoE decode different from a dense FFN. Compute
+    scales with the experts each token activates (``batch * top_k`` — linear),
+    but an expert's weights are read from HBM **once** no matter how many tokens
+    in the step route to it. So weight traffic scales with the size of the
+    *union* of selected experts, which saturates:
+
+        distinct(B) = E * (1 - (1 - k/E)^B)
+
+    Under uniform routing, an expert is missed by one token with probability
+    ``(1 - k/E)`` and by all ``B`` with that raised to ``B``. Two limits matter:
+
+    * ``B * k << E`` -> ``distinct ~= B * k`` (linear; few collisions), and
+    * ``B`` large    -> ``distinct -> E`` (every expert touched, so the step has
+      fetched the *whole* model and MoE's bandwidth advantage over a dense model
+      of the same total size is gone).
+
+    The knee sits near ``B ~= E / k``. Because compute keeps growing linearly
+    past it while bytes flatten, arithmetic intensity rises with batch — which is
+    why MoE decode is memory-bandwidth-bound at low batch and only becomes
+    compute-bound at large batch.
+
+    Uniform routing is an assumption, not a measurement. Real routers are skewed,
+    and skew makes tokens *collide* on hot experts, so the true distinct count is
+    at or below this estimate — the prediction errs toward more traffic (slower),
+    never toward an optimistic floor. Deviation detection only needs a stable,
+    directionally-correct reference, and the expert-imbalance invariant is what
+    measures the skew itself.
+
+    Returns a float (an expectation, not a count). ``0.0`` when there is nothing
+    to route.
+    """
+    if num_experts <= 0 or top_k <= 0 or batch <= 0:
+        return 0.0
+    k = min(top_k, num_experts)
+    # k == num_experts collapses the base to 0.0, giving distinct == E for any
+    # batch >= 1, which is correct: every token already touches every expert.
+    p_expert_missed_by_all = (1.0 - k / num_experts) ** batch
+    return num_experts * (1.0 - p_expert_missed_by_all)
 
 
 @dataclass(frozen=True)

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -224,21 +224,23 @@ _MOE_ALIASES: dict[str, tuple[str, ...]] = {
     "moe_layer_step": ("decoder_sparse_step", "moe_layer_freq"),
 }
 
+#: Attention-shape aliases. Deliberately separate from the MoE table: hybrid
+#: attention and a mixture FFN are independent choices, and a hybrid model with a
+#: dense FFN (or a plain MoE transformer) must still get the right one.
+_ATTN_ALIASES: dict[str, tuple[str, ...]] = {
+    "full_attn_layer_step": ("full_attention_interval", "attn_layer_freq"),
+}
+
 #: quant_method -> bytes per weight element. MoE decode is weight-fetch bound,
 #: so using the activation width for a quantized checkpoint would overstate the
 #: dominant term by 2x (fp8) or 4x (4-bit).
 _QUANT_WEIGHT_BYTES: dict[str, int] = {"fp8": 1, "compressed-tensors": 1, "modelopt_fp8": 1}
 
 
-def _moe_fields_from_hf(hf: Any) -> dict[str, Any]:
-    """MoE ``ModelSpec`` kwargs read off an HF config, or ``{}`` for a dense model.
-
-    Every field is optional: a config with no expert fields yields ``{}`` and the
-    spec stays dense, which is the correct read for a non-MoE model rather than a
-    guess. Duck-typed across families and tolerant of partial configs.
-    """
+def _read_int_aliases(hf: Any, table: dict[str, tuple[str, ...]]) -> dict[str, Any]:
+    """First positive int found for each field across its aliases. Duck-typed."""
     out: dict[str, Any] = {}
-    for field, aliases in _MOE_ALIASES.items():
+    for field, aliases in table.items():
         for alias in aliases:
             raw = getattr(hf, alias, None)
             if raw is None:
@@ -250,11 +252,27 @@ def _moe_fields_from_hf(hf: Any) -> dict[str, Any]:
             if value > 0:
                 out[field] = value
                 break
+    return out
+
+
+def _moe_fields_from_hf(hf: Any) -> dict[str, Any]:
+    """Shape ``ModelSpec`` kwargs read off an HF config.
+
+    Covers two *independent* axes — whether the FFN is a mixture, and whether
+    attention is hybrid — so a hybrid-attention dense model still gets its
+    attention shape, and a plain MoE transformer still gets its experts. Every
+    field is optional; anything absent falls back to the dense/conventional
+    default rather than being guessed. Tolerant of partial configs.
+    """
+    # Attention shape is independent of the FFN, so it survives the MoE gate.
+    out: dict[str, Any] = _read_int_aliases(hf, _ATTN_ALIASES)
+    moe = _read_int_aliases(hf, _MOE_ALIASES)
 
     # Only a routed-expert count *and* a top-k make the FFN a mixture; without
-    # both, leave the spec dense rather than half-configured.
-    if not (out.get("num_experts") and out.get("experts_per_token")):
-        return {}
+    # both, leave the FFN dense rather than half-configured.
+    if not (moe.get("num_experts") and moe.get("experts_per_token")):
+        return out
+    out.update(moe)
 
     quant = getattr(hf, "quantization_config", None)
     method = None

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -219,6 +219,9 @@ _MOE_ALIASES: dict[str, tuple[str, ...]] = {
     "moe_intermediate": ("moe_intermediate_size", "expert_intermediate_size"),
     "shared_experts": ("n_shared_experts", "num_shared_experts"),
     "shared_expert_intermediate": ("shared_expert_intermediate_size",),
+    # Per-layer placement: MoE checkpoints are not uniformly sparse.
+    "first_dense_layers": ("first_k_dense_replace",),
+    "moe_layer_step": ("decoder_sparse_step", "moe_layer_freq"),
 }
 
 #: quant_method -> bytes per weight element. MoE decode is weight-fetch bound,

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -196,6 +196,7 @@ def _model_spec_from_engine(engine: Any):
         n_heads = int(hf.num_attention_heads)
         n_kv = int(getattr(hf, "num_key_value_heads", n_heads) or n_heads)
         head_dim = int(getattr(hf, "head_dim", 0) or (hidden // n_heads))
+        moe = _moe_fields_from_hf(hf)
         return ModelSpec(
             hidden=hidden,
             n_layers=int(hf.num_hidden_layers),
@@ -204,9 +205,65 @@ def _model_spec_from_engine(engine: Any):
             head_dim=head_dim,
             intermediate=int(getattr(hf, "intermediate_size", 4 * hidden)),
             vocab=int(hf.vocab_size),
+            **moe,
         )
     except Exception:
         return None
+
+
+#: HF config field aliases per MoE family — the same quantity is spelled
+#: differently by Qwen / Mixtral / DeepSeek, so try each in order.
+_MOE_ALIASES: dict[str, tuple[str, ...]] = {
+    "num_experts": ("num_experts", "num_local_experts", "n_routed_experts"),
+    "experts_per_token": ("num_experts_per_tok", "moe_top_k", "num_selected_experts"),
+    "moe_intermediate": ("moe_intermediate_size", "expert_intermediate_size"),
+    "shared_experts": ("n_shared_experts", "num_shared_experts"),
+    "shared_expert_intermediate": ("shared_expert_intermediate_size",),
+}
+
+#: quant_method -> bytes per weight element. MoE decode is weight-fetch bound,
+#: so using the activation width for a quantized checkpoint would overstate the
+#: dominant term by 2x (fp8) or 4x (4-bit).
+_QUANT_WEIGHT_BYTES: dict[str, int] = {"fp8": 1, "compressed-tensors": 1, "modelopt_fp8": 1}
+
+
+def _moe_fields_from_hf(hf: Any) -> dict[str, Any]:
+    """MoE ``ModelSpec`` kwargs read off an HF config, or ``{}`` for a dense model.
+
+    Every field is optional: a config with no expert fields yields ``{}`` and the
+    spec stays dense, which is the correct read for a non-MoE model rather than a
+    guess. Duck-typed across families and tolerant of partial configs.
+    """
+    out: dict[str, Any] = {}
+    for field, aliases in _MOE_ALIASES.items():
+        for alias in aliases:
+            raw = getattr(hf, alias, None)
+            if raw is None:
+                continue
+            try:
+                value = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                out[field] = value
+                break
+
+    # Only a routed-expert count *and* a top-k make the FFN a mixture; without
+    # both, leave the spec dense rather than half-configured.
+    if not (out.get("num_experts") and out.get("experts_per_token")):
+        return {}
+
+    quant = getattr(hf, "quantization_config", None)
+    method = None
+    if isinstance(quant, dict):
+        method = quant.get("quant_method")
+    elif quant is not None:
+        method = getattr(quant, "quant_method", None)
+    if isinstance(method, str):
+        wb = _QUANT_WEIGHT_BYTES.get(method.lower())
+        if wb:
+            out["weight_dtype_bytes"] = wb
+    return out
 
 
 def _clamp_pct(value: float) -> float:

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -237,6 +237,36 @@ _ATTN_ALIASES: dict[str, tuple[str, ...]] = {
 _QUANT_WEIGHT_BYTES: dict[str, int] = {"fp8": 1, "compressed-tensors": 1, "modelopt_fp8": 1}
 
 
+def _batch_config_from_stats(sched: Any):
+    """A :class:`BatchConfig` carrying the *observed* decode batch, or ``None``.
+
+    ``predict_graph``'s default is ``batch=1``. That is wrong for any real serving
+    window and especially wrong for a mixture-of-experts model, where weight
+    traffic scales with the distinct experts a batch activates: at top-8 of 256,
+    a batch of 1 touches 8 experts but a batch of 16 touches ~100, so scoring a
+    batch-16 step against the batch-1 ceiling understates expert traffic by more
+    than 10x. ``mean_running`` is vLLM's own count of concurrently running
+    sequences, which is exactly the decode batch.
+
+    Returns ``None`` (caller falls back to the default) when no scheduler samples
+    were taken — a CPU box, a dry run, or an engine that exposes no stats. Better
+    a documented default than a fabricated batch.
+
+    ``kv_cache_len`` is deliberately left at its default: nothing in the sampled
+    stats gives a token count (``peak_gpu_cache_usage`` is a fraction of blocks,
+    not a length), and inventing one would move the full-attention ceiling on a
+    guess. Sourcing it is tracked separately.
+    """
+    from gitm.planner.roofline import BatchConfig
+
+    if sched is None or getattr(sched, "n_samples", 0) == 0:
+        return None
+    running = getattr(sched, "mean_running", None)
+    if running is None or running < 1:
+        return None
+    return BatchConfig(batch=max(int(round(float(running))), 1))
+
+
 def _read_int_aliases(hf: Any, table: dict[str, tuple[str, ...]]) -> dict[str, Any]:
     """First positive int found for each field across its aliases. Duck-typed."""
     out: dict[str, Any] = {}
@@ -533,7 +563,14 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     pctx = build_planner_context(cfg.engine, workload=workload)
     _spec = _model_spec_from_engine(cfg.engine)
     _hw = hardware_spec_for(pctx.peak)
-    graph = predict_graph(model=_spec, hw=_hw) if _spec is not None else predict_graph(hw=_hw)
+    # Batch matters for the same reason the model does — and more so on a
+    # mixture, where weight traffic follows the *distinct* experts a batch
+    # activates: distinct(1)=top_k but distinct(16) is an order of magnitude
+    # larger, so predicting a batch-16 step at the batch-1 default understates
+    # expert traffic ~12x. Read the real concurrency off the sampled scheduler
+    # rather than defaulting.
+    _batch = _batch_config_from_stats(sched_summary)
+    graph = predict_graph(model=_spec, hw=_hw, batch=_batch)
     (run_dir / "predicted_graph.json").write_text(
         json.dumps(
             {"nodes": len(graph.nodes), "total_pred_s": graph.total_pred_s, "hardware": _hw.name},

--- a/tests/test_moe_roofline.py
+++ b/tests/test_moe_roofline.py
@@ -325,6 +325,105 @@ def test_param_accounting_is_internally_consistent():
     assert m.active_params == 2 * (attn + experts_active + shared + router) + embed
 
 
+# --- hybrid attention: linear layers do not carry a growing KV cache ---------
+
+
+def test_conventional_transformer_is_all_full_attention():
+    m = ModelSpec(n_layers=4)
+    assert [m.is_full_attention_layer(i) for i in range(4)] == [True] * 4
+    assert m.n_full_attention_layers == 4
+    assert not m.is_hybrid_attention
+
+
+def test_hybrid_places_one_full_attention_layer_every_step():
+    m = ModelSpec(n_layers=8, full_attn_layer_step=4)
+    assert [m.is_full_attention_layer(i) for i in range(8)] == [
+        True, False, False, False, True, False, False, False
+    ]
+    assert m.n_full_attention_layers == 2
+    assert m.is_hybrid_attention
+
+
+def test_linear_attention_traffic_is_flat_in_context():
+    """The defining property: a recurrent state does not grow with sequence length,
+    so a linear layer's traffic is identical at 1k and 16k context."""
+    m = ModelSpec(hidden=2048, n_layers=2, n_heads=32, num_kv_heads=4,
+                  head_dim=128, full_attn_layer_step=2)  # layer 0 full, layer 1 linear
+    short = predict_graph(m, H100, BatchConfig(batch=8, kv_cache_len=1024))
+    long = predict_graph(m, H100, BatchConfig(batch=8, kv_cache_len=16384))
+    lin_short = [n for n in short.nodes if n.op == "attn_score_value"][1].prediction
+    lin_long = [n for n in long.nodes if n.op == "attn_score_value"][1].prediction
+    assert lin_short.bytes == lin_long.bytes, "linear-attention state must be context-free"
+    # ...while the full-attention layer scales with context, 16x here.
+    full_short = [n for n in short.nodes if n.op == "attn_score_value"][0].prediction
+    full_long = [n for n in long.nodes if n.op == "attn_score_value"][0].prediction
+    assert full_long.bytes == pytest.approx(16 * full_short.bytes)
+
+
+def test_hybrid_cuts_long_context_attention_traffic_dramatically():
+    """Why a hybrid model serves 16k context at a few percent KV utilisation:
+    pricing every layer as full attention overstates traffic by ~an order of
+    magnitude."""
+    shape = dict(hidden=2048, n_layers=8, n_heads=32, num_kv_heads=4, head_dim=128)
+    conventional = ModelSpec(**shape)
+    hybrid = ModelSpec(**shape, full_attn_layer_step=4)
+    cfg = BatchConfig(batch=16, kv_cache_len=16384)
+    total = lambda m: sum(  # noqa: E731
+        n.prediction.bytes for n in predict_graph(m, H100, cfg).nodes
+        if n.op == "attn_score_value"
+    )
+    assert total(hybrid) < total(conventional) / 3
+
+
+def test_hybrid_attention_does_not_change_the_op_vocabulary():
+    """Linear-attention layers still emit attn_score_value — the canonical
+    vocabulary that classify_op and library.yaml key off is unchanged."""
+    ops = [n.op for n in predict_graph(
+        ModelSpec(n_layers=4, full_attn_layer_step=2), H100, BatchConfig(batch=2)
+    ).nodes]
+    assert ops.count("attn_score_value") == 4
+    assert set(ops) == {n.op for n in predict_graph(ModelSpec(n_layers=4)).nodes}
+
+
+def test_hybrid_and_moe_compose():
+    """The two axes are independent: a model can be hybrid-attention AND MoE."""
+    m = ModelSpec(hidden=2048, n_layers=8, intermediate=768, n_heads=32,
+                  num_kv_heads=4, head_dim=128, num_experts=64, experts_per_token=4,
+                  moe_intermediate=768, full_attn_layer_step=4, first_dense_layers=1)
+    assert m.is_moe and m.is_hybrid_attention
+    assert m.n_full_attention_layers == 2
+    assert m.n_moe_layers == 7  # layer 0 dense FFN
+    g = predict_graph(m, H100, BatchConfig(batch=8, kv_cache_len=4096))
+    assert g.total_pred_s > 0
+    assert all(n.prediction.bytes > 0 for n in g.nodes)
+
+
+def test_hf_attention_shape_survives_a_dense_ffn():
+    """Regression: attention shape and FFN sparsity are independent axes, so a
+    hybrid model with a dense FFN must still get full_attn_layer_step."""
+    from gitm.scheduler.loop import _moe_fields_from_hf
+
+    class HybridDense:  # hybrid attention, no experts
+        full_attention_interval = 4
+
+    class PlainMoE:  # experts, conventional attention
+        num_experts = 64
+        num_experts_per_tok = 4
+
+    assert _moe_fields_from_hf(HybridDense()) == {"full_attn_layer_step": 4}
+    got = _moe_fields_from_hf(PlainMoE())
+    assert got["num_experts"] == 64 and "full_attn_layer_step" not in got
+
+
+def test_hf_half_configured_moe_stays_dense():
+    from gitm.scheduler.loop import _moe_fields_from_hf
+
+    class OnlyExpertCount:
+        num_experts = 64  # no top-k
+
+    assert _moe_fields_from_hf(OnlyExpertCount()) == {}
+
+
 def test_total_prediction_is_finite_and_positive_across_shapes():
     """Versatility guard: a spread of real MoE shapes all predict sanely."""
     shapes = [

--- a/tests/test_moe_roofline.py
+++ b/tests/test_moe_roofline.py
@@ -1,0 +1,240 @@
+"""MoE roofline: batch-dependent expert fetch, and dense back-compat.
+
+The property under test is the one that makes a mixture different from a dense
+FFN: *compute* scales with the experts each token activates (linear in batch)
+while *weight traffic* scales with the distinct experts the batch touches, which
+saturates at ``num_experts``. Getting that curve right is what makes an MoE
+residual mean anything — a dense ceiling is wrong by ~28x at batch 1, and a
+flat "active params" ceiling is wrong by the same factor at large batch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gitm.planner.graph import predict_graph
+from gitm.planner.roofline import BatchConfig, HardwareSpec, ModelSpec, distinct_experts
+
+# Qwen3.6-35B-A3B-FP8 shaped: narrow hidden, many narrow experts, one shared
+# expert, fp8 weights with bf16 activations.
+MOE = ModelSpec(
+    name="moe-test", hidden=2048, n_layers=40, n_heads=32, num_kv_heads=4,
+    head_dim=128, intermediate=0, vocab=151936, num_experts=256,
+    experts_per_token=8, moe_intermediate=768, shared_experts=1,
+    dtype_bytes=2, weight_dtype_bytes=1,
+)
+H100 = HardwareSpec(
+    name="H100", peak_flops_fp16_per_s=1979e12, peak_mem_bw_bytes_per_s=3.35e12
+)
+
+
+def _node(model, batch, op, hw=H100):
+    g = predict_graph(model, hw, BatchConfig(batch=batch))
+    return next(n for n in g.nodes if n.op == op).prediction
+
+
+# --- distinct_experts: the term itself ---------------------------------------
+
+
+def test_batch_one_touches_exactly_top_k():
+    assert distinct_experts(1, 256, 8) == pytest.approx(8.0)
+
+
+def test_saturates_at_num_experts():
+    # Past the knee the union stops growing — the step has fetched every expert,
+    # i.e. the whole model, so MoE's bandwidth edge over a dense model is gone.
+    assert distinct_experts(10**6, 256, 8) == pytest.approx(256.0)
+    assert distinct_experts(128, 256, 8) > 250  # ~98% by batch 128
+
+
+def test_sublinear_between_the_limits():
+    """Strictly below the naive b*k line once collisions start, and monotone."""
+    prev = 0.0
+    for b in (1, 2, 4, 8, 16, 32, 64, 128):
+        d = distinct_experts(b, 256, 8)
+        assert d > prev, "distinct count must be monotone in batch"
+        assert d <= min(b * 8, 256) + 1e-9, "cannot exceed b*k, nor the expert count"
+        if b >= 8:
+            assert d < b * 8, f"collisions must make it sublinear by b={b}"
+        prev = d
+
+
+def test_top_k_equal_to_num_experts_touches_all():
+    # Every token already routes everywhere; one token suffices.
+    assert distinct_experts(1, 8, 8) == pytest.approx(8.0)
+    # And top_k is clamped rather than allowed to exceed the expert count.
+    assert distinct_experts(4, 8, 99) == pytest.approx(8.0)
+
+
+def test_degenerate_inputs_are_zero_not_errors():
+    assert distinct_experts(0, 256, 8) == 0.0
+    assert distinct_experts(4, 0, 8) == 0.0
+    assert distinct_experts(4, 256, 0) == 0.0
+    assert distinct_experts(-1, 256, 8) == 0.0
+
+
+# --- ModelSpec surface --------------------------------------------------------
+
+
+def test_dense_spec_is_not_moe_and_falls_back():
+    m = ModelSpec()
+    assert not m.is_moe
+    assert m.top_k == 0
+    assert m.w_bytes == m.dtype_bytes  # no separate weight width configured
+    assert m.expert_intermediate == m.intermediate
+
+
+def test_moe_spec_properties():
+    assert MOE.is_moe
+    assert MOE.top_k == 8
+    assert MOE.w_bytes == 1 and MOE.dtype_bytes == 2  # fp8 weights, bf16 acts
+    assert MOE.expert_intermediate == 768
+    assert MOE.shared_intermediate == 768  # falls back to the routed width
+
+
+def test_num_experts_without_top_k_stays_dense():
+    """Half-configured is dense, not a mixture — no silent guessing."""
+    assert not ModelSpec(num_experts=256).is_moe
+    assert not ModelSpec(experts_per_token=8).is_moe
+
+
+# --- graph: dense back-compat -------------------------------------------------
+
+
+@pytest.mark.parametrize("b", [1, 8, 64])
+def test_dense_ffn_arithmetic_is_unchanged(b):
+    """The dense path must reproduce the pre-MoE formulas byte for byte."""
+    m = ModelSpec()
+    dt, h, ff = m.dtype_bytes, m.hidden, m.intermediate
+    gu = _node(m, b, "mlp_gate_up")
+    dn = _node(m, b, "mlp_down")
+    assert gu.flops == 2 * 2 * b * h * ff
+    assert gu.bytes == dt * (b * h + 2 * h * ff + 2 * b * ff)
+    assert dn.flops == 2 * b * ff * h
+    assert dn.bytes == dt * (b * ff + ff * h + b * h)
+
+
+def test_moe_does_not_disturb_non_ffn_ops():
+    """Only the FFN ops change; attention/lm_head must match the dense model."""
+    shape = dict(hidden=2048, n_layers=2, n_heads=32, num_kv_heads=4,
+                 head_dim=128, vocab=151936, intermediate=768)
+    dense = ModelSpec(**shape)
+    moe = ModelSpec(**shape, num_experts=256, experts_per_token=8, moe_intermediate=768)
+    for op in ("qkv_proj", "attn_score_value", "attn_out_proj", "lm_head"):
+        d, m = _node(dense, 8, op), _node(moe, 8, op)
+        assert (d.flops, d.bytes) == (m.flops, m.bytes), f"{op} should be untouched"
+
+
+def test_graph_node_vocabulary_is_unchanged_for_moe():
+    """No new op names — library.yaml/classify_op key off this vocabulary."""
+    dense_ops = {n.op for n in predict_graph(ModelSpec(n_layers=2)).nodes}
+    moe_ops = {n.op for n in predict_graph(
+        ModelSpec(n_layers=2, num_experts=64, experts_per_token=4, moe_intermediate=512)
+    ).nodes}
+    assert moe_ops == dense_ops
+
+
+# --- graph: the MoE property that matters -------------------------------------
+
+
+def test_compute_grows_linearly_while_weight_traffic_saturates():
+    """The core asymmetry. Doubling batch past the knee roughly doubles flops but
+    barely moves bytes, because the expert union is already nearly complete."""
+    big, bigger = _node(MOE, 512, "mlp_gate_up"), _node(MOE, 1024, "mlp_gate_up")
+    assert bigger.flops == pytest.approx(2 * big.flops, rel=0.01)
+    assert bigger.bytes < 1.30 * big.bytes, "weight traffic must have flattened"
+
+
+def test_arithmetic_intensity_rises_with_batch():
+    """Direct consequence: FLOP/byte climbs, so the op walks toward compute-bound."""
+    ai = [
+        _node(MOE, b, "mlp_gate_up").flops / _node(MOE, b, "mlp_gate_up").bytes
+        for b in (1, 8, 32, 128, 1024)
+    ]
+    assert ai == sorted(ai), f"AI must be monotone in batch, got {ai}"
+    assert ai[0] < 5, "batch-1 decode is a GEMV: a couple of FLOPs per byte"
+    assert ai[-1] > 10 * ai[0]
+
+
+def test_batch_one_decode_is_memory_bound():
+    assert _node(MOE, 1, "mlp_gate_up").bound == "memory"
+
+
+def test_moe_moves_far_less_than_a_dense_model_of_the_same_total_size():
+    """At batch 1 only top-k experts are read — the reason MoE is efficient."""
+    dense_equiv = ModelSpec(
+        hidden=2048, n_layers=40, intermediate=256 * 768, dtype_bytes=2, weight_dtype_bytes=1
+    )
+    d = _node(dense_equiv, 1, "mlp_gate_up").bytes
+    m = _node(MOE, 1, "mlp_gate_up").bytes
+    assert d / m > 20, f"expected a large gap at batch 1, got {d / m:.1f}x"
+
+
+def test_large_batch_fetches_the_entire_expert_set():
+    """Past saturation the step reads *every* expert — the whole model's weights —
+    so MoE's bandwidth advantage over a dense model of the same total size is gone.
+
+    Asserted as an exact decomposition, which pins the formula rather than a
+    ratio. Note total bytes still differ from a same-width dense FFN: that model
+    also pushes every token through a 256x wider intermediate, so its
+    *activation* traffic is far larger. Only the weight term converges.
+    """
+    b = 4096
+    node = _node(MOE, b, "mlp_gate_up")
+    assert distinct_experts(b, MOE.num_experts, MOE.top_k) == pytest.approx(
+        MOE.num_experts
+    ), "precondition: the expert union must be saturated at this batch"
+
+    weights = MOE.w_bytes * (
+        MOE.num_experts * 2 * MOE.hidden * MOE.expert_intermediate  # every routed expert
+        + MOE.shared_experts * 2 * MOE.hidden * MOE.shared_intermediate
+        + MOE.hidden * MOE.num_experts  # router
+    )
+    acts = MOE.dtype_bytes * (
+        b * MOE.hidden
+        + 2 * b * (MOE.top_k * MOE.expert_intermediate
+                   + MOE.shared_experts * MOE.shared_intermediate)
+    )
+    assert node.bytes == pytest.approx(weights + acts, rel=1e-9)
+
+    # And the weight half matches what a dense model of the same total size reads.
+    dense_equiv = ModelSpec(
+        hidden=2048, n_layers=40, intermediate=256 * 768, dtype_bytes=2, weight_dtype_bytes=1
+    )
+    dense_weights = dense_equiv.w_bytes * 2 * dense_equiv.hidden * dense_equiv.intermediate
+    assert weights == pytest.approx(dense_weights, rel=0.01)
+
+
+def test_shared_expert_adds_flops_and_bytes():
+    base = dict(hidden=2048, n_layers=2, intermediate=768, num_experts=64,
+                experts_per_token=4, moe_intermediate=768)
+    without = _node(ModelSpec(**base), 8, "mlp_gate_up")
+    with_shared = _node(ModelSpec(**base, shared_experts=1), 8, "mlp_gate_up")
+    assert with_shared.flops > without.flops
+    assert with_shared.bytes > without.bytes
+
+
+def test_quantized_weights_cut_the_dominant_term():
+    """fp8 weights roughly halve batch-1 traffic vs bf16 — it is nearly all weights."""
+    base = dict(hidden=2048, n_layers=2, num_experts=256, experts_per_token=8,
+                moe_intermediate=768, intermediate=768, dtype_bytes=2)
+    bf16 = _node(ModelSpec(**base), 1, "mlp_gate_up").bytes
+    fp8 = _node(ModelSpec(**base, weight_dtype_bytes=1), 1, "mlp_gate_up").bytes
+    assert 0.45 < fp8 / bf16 < 0.6, f"expected ~half, got {fp8 / bf16:.2f}"
+
+
+def test_total_prediction_is_finite_and_positive_across_shapes():
+    """Versatility guard: a spread of real MoE shapes all predict sanely."""
+    shapes = [
+        dict(num_experts=8, experts_per_token=2, moe_intermediate=14336),    # Mixtral-ish
+        dict(num_experts=64, experts_per_token=6, moe_intermediate=1408),    # DeepSeek-ish
+        dict(num_experts=128, experts_per_token=8, moe_intermediate=768),    # Qwen-ish
+        dict(num_experts=256, experts_per_token=1, moe_intermediate=2048),   # extreme top-1
+    ]
+    for extra in shapes:
+        m = ModelSpec(hidden=2048, n_layers=4, intermediate=768, **extra)
+        for b in (1, 16, 256):
+            g = predict_graph(m, H100, BatchConfig(batch=b))
+            assert g.total_pred_s > 0
+            assert all(n.prediction.t_pred_s >= 0 for n in g.nodes)
+            assert all(n.prediction.bytes > 0 for n in g.nodes)

--- a/tests/test_moe_roofline.py
+++ b/tests/test_moe_roofline.py
@@ -223,6 +223,108 @@ def test_quantized_weights_cut_the_dominant_term():
     assert 0.45 < fp8 / bf16 < 0.6, f"expected ~half, got {fp8 / bf16:.2f}"
 
 
+# --- per-layer placement: MoE checkpoints are not uniformly sparse -----------
+
+
+def test_all_layers_moe_by_default():
+    m = ModelSpec(n_layers=4, num_experts=64, experts_per_token=4)
+    assert [m.is_moe_layer(i) for i in range(4)] == [True] * 4
+    assert m.n_moe_layers == 4
+
+
+def test_leading_dense_layers_are_dense():
+    """DeepSeek-style first_k_dense_replace."""
+    m = ModelSpec(n_layers=6, num_experts=64, experts_per_token=4, first_dense_layers=2)
+    assert [m.is_moe_layer(i) for i in range(6)] == [False, False, True, True, True, True]
+    assert m.n_moe_layers == 4
+
+
+def test_moe_layer_step_interleaves():
+    """Qwen-style decoder_sparse_step: every Nth layer is MoE."""
+    m = ModelSpec(n_layers=6, num_experts=64, experts_per_token=4, moe_layer_step=2)
+    assert [m.is_moe_layer(i) for i in range(6)] == [True, False, True, False, True, False]
+    assert m.n_moe_layers == 3
+
+
+def test_dense_model_has_no_moe_layers():
+    m = ModelSpec(n_layers=4)
+    assert not any(m.is_moe_layer(i) for i in range(4))
+    assert m.n_moe_layers == 0
+
+
+def test_dense_layers_are_priced_as_dense_in_the_graph():
+    """A dense block inside an MoE model must use dense FFN arithmetic — pricing
+    it as MoE would inflate the predicted ceiling for that layer."""
+    m = ModelSpec(hidden=2048, n_layers=4, intermediate=768, num_experts=256,
+                  experts_per_token=8, moe_intermediate=768, first_dense_layers=2)
+    g = predict_graph(m, H100, BatchConfig(batch=16))
+    gate_ups = [n for n in g.nodes if n.op == "mlp_gate_up"]
+    assert len(gate_ups) == 4
+    dense_bytes = gate_ups[0].prediction.bytes   # layer 0 -> dense
+    moe_bytes = gate_ups[2].prediction.bytes     # layer 2 -> MoE
+    assert dense_bytes != moe_bytes
+    # The dense layer must match the plain single-FFN formula exactly.
+    dt, wb, h, ff = m.dtype_bytes, m.w_bytes, m.hidden, m.intermediate
+    b = 16
+    assert dense_bytes == dt * (b * h + 2 * b * ff) + wb * (2 * h * ff)
+    # And the MoE layer reads many experts, so it moves strictly more.
+    assert moe_bytes > dense_bytes
+
+
+# --- active vs total params ---------------------------------------------------
+
+
+def test_dense_model_active_equals_total():
+    m = ModelSpec()
+    assert m.active_params == m.total_params
+
+
+def test_moe_active_is_a_small_fraction_of_total():
+    """The '35B-A3B' property: only top_k of num_experts participate per token."""
+    assert MOE.active_params < MOE.total_params
+    assert MOE.active_params / MOE.total_params < 0.2
+
+
+def test_expert_params_scale_with_k_over_e():
+    """Isolate the expert term: doubling top_k roughly doubles the active expert
+    params, while total is unchanged."""
+    base = dict(hidden=2048, n_layers=8, intermediate=768, num_experts=64,
+                moe_intermediate=768, vocab=1000)
+    k4 = ModelSpec(**base, experts_per_token=4)
+    k8 = ModelSpec(**base, experts_per_token=8)
+    assert k4.total_params == k8.total_params
+    # Difference is exactly 4 more experts' worth of FFN per MoE layer.
+    delta = k8.active_params - k4.active_params
+    expected = k4.n_moe_layers * 4 * 3 * 2048 * 768
+    assert delta == expected
+
+
+def test_dense_layers_shift_params_from_experts_to_dense_ffn():
+    base = dict(hidden=2048, n_layers=8, intermediate=768, num_experts=64,
+                experts_per_token=4, moe_intermediate=768, vocab=1000)
+    all_moe = ModelSpec(**base)
+    half = ModelSpec(**base, first_dense_layers=4)
+    # Fewer MoE layers => far fewer total params (experts dominate the count).
+    assert half.total_params < all_moe.total_params
+    assert half.n_moe_layers == 4 and all_moe.n_moe_layers == 8
+
+
+def test_param_accounting_is_internally_consistent():
+    """Hand-derive both sides for a small shape so the formula is pinned, not
+    just self-consistent."""
+    m = ModelSpec(hidden=64, n_layers=2, n_heads=4, num_kv_heads=4, head_dim=16,
+                  intermediate=128, vocab=100, num_experts=8, experts_per_token=2,
+                  moe_intermediate=32, shared_experts=1)
+    attn = 64 * (4 + 2 * 4) * 16 + 4 * 16 * 64          # qkv + out proj
+    router = 64 * 8
+    experts_total = 8 * 3 * 64 * 32
+    experts_active = 2 * 3 * 64 * 32
+    shared = 1 * 3 * 64 * 32
+    embed = 2 * 100 * 64
+    assert m.total_params == 2 * (attn + experts_total + shared + router) + embed
+    assert m.active_params == 2 * (attn + experts_active + shared + router) + embed
+
+
 def test_total_prediction_is_finite_and_positive_across_shapes():
     """Versatility guard: a spread of real MoE shapes all predict sanely."""
     shapes = [

--- a/tests/test_moe_roofline.py
+++ b/tests/test_moe_roofline.py
@@ -424,6 +424,46 @@ def test_hf_half_configured_moe_stays_dense():
     assert _moe_fields_from_hf(OnlyExpertCount()) == {}
 
 
+# --- real batch from scheduler stats -----------------------------------------
+
+
+def test_batch_config_from_stats_uses_observed_concurrency():
+    from gitm.scheduler.loop import _batch_config_from_stats
+
+    class Sched:
+        n_samples = 12
+        mean_running = 15.6
+
+    cfg = _batch_config_from_stats(Sched())
+    assert cfg is not None and cfg.batch == 16  # rounded
+
+
+def test_batch_config_falls_back_when_no_samples():
+    """No stats -> None, so the caller keeps the documented default rather than
+    inventing a batch."""
+    from gitm.scheduler.loop import _batch_config_from_stats
+
+    class NoSamples:
+        n_samples = 0
+        mean_running = 8.0
+
+    class NoRunning:
+        n_samples = 5
+        mean_running = None
+
+    assert _batch_config_from_stats(None) is None
+    assert _batch_config_from_stats(NoSamples()) is None
+    assert _batch_config_from_stats(NoRunning()) is None
+
+
+def test_wrong_batch_badly_misprices_expert_traffic():
+    """Why the batch source matters: scoring a batch-16 step against the batch-1
+    default understates expert weight traffic by ~10x on a top-8-of-256 mixture."""
+    at1 = _node(MOE, 1, "mlp_gate_up").bytes
+    at16 = _node(MOE, 16, "mlp_gate_up").bytes
+    assert at16 / at1 > 8, f"expected a large gap, got {at16 / at1:.1f}x"
+
+
 def test_total_prediction_is_finite_and_positive_across_shapes():
     """Versatility guard: a spread of real MoE shapes all predict sanely."""
     shapes = [


### PR DESCRIPTION
Makes the predicted ceiling meaningful for mixture-of-experts models. Every downstream consumer — residuals, deviation, attribution, largest-residual targeting, lever selection — is measured against `t_pred`, so on an MoE model a dense ceiling makes all of it noise.

## Why: validated against a real captured MoE run

I checked this against an actual on-GPU capture (Qwen MoE, H100, 57,376 kernels — `fused_moe_kernel`, `topkGating<8,256,…>`, fp8 expert GEMMs). What the dense ceiling produced:

| | |
|---|---|
| observed kernels | **57,376** |
| predicted nodes | **161** (= 32 layers × 5 + 1, i.e. the *Llama-2-7B default*) |
| `<unmodeled>` | **55,985 — 97.6%** |
| violations / residuals | **1,392 / 1,391 — a ~100% violation rate** |

And on the one op that did map, comparing ceilings against the observed median `fused_moe_kernel` (16.3 µs):

| ceiling | predicted | residual |
|---|---|---|
| dense Llama-2-7B (what the run used) | 53.9 µs | **−69.7%** |
| MoE-aware (this branch) | 7.7 µs | **+112%** |

**The sign is the point.** A roofline is a *floor* on time, so observed must be ≥ predicted. The dense ceiling says the model runs 3.3× *faster than its own floor* — physically impossible, and therefore no actionable signal. The MoE ceiling says it runs 2.1× above an achievable floor, which is a real headroom number. (Magnitude is approximate: hidden/layer count weren't recoverable from the trace, only `num_experts=256`/`top_k=8` from the kernel template.)

## What changed

**1. Batch-dependent expert fetch** — `distinct(B) = E·(1 − (1 − k/E)^B)`. An expert's weights are read once per step however many tokens route to it, so weight traffic follows the *union* of selected experts while compute follows `b·top_k`. Compute is linear, bytes saturate at `E`, so arithmetic intensity rises with batch — MoE decode is memory-bound at low batch. Verified: B=1 → 8 experts, B=32 → 163, B=128 → 252, → 256.

**2. Per-layer MoE placement** — real checkpoints aren't uniformly sparse (DeepSeek `first_k_dense_replace`, Qwen `decoder_sparse_step`). Modeling every layer as MoE inflates the ceiling by whatever fraction is actually dense.

**3. Active-vs-total params** — FLOPs follow active weights, checkpoint size and saturated traffic follow total. Conflating them is the ~10× error. *Independent check: the dense accounting reproduces Llama-2-7B's published 6.74B from the default spec.*

**4. Hybrid attention** — linear/recurrent layers (gated DeltaNet, Mamba) keep constant state, not a growing KV cache. Pricing them as KV overstates traffic by ~`kv_len/head_dim` — >100× at 16k context, which is why a real hybrid run shows single-digit KV utilisation where a dense model predicts saturation. The tracer already separated these (`kernel_taxonomy`'s `linear_attn` bucket); the ceiling didn't.

**5. Observed batch** — `predict_graph` was called with no `BatchConfig`, so every prediction assumed `batch=1`. Now reads `mean_running` off the scheduler samples the loop already collects.

Also: quantized-weight width split from activation width (`weight_dtype_bytes`), since MoE decode is weight-fetch bound and fp8 checkpoints are the common case; HF config readers across Qwen/Mixtral/DeepSeek naming.

## Compatibility

Every MoE field is opt-in; `num_experts=0` keeps the dense path **byte-identical** to the previous formulas, asserted at b=1/8/64. The canonical op vocabulary (`qkv_proj … lm_head`) that `classify_op` and `library.yaml`'s `applies_to_kernels` key off is unchanged — linear-attention layers still emit `attn_score_value`, and the router GEMM is folded into `mlp_gate_up` rather than given a node.

## Honest limits

- **The dominant problem in that run is not the ceiling — it's that 97.6% of kernels map to no op at all.** That's `classify_op`/alignment, which this PR does not address. Fixing the ceiling is necessary, not sufficient.
- That run also fell back to the *default* spec rather than the real model, meaning `_model_spec_from_engine` returned `None` — a silent failure worth its own investigation.
- `kv_cache_len` is still defaulted; nothing in the sampled stats gives a token count, and inventing one would move the full-attention ceiling on a guess.
- Uniform routing is an explicit assumption. Real routers are skewed, and skew makes tokens collide on hot experts, so true distinct count is at or below this estimate — the prediction errs toward more traffic, never toward an optimistic floor.
- `linear_attn_state_elems = n_heads·head_dim²` is an approximation; architectures differ on whether linear heads share softmax head dims. The *shape* (flat in sequence length) is what matters.

## Tests

42 tests in `tests/test_moe_roofline.py`, including a hand-derived param-accounting identity, byte-exact dense back-compat, and linear-attention bytes identical at 1k vs 16k context while full attention scales 16×. `ruff` clean. Full-suite failures identical to the `origin/main` baseline (9 pre-existing), none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
