### PR TITLE
feat: sparse-MoE predicted graph + per-rank sharding DeepSeek-V4 on Blackwell

### DIFF
--- a/gitm/optimizer/deviation.py
+++ b/gitm/optimizer/deviation.py
@@ -42,8 +42,39 @@ from gitm.tracer.schema import KernelEvent, Trace
 # vLLM's `reshape_and_cache_flash_kernel`/`_compute_slot_mapping_kernel`
 # weren't covered before.
 _OP_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
+    # ── sparse-MoE / compressed-attention ops, first because their vocabularies
+    # are subsets of the generic ones below: `moe_align_block_size` contains
+    # "moe" but is routing, not an expert GEMM; `shared_expert` contains
+    # "expert" but is unconditional work with a completely different cost curve;
+    # and the indexer must never fall through to a bare "index" rule, which is
+    # how it currently gets misfiled as elementwise in the coarse taxonomy.
+    #
+    # Needles are deliberately narrow ("indexer", not "index") — a loose needle
+    # here silently reattributes ordinary gather/scatter work to attention, and
+    # a wrong attribution is worse than an unmodeled one because it is invisible.
+    # Collectives first of all. NCCL names every kernel `ncclDevKernel_<Op>`, so
+    # a generic "nccl" needle would swallow the all-to-all — and expert-parallel
+    # dispatch is the one collective whose cost a MoE deployment exists to
+    # trade against, so it must not disappear into a bucket labelled all-reduce.
+    (("alltoall", "all_to_all", "_a2a", "dispatch_combine"), "moe_all_to_all"),
+    (("nccl", "allreduce", "all_reduce", "custom_ar", "cross_device",
+      "one_shot", "two_shot", "reduce_scatter", "all_gather"), "tp_all_reduce"),
+    (("indexer", "lightning_index", "index_topk", "topk_indices"), "attn_index_score"),
+    (("shared_expert", "moe_shared"), "moe_shared"),
+    (("moe_align", "topk_softmax", "router", "routing", "sinkhorn",
+      "expert_bias"), "moe_router"),
+    (("moe", "expert", "grouped_gemm", "group_gemm", "groupedgemm"), "moe_routed"),
+    (("dspark",), "dspark"),
+    (("flash_mla", "mla_sparse", "sparse_mla", "cutlass_mla",
+      "sparse_fwd"), "attn_score_value"),
     (("flash_attn", "flashattn", "flash_fwd", "paged_attention", "paged_attn", "fmha",
       "attention", "attn_score", "reshape_and_cache", "slot_mapping"), "attn_score_value"),
+    (("q_a_proj", "q_lora", "q_down"), "attn_q_a"),
+    (("q_b_proj", "q_up"), "attn_q_b"),
+    # `kv_b_proj` is absent on purpose: in the absorbed decode form it is folded
+    # into the query and output projections, so there is no node to map it to and
+    # a guess would attribute real work to the wrong op.
+    (("kv_a_proj", "kv_lora", "kv_down", "compress_kv"), "attn_kv_a"),
     (("qkv",), "qkv_proj"),
     (("o_proj", "out_proj", "attn_out"), "attn_out_proj"),
     (("gate_up", "gate_proj", "up_proj", "swiglu", "silu_and_mul"), "mlp_gate_up"),

--- a/gitm/planner/context.py
+++ b/gitm/planner/context.py
@@ -27,6 +27,17 @@ from gitm.planner.roofline import HardwareSpec
 # itself. "L40" must stay ordered before "L4" (see peak_for_sku) since "l4" is
 # a substring of "l40" and the first substring match wins.
 _PEAKS: dict[str, tuple[float, float]] = {
+    # "GB200" must precede "B200": the latter is a substring of the former, and
+    # the first substring match wins. Both are the same silicon per GPU, so the
+    # ordering is cosmetic here — it stops mattering the moment they diverge.
+    # Blackwell Ultra raises dense fp4 by ~1.67x and doubles HBM, but leaves
+    # bf16/fp8 and — decisively for decode — memory bandwidth unchanged at
+    # 8 TB/s. A memory-bound decode step therefore sees essentially none of the
+    # uplift, which is only visible if these are separate entries.
+    "GB300": (2250e12, 8000e9),
+    "B300": (2250e12, 8000e9),
+    "GB200": (2250e12, 8000e9),
+    "B200": (2250e12, 8000e9),
     "H100": (989e12, 3350e9),
     "H200": (989e12, 4800e9),
     "A100-SXM": (312e12, 2039e9),
@@ -36,6 +47,64 @@ _PEAKS: dict[str, tuple[float, float]] = {
     "T4": (65e12, 320e9),  # the common free-tier Colab GPU
     "V100": (125e12, 900e9),
 }
+
+# Low-precision tensor-core peaks (FLOP/s), keyed by the same SKU substrings as
+# ``_PEAKS``. A SKU absent here has no fp8/fp4 path *or* no catalogue entry yet;
+# both resolve identically in :func:`gitm.planner.roofline.resolve_peak`, which
+# falls back up the precision ladder and flags the prediction.
+#
+# Dense figures, no 2:4 sparsity — the sparsity-doubled numbers in vendor
+# marketing do not apply to a dense decode step, and using them would halve every
+# predicted compute time and so double the apparent headroom.
+#
+_QUANT_PEAKS: dict[str, dict[str, float]] = {
+    # Blackwell Ultra: 15 PFLOPS dense fp4, with fp8/bf16 carried over from B200.
+    "GB300": {"fp8": 4500e12, "fp4": 15000e12},
+    "B300": {"fp8": 4500e12, "fp4": 15000e12},
+    "GB200": {"fp8": 4500e12, "fp4": 9000e12},
+    "B200": {"fp8": 4500e12, "fp4": 9000e12},
+    # Hopper has fp8 tensor cores; it has no fp4 path (MXFP4 runs dequantised
+    # through Marlin, which is why an fp4 checkpoint traced on H100/H200 prices
+    # against fp8 and still shows a compute-bound expert GEMM).
+    "H100": {"fp8": 1979e12},
+    "H200": {"fp8": 1979e12},
+}
+
+
+# Per-GPU bidirectional NVLink bandwidth (bytes/s), same substring keys. Used to
+# price the collectives a sharded graph emits. A SKU absent here leaves the spec
+# at 0.0, which makes the sharded planner report collectives as unpriced instead
+# of predicting them as free — an unpriced node is a visible gap, a free one is a
+# wrong ceiling.
+_INTERCONNECT: dict[str, float] = {
+    "GB300": 1800e9,  # NVLink 5
+    "B300": 1800e9,
+    "GB200": 1800e9,
+    "B200": 1800e9,
+    "H100": 900e9,  # NVLink 4
+    "H200": 900e9,
+    "A100": 600e9,  # NVLink 3
+}
+
+
+def quant_peaks_for_sku(sku: str | None) -> dict[str, float]:
+    """Low-precision peaks for a SKU string (substring match), else empty."""
+    if not sku:
+        return {}
+    for key, peaks in _QUANT_PEAKS.items():
+        if key.lower() in sku.lower():
+            return peaks
+    return {}
+
+
+def interconnect_bw_for_sku(sku: str | None) -> float:
+    """Per-GPU bidirectional NVLink bandwidth for a SKU, else ``0.0``."""
+    if not sku:
+        return 0.0
+    for key, bw in _INTERCONNECT.items():
+        if key.lower() in sku.lower():
+            return bw
+    return 0.0
 
 
 @dataclass
@@ -90,17 +159,23 @@ def hardware_spec_for(peak: HardwarePeak | None) -> HardwareSpec:
     Falls back to ``HardwareSpec()`` (A100-SXM4-80GB) when the SKU wasn't
     recognized (unknown NVML name, ``GITM_GPU_SKU`` unset, no GPU) — the same
     default ``predict_graph`` silently used everywhere before this existed.
-    ``peak_flops`` covers fp16/bf16 (the only dtypes the decode graph
-    predicts); fp32 peak isn't in the catalogue and stays at the dataclass
-    default since nothing currently predicts fp32 kernels.
+    ``peak_flops`` covers fp16/bf16; fp8/fp4 come from ``_QUANT_PEAKS`` when the
+    SKU has them, and stay ``0.0`` otherwise so ``resolve_peak`` can fall back
+    and mark the prediction rather than pricing an fp4 GEMM at the bf16 rate.
+    fp32 peak isn't in the catalogue and stays at the dataclass default since
+    nothing currently predicts fp32 kernels.
     """
     if peak is None:
         return HardwareSpec()
+    quant = quant_peaks_for_sku(peak.name)
     return HardwareSpec(
         name=peak.name,
         peak_flops_fp16_per_s=peak.peak_flops,
         peak_flops_bf16_per_s=peak.peak_flops,
+        peak_flops_fp8_per_s=quant.get("fp8", 0.0),
+        peak_flops_fp4_per_s=quant.get("fp4", 0.0),
         peak_mem_bw_bytes_per_s=peak.peak_bw_bytes_s,
+        interconnect_bw_bytes_per_s=interconnect_bw_for_sku(peak.name),
     )
 
 

--- a/gitm/planner/graph.py
+++ b/gitm/planner/graph.py
@@ -17,6 +17,8 @@ from gitm.planner.roofline import (
     HardwareSpec,
     ModelSpec,
     RooflinePrediction,
+    ShardingConfig,
+    SparseMoEModelSpec,
     distinct_experts,
     roofline,
 )
@@ -101,14 +103,43 @@ class PredictedNode:
 
 @dataclass
 class Graph:
-    model: ModelSpec
+    # Dense (:func:`predict_graph`) or sparse-MoE
+    # (:func:`gitm.planner.moe_graph.predict_moe_graph`) — the node list is the
+    # same shape either way, so everything downstream of the planner (residuals,
+    # deviation, attribution) consumes both without branching.
+    model: ModelSpec | SparseMoEModelSpec
     hw: HardwareSpec
     batch: BatchConfig
     nodes: list[PredictedNode] = field(default_factory=list)
+    # How the model is spread across ranks. The default (1/1/1) means the graph
+    # is whole-model, which is what every dense caller wants.
+    sharding: ShardingConfig = field(default_factory=ShardingConfig)
 
     @property
     def total_pred_s(self) -> float:
         return sum(n.prediction.t_pred_s for n in self.nodes)
+
+    @property
+    def has_unpriced_collectives(self) -> bool:
+        """True if a collective moves bytes but predicts zero time.
+
+        Happens when the SKU has no interconnect bandwidth in the catalogue. The
+        node is still in the graph — it just costs nothing, which would quietly
+        credit a sharded deployment with a free all-to-all. Louder to ask than to
+        discover it in a report.
+        """
+        return any(
+            n.prediction.bytes > 0 and n.prediction.t_pred_s == 0.0 for n in self.nodes
+        )
+
+    @property
+    def has_fallback_peaks(self) -> bool:
+        """True if any node was priced against a dtype it doesn't run in.
+
+        The report must surface this: a graph built on fallback peaks has a
+        systematically low ceiling, so its headroom is an overestimate.
+        """
+        return any(n.prediction.peak_is_fallback for n in self.nodes)
 
 
 def predict_graph(

--- a/gitm/planner/moe_graph.py
+++ b/gitm/planner/moe_graph.py
@@ -1,0 +1,487 @@
+"""Predicted execution graph for a sparse-MoE decode step.
+
+:func:`gitm.planner.graph.predict_graph` models a dense transformer, where three
+things are true that make the roofline easy: every weight is read every step,
+attention reads the whole KV cache, and one dtype prices the entire model. A
+DeepSeek-V4-class checkpoint breaks all three, and each break is a term the dense
+graph has no place to put:
+
+**Expert weight traffic is a set-union problem, not a multiplication.** With
+``num_experts_per_tok`` of ``n_routed_experts`` firing per token, FLOPs scale with
+``positions x top_k`` — but HBM traffic scales with how many *distinct* experts the
+batch collectively touched, which saturates at ``n_routed_experts`` and is the
+dominant cost of a decode step. At batch 1 a step reads 6 of 256 experts; by batch
+256 it reads essentially all of them for the same per-token FLOPs. The dense model
+has no term that saturates, so it mispredicts the low-batch floor by ~40x and then
+attributes the difference to a cause. The term itself is
+:func:`gitm.planner.roofline.distinct_experts`, shared with the dense MoE roofline
+rather than reimplemented here — it is the same union, and two copies of it would
+drift.
+
+**Context length stops driving the attention core.** Compressed KV plus an indexer
+that keeps ``index_topk`` candidates means the attention core reads a bounded
+number of tokens no matter how long the sequence gets. What grows with context is
+the *indexer scan* — a different node, with a different bound, that the dense graph
+would have folded into attention and then blamed on the wrong kernel.
+
+**Precision is per-tensor-class.** Experts run fp4, linears fp8, the KV cache fp8.
+The load-bearing half of this is *bytes*, not FLOPs: pricing fp4 expert weights at
+bf16 inflates the dominant term 3.3x. The peak-FLOPS half barely moves a decode
+step — every node is memory-bound, so the compute ceiling never binds — but it
+governs prefill, where it does.
+
+Sharding is modelled per rank (:class:`ShardingConfig`): tensor parallelism splits
+heads and dense linears, expert parallelism splits whole experts, and both emit the
+collective they actually pay for. Two results fall out that the unsharded graph
+could not express — TP does *not* divide KV traffic on a single-KV-head model, and
+EP versus TP moves identical weight bytes per rank. Both are documented at the
+nodes that produce them.
+
+Known limits, stated rather than hidden:
+
+* **Collectives are bandwidth-only.** No latency floor, so at decode message sizes
+  the all-to-all and all-reduce nodes are optimistic; they carry ``estimated``. A
+  SKU with no interconnect figure leaves them at zero, which
+  :attr:`Graph.has_unpriced_collectives` surfaces rather than banking as free.
+* **Uniform routing.** :func:`~gitm.planner.roofline.distinct_experts` assumes a
+  balanced router.
+  Real routing is skewed, which touches *fewer* distinct experts and so moves less
+  weight traffic than predicted — the conservative direction, since it under-reports
+  headroom rather than inventing it.
+* **Nodes marked** ``estimated`` **are documented approximations** (grouped output
+  projection, DSpark, every collective) and carry that flag into the report so an
+  estimate is never read as a measurement.
+* **Expert-parallel skew is calibrated, not predicted.**
+  :attr:`ShardingConfig.ep_imbalance` defaults to perfect balance; the real figure
+  comes from a trace. Inventing a routing distribution here would be a guess
+  wearing a model's clothes.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+from typing import Any
+
+from gitm.planner.graph import Graph, PredictedNode
+from gitm.planner.roofline import (
+    BatchConfig,
+    HardwareSpec,
+    ShardingConfig,
+    SparseMoEModelSpec,
+    distinct_experts,
+    roofline,
+    weight_bytes,
+)
+
+
+def effective_kv_tokens(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
+    """KV positions the attention *core* reads for ``layer`` at ``kv_len`` context.
+
+    Three mechanisms compose, in this order:
+
+    1. **Compression.** A layer with ratio ``r`` keeps one compressed entry per
+       ``r`` tokens, so the candidate set is ``ceil(kv_len / r)``. Ratio 0 or 1
+       means the layer is uncompressed and attends to everything.
+    2. **Selection.** The indexer scores those candidates and keeps at most
+       ``index_topk``.
+    3. **Sliding window.** The most recent ``sliding_window`` tokens are read
+       uncompressed regardless of what selection chose.
+
+    The consequence worth internalising: once ``kv_len / r`` exceeds
+    ``index_topk``, the core's read is *constant in context length*. A layer with
+    ratio 128 and one with ratio 4 read the same number of tokens at 64K context
+    — they differ in KV *storage* and in how much the indexer has to scan, not in
+    what attention itself costs. A residual that scales with context therefore
+    belongs to the indexer node, and blaming it on attention is the mistake this
+    split exists to prevent.
+    """
+    if kv_len <= 0:
+        return 0
+    r = spec.compress_ratio(layer)
+    if r <= 1:
+        return kv_len
+    candidates = math.ceil(kv_len / r)
+    selected = min(spec.index_topk, candidates)
+    return min(kv_len, spec.sliding_window + selected)
+
+
+def index_candidates(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
+    """Positions the indexer must score for ``layer`` — the compressed set.
+
+    Unbounded in context length, which is what makes this the node that decides
+    whether a million-token deployment is viable.
+    """
+    if kv_len <= 0:
+        return 0
+    r = spec.compress_ratio(layer)
+    if r <= 1:
+        return kv_len
+    return math.ceil(kv_len / r)
+
+
+def model_weight_bytes(
+    spec: SparseMoEModelSpec, sharding: ShardingConfig | None = None
+) -> float:
+    """Resident weight bytes on one rank.
+
+    Decides whether a deployment shape is possible at all, which the timing graph
+    cannot: a config that predicts beautifully and does not fit is not a config.
+    Counts experts at ``expert_dtype`` and everything else at ``weight_dtype``,
+    since collapsing the two is a ~3x error on the dominant term.
+
+    Validated against ground truth: ``DeepSeek-V4-Flash`` predicts 156 GB against
+    a published 160 GB checkpoint (-2.4%), the residual being norms, biases and
+    per-tensor metadata this does not enumerate.
+
+    The DSpark variant is the known gap. ``DeepSeek-V4-Flash-0731`` publishes at
+    167 GB — 7 GB more than the base checkpoint for three extra layers' worth of
+    DSpark — while the low-rank pair modelled here accounts for ~6 MB. The shape
+    is not public, so the term below is carried for internal consistency with the
+    graph's ``dspark`` node and is *known to be orders of magnitude low*. Treat a
+    footprint prediction for that checkpoint as a lower bound, not an estimate.
+    """
+    sh = sharding or ShardingConfig()
+    tp = max(1, sh.tp)
+    es = max(1, sh.expert_shards)
+    ew = weight_bytes(spec.expert_dtype)
+    ww = weight_bytes(spec.weight_dtype)
+    h, inter = spec.hidden, spec.moe_intermediate_size
+    layers = spec.n_layers + spec.num_nextn_predict_layers
+
+    experts = layers * spec.n_routed_experts * 3 * h * inter * ew / es
+    shared = layers * spec.n_shared_experts * 3 * h * inter * ew / tp
+    attn_per_layer = (
+        h * spec.q_lora_rank  # q_a, replicated
+        + spec.q_lora_rank * spec.n_heads * spec.q_head_dim / tp
+        + h * spec.kv_latent_dim  # kv_a, replicated
+        + h * spec.index_n_heads * spec.index_head_dim / tp
+        + spec.n_heads * spec.head_dim * spec.o_lora_rank / (spec.o_groups * tp)
+        + spec.o_lora_rank * h
+        + h * spec.n_routed_experts  # router, replicated
+    )
+    embed = 2 * spec.vocab * h / tp  # input embedding + untied lm_head
+    dspark = len(spec.dspark_layer_ids) * 2 * h * spec.dspark_markov_rank / tp
+    return experts + shared + (layers * attn_per_layer + embed + dspark) * ww
+
+
+def kv_bytes_per_token(spec: SparseMoEModelSpec) -> float:
+    """Resident KV-cache bytes for one token of context, across all layers.
+
+    Compression is per-layer, so this is a sum and not a multiplication: on this
+    checkpoint two layers store a full latent, twenty store a quarter of one, and
+    twenty-one store 1/128th. Using any single ratio is wrong by up to 128x, and
+    KV footprint is what sets the concurrency ceiling.
+    """
+    kw = weight_bytes(spec.kv_dtype)
+    total = 0.0
+    for layer in range(spec.n_layers):
+        r = max(1, spec.compress_ratio(layer))
+        # The latent, plus the indexer's key for the same (compressed) position.
+        total += (spec.kv_latent_dim + spec.index_head_dim) * kw / r
+    return total
+
+
+def _linear(rows: float, k: int, n: int, act_b: float, w_b: float) -> tuple[float, float]:
+    """(flops, bytes) for a ``(rows, k) @ (k, n)`` projection.
+
+    Bytes count the activation in, the weights, and the activation out. At decode
+    ``rows`` is small and the weight term dominates — which is why weight dtype,
+    not activation dtype, sets the floor for every projection here.
+    """
+    return 2.0 * rows * k * n, act_b * rows * k + w_b * k * n + act_b * rows * n
+
+
+def _emit_layer(
+    g: Graph,
+    spec: SparseMoEModelSpec,
+    hw: HardwareSpec,
+    layer: int,
+    *,
+    positions: float,
+    sequences: int,
+    kv_len: int,
+    sh: ShardingConfig,
+    prefix: str = "",
+) -> None:
+    """Append one transformer layer's predicted nodes to ``g``.
+
+    ``positions`` is how many sequence positions this layer computes; ``sequences``
+    is how many distinct KV caches those positions read from. They differ under
+    speculative decoding, and the difference is the whole reason MTP helps a
+    memory-bound decode: eight draft positions verified in one step read the KV
+    cache *once*, so cache traffic amortises across them while FLOPs do not. Using
+    one number for both would erase that effect and predict MTP as pure overhead.
+    """
+    h = spec.hidden
+    aw = weight_bytes(spec.act_dtype)
+    ww = weight_bytes(spec.weight_dtype)
+    ew = weight_bytes(spec.expert_dtype)
+    kw = weight_bytes(spec.kv_dtype)
+    wd, ed = spec.weight_dtype, spec.expert_dtype
+
+    def add(op: str, flops: float, byts: float, dtype: str, *, estimated: bool = False) -> None:
+        name = f"{prefix}{op}"
+        g.nodes.append(
+            PredictedNode(name, layer, roofline(name, flops, byts, hw, dtype, estimated=estimated))
+        )
+
+    tp = max(1, sh.tp)
+    es = max(1, sh.expert_shards)
+
+    # ── attention: low-rank query, compressed KV latent ──────────────────────
+    # ``q_a`` and ``kv_a`` are replicated across tensor-parallel ranks: they
+    # produce the shared latent, which has nothing to split when there is one KV
+    # head. Every rank pays for them in full, so TP's speedup on attention is
+    # strictly less than ``tp``.
+    f, b = _linear(positions, h, spec.q_lora_rank, aw, ww)
+    add("attn_q_a", f, b, wd)
+
+    f, b = _linear(positions, spec.q_lora_rank, spec.n_heads * spec.q_head_dim // tp, aw, ww)
+    add("attn_q_b", f, b, wd)
+
+    # KV down-projection, plus the cache write for the positions just computed.
+    f, b = _linear(positions, h, spec.kv_latent_dim, aw, ww)
+    add("attn_kv_a", f, b + positions * spec.kv_latent_dim * kw, wd)
+
+    # ── indexer: project the query, then scan the compressed candidate set ───
+    f, b = _linear(positions, h, spec.index_n_heads * spec.index_head_dim // tp, aw, ww)
+    add("attn_index_proj", f, b, wd)
+
+    cand = index_candidates(spec, layer, kv_len)
+    add(
+        "attn_index_score",
+        2.0 * positions * (spec.index_n_heads // tp) * spec.index_head_dim * cand,
+        # Index keys live in the cache: read once per sequence, not per position,
+        # and replicated across TP ranks alongside the KV latent.
+        sequences * cand * spec.index_head_dim * kw,
+        wd,
+    )
+
+    # ── attention core over the selected positions ──────────────────────────
+    t_eff = effective_kv_tokens(spec, layer, kv_len)
+    qk = 2.0 * positions * (spec.n_heads // tp) * spec.q_head_dim * t_eff
+    pv = 2.0 * positions * (spec.n_heads // tp) * spec.head_dim * t_eff
+    add(
+        "attn_score_value",
+        qk + pv,
+        # One latent, shared by every query head. Multiplying by ``n_heads`` here
+        # is the classic compressed-KV modelling error and inflates decode KV
+        # traffic by 64x on this checkpoint.
+        #
+        # Deliberately *not* divided by ``tp``: a single KV head cannot be split,
+        # so the latent cache is replicated and every rank reads all of it. Tensor
+        # parallelism buys no KV bandwidth on this architecture — the opposite of
+        # the intuition carried over from GQA models, and a lever-ranking error
+        # waiting to happen if the graph divided here.
+        sequences * t_eff * spec.kv_latent_dim * kw,
+        wd,
+    )
+
+    # Output projection, grouped and low-rank. ``o_groups`` partitions the head
+    # dimension so each group carries its own slice of the rank — modelled as an
+    # even split, which is the documented reading of the config and not a
+    # published shape, hence ``estimated``.
+    o_in = spec.n_heads * spec.head_dim // tp
+    f_a, b_a = _linear(positions, o_in, max(1, spec.o_lora_rank // spec.o_groups), aw, ww)
+    f_b, b_b = _linear(positions, spec.o_lora_rank, h, aw, ww)
+    # Named to match the dense graph's output projection: it is the same op in
+    # the same place, so residuals for it stay comparable across model families.
+    add("attn_out_proj", f_a + f_b, b_a + b_b, wd, estimated=True)
+
+    # ── mixture of experts ──────────────────────────────────────────────────
+    # Routing is replicated: every rank scores every expert so it knows what to
+    # keep and what to ship.
+    f, b = _linear(positions, h, spec.n_routed_experts, aw, ww)
+    add("moe_router", f, b, wd)
+
+    inter = spec.moe_intermediate_size
+    # gate + up + down == three h x inter matrices per expert.
+    per_expert_weights = 3.0 * h * inter
+    per_position_flops = 6.0 * h * inter  # 2 * (gate + up + down) * h * inter
+
+    if spec.n_shared_experts > 0:
+        add(
+            "moe_shared",
+            per_position_flops * positions * spec.n_shared_experts / tp,
+            per_expert_weights * spec.n_shared_experts * ew / tp
+            + aw * (positions * h * 2 + positions * inter * 2 * spec.n_shared_experts / tp),
+            ed,
+        )
+
+    # Shared with the dense MoE roofline — one owner for the union term. Note the
+    # argument is *positions*, not sequences: under speculative decoding every
+    # drafted position routes independently, so drafts widen the expert set the
+    # step must fetch.
+    distinct = distinct_experts(
+        int(positions), spec.n_routed_experts, spec.num_experts_per_tok
+    )
+    # Under EP a step waits for the rank that drew the most selected experts, so
+    # the imbalance factor multiplies the *slowest* rank's share, not the mean.
+    skew = sh.ep_imbalance if sh.ep > 1 else 1.0
+    add(
+        "moe_routed",
+        per_position_flops * positions * spec.num_experts_per_tok * skew / es,
+        # The union term: arithmetic scales with positions, weight traffic with
+        # how many distinct experts the batch woke up — then divided across the
+        # ranks that hold them.
+        per_expert_weights * distinct * ew * skew / es
+        + aw * (positions * h * 2 + positions * inter * 2 * spec.num_experts_per_tok / es),
+        ed,
+    )
+
+    # ── low-rank state update on the tail layers ────────────────────────────
+    if layer in spec.dspark_layer_ids:
+        rank = spec.dspark_markov_rank
+        f_d, b_d = _linear(positions, h, rank // tp, aw, ww)
+        f_u, b_u = _linear(positions, rank // tp, h, aw, ww)
+        # Coarse: a down-up low-rank pair. The published shape isn't public, so
+        # this establishes an order of magnitude and flags itself as an estimate
+        # rather than sitting silently in the total.
+        add("dspark", f_d + f_u, b_d + b_u, wd, estimated=True)
+
+    # ── cross-rank traffic ──────────────────────────────────────────────────
+    # Priced against the interconnect, not HBM, by swapping the bandwidth term.
+    # Bandwidth-only: no latency floor, so at decode message sizes these are
+    # optimistic and flagged ``estimated``. A zero-bandwidth spec leaves them at
+    # t_pred == 0, which ``Graph.has_unpriced_collectives`` surfaces rather than
+    # letting a free all-to-all sit in the total.
+    if tp > 1 or sh.ep > 1:
+        link = replace(hw, peak_mem_bw_bytes_per_s=hw.interconnect_bw_bytes_per_s)
+
+        def add_link(op: str, byts: float) -> None:
+            name = f"{prefix}{op}"
+            g.nodes.append(
+                PredictedNode(
+                    name, layer,
+                    roofline(name, 0.0, byts, link, spec.act_dtype, estimated=True),
+                )
+            )
+
+        if sh.ep > 1:
+            # Dispatch each position's hidden state to the ranks owning its
+            # experts, then combine the results back. Only the fraction that
+            # leaves this rank crosses the link.
+            off_rank = (sh.ep - 1) / sh.ep
+            add_link(
+                "moe_all_to_all",
+                2.0 * positions * spec.num_experts_per_tok * h * aw * off_rank,
+            )
+        if tp > 1:
+            # Two all-reduces per layer (post-attention, post-MoE). Ring cost is
+            # 2*(tp-1)/tp bytes per participant per reduction.
+            add_link("tp_all_reduce", 2.0 * (2.0 * (tp - 1) / tp) * positions * h * aw)
+
+
+def predict_moe_graph(
+    model: SparseMoEModelSpec | None = None,
+    hw: HardwareSpec | None = None,
+    batch: BatchConfig | None = None,
+    sharding: ShardingConfig | None = None,
+) -> Graph:
+    """Emit a predicted execution graph for one sparse-MoE decode step, per rank.
+
+    The main stack runs over every position in the step (the verified token plus
+    any speculative drafts); the MTP head then runs over one position per
+    sequence to propose the next draft.
+
+    With ``sharding`` left at its default the graph is whole-model, as before.
+    Given a real sharding it predicts what *one rank* does — which is what that
+    rank's kernels are observed doing, and therefore the only thing a residual
+    against a per-rank trace can mean.
+    """
+    spec = model or SparseMoEModelSpec()
+    hw = hw or HardwareSpec()
+    batch = batch or BatchConfig()
+    sh = sharding or ShardingConfig()
+
+    g = Graph(model=spec, hw=hw, batch=batch, sharding=sh)
+    positions = batch.positions_per_step
+    sequences = batch.batch
+    kv_len = batch.kv_cache_len
+
+    for layer in range(spec.n_layers):
+        _emit_layer(
+            g, spec, hw, layer,
+            positions=positions, sequences=sequences, kv_len=kv_len, sh=sh,
+        )
+
+    # Multi-token prediction head: extra layers that draft, running one position
+    # per sequence. Their cost is paid every step whether or not the drafts are
+    # accepted, which is why ``BatchConfig.acceptance_rate`` belongs in the
+    # per-token denominator and not in this node's cost.
+    #
+    # Deliberately *not* given distinct op names. An MTP layer's q_a projection
+    # is a q_a projection; what makes it the draft head is its position in the
+    # stack, which ``layer >= n_layers`` already says. Renaming the ops would
+    # invent identities that no kernel name can ever match, leaving every MTP
+    # node predicted-but-never-observed. Layer index is the disambiguator here,
+    # exactly as ``docs/kernel_identity.md`` specifies.
+    for i in range(spec.num_nextn_predict_layers):
+        _emit_layer(
+            g, spec, hw, spec.n_layers + i,
+            positions=sequences, sequences=sequences, kv_len=kv_len, sh=sh,
+        )
+
+    # Vocabulary projection: logits for every position the step computed, since a
+    # speculative step needs a distribution at each drafted position to verify it.
+    # Sharded along the vocabulary under TP.
+    aw = weight_bytes(spec.act_dtype)
+    ww = weight_bytes(spec.weight_dtype)
+    f, b = _linear(positions, spec.hidden, spec.vocab // max(1, sh.tp), aw, ww)
+    g.nodes.append(
+        PredictedNode("lm_head", None, roofline("lm_head", f, b, hw, spec.weight_dtype))
+    )
+
+    return g
+
+
+def spec_from_hf_config(cfg: dict[str, Any], *, name: str | None = None) -> SparseMoEModelSpec:
+    """Build a :class:`SparseMoEModelSpec` from a HuggingFace ``config.json``.
+
+    Reads the checkpoint's own declared shape so the graph can never drift from
+    the model it claims to predict. Quantisation dtypes come from
+    ``quantization_config`` (linears) and ``expert_dtype`` (experts), which on a
+    mixed-precision checkpoint are genuinely different and must not be collapsed.
+
+    ``compress_ratios`` ships longer than ``num_hidden_layers`` (it carries
+    trailing entries for the MTP and padding slots); only the first
+    ``num_hidden_layers`` entries index real layers, so the tail is dropped
+    rather than silently shifting every layer's ratio.
+    """
+    q = cfg.get("quantization_config") or {}
+    weight_dtype = str(q.get("quant_method", "bf16")).lower()
+    n_layers = int(cfg.get("num_hidden_layers", 43))
+    ratios = tuple(int(r) for r in (cfg.get("compress_ratios") or ())[:n_layers])
+
+    return SparseMoEModelSpec(
+        name=name or str(cfg.get("model_type", "sparse-moe")),
+        hidden=int(cfg.get("hidden_size", 4096)),
+        n_layers=n_layers,
+        n_heads=int(cfg.get("num_attention_heads", 64)),
+        num_kv_heads=int(cfg.get("num_key_value_heads", 1)),
+        head_dim=int(cfg.get("head_dim", 512)),
+        qk_rope_head_dim=int(cfg.get("qk_rope_head_dim", 64)),
+        q_lora_rank=int(cfg.get("q_lora_rank", 1024)),
+        o_lora_rank=int(cfg.get("o_lora_rank", 1024)),
+        o_groups=int(cfg.get("o_groups", 1)),
+        vocab=int(cfg.get("vocab_size", 129280)),
+        n_routed_experts=int(cfg.get("n_routed_experts", 256)),
+        n_shared_experts=int(cfg.get("n_shared_experts", 1)),
+        num_experts_per_tok=int(cfg.get("num_experts_per_tok", 6)),
+        moe_intermediate_size=int(cfg.get("moe_intermediate_size", 2048)),
+        index_n_heads=int(cfg.get("index_n_heads", 64)),
+        index_head_dim=int(cfg.get("index_head_dim", 128)),
+        index_topk=int(cfg.get("index_topk", 512)),
+        sliding_window=int(cfg.get("sliding_window", 0) or 0),
+        compress_ratios=ratios,
+        num_nextn_predict_layers=int(cfg.get("num_nextn_predict_layers", 0)),
+        dspark_layer_ids=tuple(int(i) for i in (cfg.get("dspark_target_layer_ids") or ())),
+        dspark_markov_rank=int(cfg.get("dspark_markov_rank", 0)),
+        weight_dtype=weight_dtype,
+        expert_dtype=str(cfg.get("expert_dtype", weight_dtype)).lower(),
+        # vLLM serves this checkpoint with an fp8 KV cache; the config does not
+        # declare cache dtype, so it is a serving decision, not a model fact.
+        kv_dtype="fp8",
+        act_dtype=str(cfg.get("torch_dtype", "bf16")).lower().replace("bfloat16", "bf16"),
+    )

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -8,11 +8,45 @@ For each op we compute:
 
 with a vendor-specific efficiency band ``(eff_lo, eff_hi)``: a kernel within
 that band is "as expected". Residuals outside the band drive attribution.
+
+**The peak must match the op's dtype.** A checkpoint that runs fp8 linears and
+fp4 experts priced against a bf16 peak understates its own ceiling by 2-4x, and
+an understated ceiling reads as recoverable headroom that isn't there — the one
+error the headroom report exists to avoid making. ``roofline`` therefore resolves
+a peak per dtype and records which peak it actually used, so a catalogue miss
+surfaces as ``peak_is_fallback`` rather than as a confident wrong number.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+# Bytes of HBM traffic per stored weight, including the quantisation scales that
+# ride alongside the payload. Scales are a real fraction of the bytes a decode
+# step moves — at fp4 they are 6% of expert traffic, which is larger than several
+# effects the monitor is expected to resolve.
+_WEIGHT_BYTES: dict[str, float] = {
+    "fp32": 4.0,
+    "fp16": 2.0,
+    "bf16": 2.0,
+    # One fp32 scale per 128x128 block (DeepSeek-style block quantisation).
+    "fp8": 1.0 + 4.0 / (128 * 128),
+    # MXFP4: one e8m0 (1 byte) scale per 32 values.
+    "mxfp4": 0.5 + 1.0 / 32,
+    # NVFP4: one e4m3 (1 byte) scale per 16 values.
+    "nvfp4": 0.5 + 1.0 / 16,
+}
+_WEIGHT_BYTES["fp4"] = _WEIGHT_BYTES["mxfp4"]
+
+
+def weight_bytes(dtype: str) -> float:
+    """Bytes moved per stored weight for ``dtype``, scales included.
+
+    Unknown dtypes fall back to bf16 (2 bytes) — the conservative direction,
+    since over-counting weight traffic predicts a *slower* floor and so cannot
+    manufacture headroom.
+    """
+    return _WEIGHT_BYTES.get(dtype.lower(), 2.0)
 
 
 @dataclass(frozen=True)
@@ -21,13 +55,24 @@ class HardwareSpec:
 
     Numbers below are illustrative defaults for A100-SXM4-80GB. Real values
     land in a vendor catalogue at ``gitm/planner/catalogue.yaml`` (roadmap).
+
+    ``peak_flops_fp8_per_s`` / ``peak_flops_fp4_per_s`` are ``0.0`` when the SKU
+    has no such tensor-core path (A100 predates both) *or* when the catalogue
+    simply doesn't carry the figure. Both cases mean the same thing to
+    :func:`roofline` — fall back to a dtype we do have and say so.
     """
 
     name: str = "A100-SXM4-80GB"
     peak_flops_fp16_per_s: float = 312e12
     peak_flops_bf16_per_s: float = 312e12
     peak_flops_fp32_per_s: float = 19.5e12
+    peak_flops_fp8_per_s: float = 0.0
+    peak_flops_fp4_per_s: float = 0.0
     peak_mem_bw_bytes_per_s: float = 2_039e9
+    # Per-GPU bidirectional interconnect bandwidth, used to price collectives.
+    # ``0.0`` means unknown, which makes a sharded graph refuse to guess rather
+    # than predict a free all-to-all.
+    interconnect_bw_bytes_per_s: float = 0.0
     eff_lo: float = 0.55
     eff_hi: float = 0.95
 
@@ -278,12 +323,161 @@ def distinct_experts(batch: int, num_experts: int, top_k: int) -> float:
 
 
 @dataclass(frozen=True)
+class SparseMoEModelSpec:
+    """Model shape for a sparse-MoE decode step with compressed, sparse attention.
+
+    :class:`ModelSpec` describes a dense transformer: every weight is read every
+    step, attention reads the whole KV cache, and one dtype prices everything.
+    None of those hold for a DeepSeek-V4-class checkpoint, and each broken
+    assumption is a separate field here:
+
+    * **Experts are conditional.** ``num_experts_per_tok`` of ``n_routed_experts``
+      run per token, so FLOPs scale with the batch while *weight traffic* scales
+      with how many distinct experts the batch collectively touched — a number
+      that saturates at ``n_routed_experts`` and is the dominant cost at decode.
+    * **Attention is compressed and selected.** ``compress_ratios`` is per-layer;
+      an indexer scores the compressed candidates and keeps ``index_topk``, on
+      top of a ``sliding_window`` of recent tokens. Total context length stops
+      driving the attention core once selection saturates — it drives the
+      *indexer* instead, which is a different node with a different bound.
+    * **Precision is per-tensor-class.** Experts, linears, and the KV cache each
+      carry their own dtype, and each prices against its own peak.
+    """
+
+    name: str = "deepseek-v4-flash"
+    hidden: int = 4096
+    n_layers: int = 43
+    n_heads: int = 64
+    num_kv_heads: int = 1
+    head_dim: int = 512
+    qk_rope_head_dim: int = 64
+    q_lora_rank: int = 1024
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    vocab: int = 129280
+
+    # Mixture of experts
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 6
+    moe_intermediate_size: int = 2048
+
+    # Sparse / compressed attention
+    index_n_heads: int = 64
+    index_head_dim: int = 128
+    index_topk: int = 512
+    sliding_window: int = 128
+    # Per-layer KV compression. 0 or 1 == uncompressed (full attention). Indexed
+    # by layer; layers past the end of the tuple reuse the last entry.
+    compress_ratios: tuple[int, ...] = ()
+
+    # Multi-token prediction (speculative decoding head)
+    num_nextn_predict_layers: int = 1
+
+    # Low-rank state update on a subset of layers (DeepSeek "DSpark").
+    dspark_layer_ids: tuple[int, ...] = ()
+    dspark_markov_rank: int = 256
+
+    # Precision, per tensor class
+    weight_dtype: str = "fp8"  # attention + router + lm_head linears
+    expert_dtype: str = "fp4"  # routed + shared expert weights
+    kv_dtype: str = "fp8"  # KV cache and index keys
+    act_dtype: str = "bf16"  # activations between ops
+
+    def compress_ratio(self, layer: int) -> int:
+        """KV compression ratio for ``layer`` (0/1 == uncompressed)."""
+        if not self.compress_ratios:
+            return 0
+        if layer < len(self.compress_ratios):
+            return self.compress_ratios[layer]
+        return self.compress_ratios[-1]
+
+    @property
+    def q_head_dim(self) -> int:
+        """Per-head query width: the nope part plus the RoPE part."""
+        return self.head_dim + self.qk_rope_head_dim
+
+    @property
+    def kv_latent_dim(self) -> int:
+        """Bytes-per-token-per-layer worth of KV state, in elements.
+
+        With ``num_kv_heads == 1`` the latent is shared across every query head —
+        that sharing is the entire point of the compressed-KV design, and folding
+        it into ``n_heads`` (as a GQA model would) overstates decode KV traffic
+        by ``n_heads``x.
+        """
+        return self.num_kv_heads * (self.head_dim + self.qk_rope_head_dim)
+
+
+@dataclass(frozen=True)
+class ShardingConfig:
+    """How one model is spread across ranks, from the perspective of one rank.
+
+    The planner predicts *per-rank* cost, because that is what a rank's kernels
+    are observed doing. Two sharding modes exist for the experts and they are
+    routinely conflated:
+
+    * **TP-sharded experts** (``ep == 1``) — every rank holds a slice of *every*
+      expert, cut along the intermediate dimension. Perfectly load-balanced, and
+      the cross-rank cost is an all-reduce of hidden states.
+    * **Expert parallel** (``ep > 1``) — every rank holds *whole* experts,
+      ``n_routed_experts / ep`` of them, and tokens are shipped to whichever rank
+      owns their expert. The cross-rank cost is an all-to-all.
+
+    Both divide per-rank expert weight traffic by the same degree, so **EP versus
+    TP is a collective trade, not a memory trade** — a distinction worth having in
+    the graph, because the lever catalog would otherwise rank them as if one saved
+    HBM traffic the other doesn't.
+
+    ``ep_imbalance`` is where EP's real cost lives. Under TP every rank does
+    exactly 1/tp of the work; under EP a step waits for whichever rank drew the
+    most selected experts, and at low batch that skew is large. It defaults to
+    1.0 (perfect balance) and is meant to be *calibrated from a trace* rather
+    than predicted — inventing a distribution here would be a guess dressed as a
+    model.
+    """
+
+    tp: int = 1
+    ep: int = 1
+    dp: int = 1
+    ep_imbalance: float = 1.0
+
+    @property
+    def expert_shards(self) -> int:
+        """Ranks the expert weights are divided across."""
+        return self.ep if self.ep > 1 else self.tp
+
+    @property
+    def world_size(self) -> int:
+        return self.tp * self.dp
+
+
+@dataclass(frozen=True)
 class BatchConfig:
     """Decode batch shape — prompt length already paid; we predict per-step."""
 
     batch: int = 1
     prompt_len: int = 128
     kv_cache_len: int = 128  # tokens already in KV-cache when decode starts
+    # Multi-token prediction: draft positions proposed per step, and the fraction
+    # the verifier keeps. A step costs the drafted work regardless; only accepted
+    # tokens count as output, so per-token cost divides by ``tokens_per_step``.
+    speculative_tokens: int = 0
+    acceptance_rate: float = 0.0
+
+    @property
+    def positions_per_step(self) -> int:
+        """Sequence positions the model actually computes in one step."""
+        return self.batch * (1 + max(0, self.speculative_tokens))
+
+    @property
+    def tokens_per_step(self) -> float:
+        """Accepted output tokens per step — the denominator for per-token cost.
+
+        Always at least ``batch``: the non-speculative token is verified, not
+        drafted, so it is never rejected.
+        """
+        return self.batch * (1.0 + max(0, self.speculative_tokens) * self.acceptance_rate)
 
 
 @dataclass(frozen=True)
@@ -295,6 +489,62 @@ class RooflinePrediction:
     t_memory_s: float
     t_pred_s: float
     bound: str  # "compute" | "memory"
+    # Which dtype the op runs in, and which peak was actually available to price
+    # it. They differ only on a catalogue miss; see ``peak_is_fallback``.
+    dtype: str = "fp16"
+    peak_dtype: str = "fp16"
+    peak_flops_per_s: float = 0.0
+    # Set when the op's cost model is a documented approximation rather than a
+    # derivation from published shapes — carried through to the report so an
+    # estimate is never read as a measurement.
+    estimated: bool = False
+
+    @property
+    def peak_is_fallback(self) -> bool:
+        """True when the op's dtype had no peak in the catalogue.
+
+        A fallback prediction is still usable, but its ceiling is wrong in a
+        known direction (too low for a dtype faster than the fallback), so the
+        report must not present it as a clean roofline.
+        """
+        return _canon_dtype(self.dtype) != self.peak_dtype
+
+
+def _canon_dtype(dtype: str) -> str:
+    d = dtype.lower()
+    if d in ("bf16", "float16", "fp16", "half"):
+        return "fp16"
+    if d in ("fp4", "mxfp4", "nvfp4"):
+        return "fp4"
+    if d in ("fp8", "e4m3", "e5m2"):
+        return "fp8"
+    if d in ("fp32", "float32", "tf32"):
+        return "fp32"
+    return d
+
+
+def resolve_peak(hw: HardwareSpec, dtype: str) -> tuple[float, str]:
+    """(peak FLOP/s, the dtype that peak belongs to) for ``dtype`` on ``hw``.
+
+    Falls back down the precision ladder — fp4 → fp8 → fp16 — because a missing
+    low-precision peak means the catalogue is incomplete, not that the op is
+    free. Falling back *upward* in precision understates the ceiling, which is
+    the safe direction: it under-reports headroom rather than inventing it.
+    """
+    d = _canon_dtype(dtype)
+    if d == "fp32":
+        return hw.peak_flops_fp32_per_s, "fp32"
+    if d == "fp4":
+        if hw.peak_flops_fp4_per_s > 0:
+            return hw.peak_flops_fp4_per_s, "fp4"
+        if hw.peak_flops_fp8_per_s > 0:
+            return hw.peak_flops_fp8_per_s, "fp8"
+        return hw.peak_flops_fp16_per_s, "fp16"
+    if d == "fp8":
+        if hw.peak_flops_fp8_per_s > 0:
+            return hw.peak_flops_fp8_per_s, "fp8"
+        return hw.peak_flops_fp16_per_s, "fp16"
+    return hw.peak_flops_fp16_per_s, "fp16"
 
 
 def roofline(
@@ -303,12 +553,11 @@ def roofline(
     bytes_moved: float,
     hw: HardwareSpec,
     dtype: str = "fp16",
+    *,
+    estimated: bool = False,
 ) -> RooflinePrediction:
     """Compute the roofline prediction for a single op."""
-    if dtype in ("fp16", "bf16"):
-        peak_flops = hw.peak_flops_fp16_per_s
-    else:
-        peak_flops = hw.peak_flops_fp32_per_s
+    peak_flops, peak_dtype = resolve_peak(hw, dtype)
     t_c = flops / peak_flops if peak_flops > 0 else 0.0
     t_m = bytes_moved / hw.peak_mem_bw_bytes_per_s if hw.peak_mem_bw_bytes_per_s > 0 else 0.0
     bound = "compute" if t_c >= t_m else "memory"
@@ -320,4 +569,8 @@ def roofline(
         t_memory_s=t_m,
         t_pred_s=max(t_c, t_m),
         bound=bound,
+        dtype=dtype,
+        peak_dtype=peak_dtype,
+        peak_flops_per_s=peak_flops,
+        estimated=estimated,
     )

--- a/gitm/tracer/kernel_taxonomy.py
+++ b/gitm/tracer/kernel_taxonomy.py
@@ -64,9 +64,17 @@ _RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("linear_attn", ("delta_rule", "gated_delta", "deltanet", "fused_recurrent",
                      "linear_attn", "solve_tril", "wy_fast", "local_cumsum",
                      "chunk_o", "chunk_h", "selective_scan", "mamba")),
+    # Sparse/compressed attention needles ride in this bucket rather than a
+    # separate one: they are attention by cost and by what a lever would target.
+    # The indexer needles are load-bearing — a "lightning_indexer" kernel matches
+    # the "index" needle in the elementwise rule below, so without an earlier
+    # claim it lands as elementwise. That is worse than `other`: `other` is a
+    # visible finding, whereas a misfiled kernel makes the attention bucket look
+    # cheap and the elementwise bucket look inexplicably expensive.
     ("attention", ("flash_fwd", "flash_attn", "flashattn", "fmha", "paged_attention",
                    "paged_attn", "attention", "attn_score", "splitkv", "merge_attn",
-                   "mha_fwd", "cutlass_mla", "flashinfer")),
+                   "mha_fwd", "cutlass_mla", "flash_mla", "mla_sparse", "sparse_mla",
+                   "indexer", "lightning_index", "flashinfer")),
     ("kv_cache", ("reshape_and_cache", "slot_mapping", "copy_blocks", "swap_blocks",
                   "concat_and_cache", "block_table")),
     ("gemm", ("gemm", "cutlass", "sgemm", "hgemm", "s16816", "s161616", "matmul",

--- a/tests/test_moe_graph.py
+++ b/tests/test_moe_graph.py
@@ -1,0 +1,609 @@
+"""The sparse-MoE decode graph, pinned against hand-derived numbers.
+
+Every assertion here guards a term the dense graph does not have. The dense
+model is not merely *imprecise* on this architecture — it is wrong in specific,
+nameable directions, and each test below pins the correction:
+
+* expert weight traffic saturates (union, not multiplication),
+* the attention core's read stops growing with context,
+* the KV latent is shared across query heads,
+* fp4/fp8 tensors price against fp4/fp8 peaks, or say they didn't.
+
+A regression on any of these produces a confidently wrong ceiling, which the
+headroom report would then bill against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gitm.optimizer.deviation import classify_op
+from gitm.planner.context import hardware_spec_for, peak_for_sku
+from gitm.planner.moe_graph import (
+    effective_kv_tokens,
+    index_candidates,
+    kv_bytes_per_token,
+    model_weight_bytes,
+    predict_moe_graph,
+    spec_from_hf_config,
+)
+from gitm.planner.roofline import (
+    BatchConfig,
+    HardwareSpec,
+    ShardingConfig,
+    resolve_peak,
+    weight_bytes,
+)
+
+# The shape of DeepSeek-V4-Flash-0731, trimmed to the keys the planner reads.
+V4_CONFIG = {
+    "model_type": "deepseek_v4",
+    "hidden_size": 4096,
+    "num_hidden_layers": 43,
+    "num_attention_heads": 64,
+    "num_key_value_heads": 1,
+    "head_dim": 512,
+    "qk_rope_head_dim": 64,
+    "q_lora_rank": 1024,
+    "o_lora_rank": 1024,
+    "o_groups": 8,
+    "vocab_size": 129280,
+    "n_routed_experts": 256,
+    "n_shared_experts": 1,
+    "num_experts_per_tok": 6,
+    "moe_intermediate_size": 2048,
+    "index_n_heads": 64,
+    "index_head_dim": 128,
+    "index_topk": 512,
+    "sliding_window": 128,
+    # Ships 46 long for 43 layers — the tail is MTP/padding, not layers.
+    "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
+    "num_nextn_predict_layers": 1,
+    "dspark_target_layer_ids": [40, 41, 42],
+    "dspark_markov_rank": 256,
+    "expert_dtype": "fp4",
+    "quantization_config": {"quant_method": "fp8", "weight_block_size": [128, 128]},
+    "torch_dtype": "bfloat16",
+}
+
+
+# The base DeepSeek-V4-Flash checkpoint. Two real differences from -0731: no
+# DSpark at all, and 44 compress_ratios rather than 46. Both variants ship under
+# the same architecture, so the parser has to absorb the difference silently.
+V4_BASE_CONFIG = {
+    **{k: v for k, v in V4_CONFIG.items() if not k.startswith("dspark")},
+    "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0],
+}
+
+# Published safetensors total for DeepSeek-V4-Flash, from the model repo.
+V4_BASE_PUBLISHED_BYTES = 160e9
+
+
+@pytest.fixture
+def spec():
+    return spec_from_hf_config(V4_CONFIG, name="DeepSeek-V4-Flash-0731")
+
+
+@pytest.fixture
+def base_spec():
+    return spec_from_hf_config(V4_BASE_CONFIG, name="DeepSeek-V4-Flash")
+
+
+@pytest.fixture
+def b200():
+    return hardware_spec_for(peak_for_sku("NVIDIA B200"))
+
+
+# ── the union term ──────────────────────────────────────────────────────────
+#
+# The term itself (saturation, monotonicity, clamps, zero/negative guards) is
+# `distinct_experts` in roofline.py and is covered by test_moe_roofline.py. Only
+# this graph's *use* of it is tested here.
+
+
+def test_expert_fetch_is_driven_by_positions_not_sequences(spec, b200):
+    """Speculative drafts widen the expert set the step has to fetch.
+
+    Every drafted position routes independently, so eight sequences drafting four
+    positions each wake the experts of 32 tokens, not 8. This is also the guard on
+    the argument order into ``distinct_experts(batch, num_experts, top_k)`` — a
+    swap there is silent, since all three are plain ints, and would put expert
+    weight traffic somewhere between absurd and zero.
+    """
+    def routed_bytes(spec_tokens):
+        g = predict_moe_graph(
+            spec, b200,
+            BatchConfig(batch=8, kv_cache_len=4096, speculative_tokens=spec_tokens),
+        )
+        return sum(n.prediction.bytes for n in g.nodes if n.op == "moe_routed")
+
+    plain, drafted = routed_bytes(0), routed_bytes(3)
+    assert drafted > plain
+    # 8 positions wake ~44 of 256 experts; 32 wake ~140. Sublinear because the
+    # union saturates — 4x the positions is nowhere near 4x the traffic.
+    assert drafted < 4 * plain
+
+
+# ── compressed, selected attention ──────────────────────────────────────────
+
+
+def test_uncompressed_layer_reads_the_whole_cache(spec):
+    """Layers 0-1 carry ratio 0 — full attention, no selection."""
+    assert spec.compress_ratio(0) == 0
+    assert effective_kv_tokens(spec, 0, 65536) == 65536
+
+
+def test_compressed_layer_read_is_bounded_by_window_plus_topk(spec):
+    """sliding_window + index_topk is the ceiling, whatever the context."""
+    assert spec.compress_ratio(2) == 4
+    assert effective_kv_tokens(spec, 2, 65536) == 128 + 512
+
+
+def test_attention_core_read_is_constant_in_context_once_selection_saturates(spec):
+    """The headline consequence: context length leaves the attention core alone.
+
+    A residual on `attn_score_value` that scales with sequence length is
+    therefore *not* explained by "longer context" — it is a real deviation. That
+    inference is only available because this is constant.
+    """
+    at_64k = effective_kv_tokens(spec, 2, 65536)
+    at_1m = effective_kv_tokens(spec, 2, 1_048_576)
+    assert at_64k == at_1m
+
+
+def test_compress_ratio_moves_indexer_cost_not_attention_cost(spec):
+    """Ratios 4 and 128 read identically at the core but differ 32x at the scan.
+
+    This is why they are separate nodes. Folding them together would average away
+    the only signal that distinguishes the two layer types.
+    """
+    assert effective_kv_tokens(spec, 2, 65536) == effective_kv_tokens(spec, 3, 65536)
+    assert index_candidates(spec, 2, 65536) == 32 * index_candidates(spec, 3, 65536)
+
+
+def test_indexer_candidates_grow_with_context(spec):
+    """Unbounded in context — the node that decides if 1M tokens is viable."""
+    assert index_candidates(spec, 2, 1_048_576) > index_candidates(spec, 2, 65536)
+
+
+def test_effective_tokens_never_exceed_the_cache(spec):
+    """A short sequence cannot read more than it holds."""
+    assert effective_kv_tokens(spec, 2, 64) == 64
+
+
+# ── dtype-aware peaks ───────────────────────────────────────────────────────
+
+
+def test_b200_prices_fp4_against_the_fp4_peak(b200):
+    peak, used = resolve_peak(b200, "fp4")
+    assert used == "fp4"
+    assert peak == pytest.approx(9000e12)
+
+
+def test_fp4_on_a100_falls_back_and_says_so():
+    """A100 has no fp4 path. Falling back is fine; hiding it is not."""
+    peak, used = resolve_peak(HardwareSpec(), "fp4")
+    assert used == "fp16"
+    assert peak == pytest.approx(312e12)
+
+
+def test_fallback_direction_understates_the_ceiling_rather_than_inflating_it():
+    """Falling back *up* the precision ladder is the safe direction.
+
+    A lower peak predicts a slower floor, so the observed run looks closer to its
+    ceiling than it is — under-reporting headroom. The opposite error would
+    invent headroom, which is the one the refund clause cannot survive.
+    """
+    hopper = hardware_spec_for(peak_for_sku("NVIDIA H100 80GB HBM3"))
+    fp4_peak, _ = resolve_peak(hopper, "fp4")
+    fp8_peak, _ = resolve_peak(hopper, "fp8")
+    assert fp4_peak <= fp8_peak
+
+
+def test_graph_flags_when_any_node_ran_on_a_fallback_peak(spec):
+    """A100 cannot price this checkpoint; the graph must not pretend otherwise."""
+    g = predict_moe_graph(spec, HardwareSpec(), BatchConfig(batch=1, kv_cache_len=1024))
+    assert g.has_fallback_peaks
+
+
+def test_b200_graph_needs_no_fallback(spec, b200):
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=1024))
+    assert not g.has_fallback_peaks
+
+
+def test_fp4_weight_bytes_include_the_block_scales():
+    """MXFP4 is 0.5 bytes plus a 1-byte scale per 32 values, not 0.5 flat.
+
+    6% of expert traffic on this checkpoint — larger than several effects the
+    monitor is expected to resolve, so dropping it is not a rounding choice.
+    """
+    assert weight_bytes("fp4") == pytest.approx(0.5 + 1 / 32)
+    assert weight_bytes("fp8") > 1.0  # block scales ride along
+    assert weight_bytes("bf16") == 2.0
+
+
+# ── config parsing ──────────────────────────────────────────────────────────
+
+
+def test_config_parse_keeps_expert_and_linear_dtypes_distinct(spec):
+    """The whole point of the checkpoint: experts fp4, everything else fp8."""
+    assert spec.expert_dtype == "fp4"
+    assert spec.weight_dtype == "fp8"
+    assert spec.act_dtype == "bf16"
+
+
+def test_compress_ratios_truncate_to_layer_count(spec):
+    """The config ships 46 ratios for 43 layers.
+
+    Keeping the tail would not error — it would silently leave layer indices
+    correct but suggest 3 layers that don't exist. Truncating is the check.
+    """
+    assert len(V4_CONFIG["compress_ratios"]) == 46
+    assert len(spec.compress_ratios) == 43
+    assert spec.compress_ratio(42) == 4
+
+
+def test_kv_latent_is_shared_across_query_heads(spec):
+    """num_kv_heads == 1: one latent of 512+64, not 64 heads of it.
+
+    Modelling this as GQA would inflate decode KV traffic 64x and make every
+    long-context run look catastrophically memory-bound.
+    """
+    assert spec.kv_latent_dim == 512 + 64
+    assert spec.kv_latent_dim < spec.n_heads * spec.head_dim
+
+
+# ── the assembled graph ─────────────────────────────────────────────────────
+
+
+def test_expert_weight_traffic_saturates_at_the_full_expert_set(spec, b200):
+    """At large batch a step reads essentially every expert weight, once.
+
+    Pins the absolute scale, not just the shape: 43 layers x 256 experts x 3
+    matrices x 4096 x 2048 at ~0.53 bytes is ~145 GB, and the predicted bytes
+    must land there rather than at some multiple of it.
+    """
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=512, kv_cache_len=4096))
+    routed = sum(n.prediction.bytes for n in g.nodes if n.op == "moe_routed")
+    full_set = 43 * 256 * 3 * 4096 * 2048 * weight_bytes("fp4")
+    assert routed == pytest.approx(full_set, rel=0.05)
+
+
+def test_step_time_is_strongly_sublinear_in_batch(spec, b200):
+    """64x the batch for well under 64x the time — because weights saturate.
+
+    This curve is the reason batch sizing is a lever at all on this model, and a
+    graph that predicted linear growth would rank that lever as worthless.
+    """
+    def step_s(b):
+        return predict_moe_graph(
+            spec, b200, BatchConfig(batch=b, kv_cache_len=32768)
+        ).total_pred_s
+
+    assert step_s(64) < 20 * step_s(1)
+
+
+def test_low_batch_decode_is_memory_bound_on_the_experts(spec, b200):
+    """Batch 1 moves 6 experts of weights to do 6 experts of arithmetic."""
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=4096))
+    routed = [n for n in g.nodes if n.op == "moe_routed"]
+    assert routed and all(n.prediction.bound == "memory" for n in routed)
+
+
+def test_speculative_positions_amortise_cache_reads_but_not_flops(spec, b200):
+    """MTP's mechanism, made visible.
+
+    Four drafted positions verify against one KV read per sequence, so cache
+    traffic is flat while attention FLOPs scale. Collapsing positions and
+    sequences into one number would erase this and predict MTP as pure overhead.
+    """
+    plain = predict_moe_graph(spec, b200, BatchConfig(batch=8, kv_cache_len=32768))
+    spec_dec = predict_moe_graph(
+        spec, b200, BatchConfig(batch=8, kv_cache_len=32768, speculative_tokens=3)
+    )
+    def attn(g):
+        n = next(x for x in g.nodes if x.op == "attn_score_value")
+        return n.prediction.bytes, n.prediction.flops
+
+    b_plain, f_plain = attn(plain)
+    b_spec, f_spec = attn(spec_dec)
+    assert b_spec == pytest.approx(b_plain)  # one cache read per sequence
+    assert f_spec == pytest.approx(4 * f_plain)  # four positions of arithmetic
+
+
+def test_mtp_head_emits_layers_beyond_the_stack(spec, b200):
+    """The draft head is layer 43, not a renamed op — layer index is the identity."""
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=1024))
+    layers = {n.layer for n in g.nodes if n.layer is not None}
+    assert max(layers) == spec.n_layers  # 43 == one MTP layer past 0..42
+
+
+def test_dspark_only_on_its_declared_layers(spec, b200):
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=1024))
+    assert {n.layer for n in g.nodes if n.op == "dspark"} == {40, 41, 42}
+
+
+def test_estimated_nodes_are_flagged(spec, b200):
+    """Approximations must be visible to the report, never silent in the total."""
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=1024))
+    estimated = {n.op for n in g.nodes if n.prediction.estimated}
+    assert estimated == {"attn_out_proj", "dspark"}
+
+
+def test_tokens_per_step_accounts_for_acceptance():
+    """Drafts are paid for always and counted only when kept."""
+    b = BatchConfig(batch=4, speculative_tokens=3, acceptance_rate=0.5)
+    assert b.positions_per_step == 16  # all drafted work is computed
+    assert b.tokens_per_step == pytest.approx(4 * (1 + 3 * 0.5))
+
+
+# ── the observed side lines up with the predicted side ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "kernel,op",
+    [
+        ("flash_mla_sparse_fwd_kernel", "attn_score_value"),
+        ("lightning_indexer_topk_kernel", "attn_index_score"),
+        ("cutlass_moe_mm_sm100", "moe_routed"),
+        ("sm100_xmma_fp4_grouped_gemm", "moe_routed"),
+        ("moe_align_block_size_kernel", "moe_router"),
+        ("topk_softmax_kernel", "moe_router"),
+        ("shared_expert_fused_kernel", "moe_shared"),
+        ("dspark_markov_update_kernel", "dspark"),
+        # NCCL names every kernel ncclDevKernel_<Op>; the all-to-all must not be
+        # swallowed by a generic "nccl" needle, because EP dispatch is the one
+        # collective an MoE deployment exists to trade against.
+        ("ncclDevKernel_AllToAll_Simple", "moe_all_to_all"),
+        ("ncclDevKernel_AllReduce_Sum_f32", "tp_all_reduce"),
+        ("cross_device_reduce_2stage", "tp_all_reduce"),
+    ],
+)
+def test_v4_kernel_names_align_to_predicted_ops(kernel, op):
+    """Before this, every one of these returned None and the graph was unusable.
+
+    A predicted graph nothing aligns to produces no residuals, and no residuals
+    means no attribution — the whole loop downstream of Phase 1 goes quiet.
+    """
+    assert classify_op(kernel) == op
+
+
+# ── sharding across ranks ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def b300():
+    return hardware_spec_for(peak_for_sku("NVIDIA B300"))
+
+
+def test_blackwell_ultra_is_in_the_catalogue(b300):
+    """Regression: an unknown SKU silently resolves to A100 defaults.
+
+    That failure is invisible in the worst way — the fp8/fp4 peaks flag
+    themselves as fallbacks, but memory bandwidth is off by 3.9x with nothing
+    raised, and on a memory-bound workload bandwidth is the entire prediction.
+    """
+    assert b300.name != "A100-SXM4-80GB"
+    assert b300.peak_mem_bw_bytes_per_s == pytest.approx(8000e9)
+    assert b300.peak_flops_fp4_per_s == pytest.approx(15000e12)
+
+
+def test_b300_and_b200_predict_the_same_memory_bound_step(spec, b200, b300):
+    """Blackwell Ultra's 1.67x fp4 uplift buys nothing on a memory-bound decode.
+
+    Same 8 TB/s, and every node is memory-bound, so the extra compute never
+    binds. Any prediction that shows B300 faster at decode has a bug — most
+    likely a compute term that should have been a memory term.
+    """
+    bc = BatchConfig(batch=256, kv_cache_len=32768)
+    sh = ShardingConfig(tp=8)
+    assert predict_moe_graph(spec, b300, bc, sh).total_pred_s == pytest.approx(
+        predict_moe_graph(spec, b200, bc, sh).total_pred_s
+    )
+
+
+def test_tensor_parallel_does_not_divide_kv_traffic(spec, b200):
+    """With one KV head the latent cannot be split, so every rank reads all of it.
+
+    The GQA intuition says TP shards the KV cache. Here it does not, and a graph
+    that divided would rank TP as a KV-bandwidth lever that it simply is not.
+    """
+    bc = BatchConfig(batch=64, kv_cache_len=65536)
+
+    def kv_bytes(tp):
+        g = predict_moe_graph(spec, b200, bc, ShardingConfig(tp=tp))
+        return sum(n.prediction.bytes for n in g.nodes if n.op == "attn_score_value")
+
+    assert kv_bytes(8) == pytest.approx(kv_bytes(1))
+
+
+def test_tensor_parallel_does_divide_expert_traffic(spec, b200):
+    """The dominant term does shard — eight ranks, an eighth of the weights each."""
+    bc = BatchConfig(batch=256, kv_cache_len=4096)
+
+    def expert_bytes(sh):
+        g = predict_moe_graph(spec, b200, bc, sh)
+        return sum(n.prediction.bytes for n in g.nodes if n.op == "moe_routed")
+
+    assert expert_bytes(ShardingConfig(tp=8)) == pytest.approx(
+        expert_bytes(ShardingConfig(tp=1)) / 8, rel=0.02
+    )
+
+
+def test_ep_and_tp_move_identical_expert_bytes(spec, b200):
+    """EP versus TP is a *collective* trade, not a memory trade.
+
+    Whole experts on a few ranks and slices of every expert on all ranks move the
+    same bytes per rank. Only the cross-rank traffic differs. A catalogue that
+    believed EP saved HBM traffic would rank it for the wrong reason and be
+    unable to explain why it didn't help.
+    """
+    bc = BatchConfig(batch=256, kv_cache_len=4096)
+
+    def expert_bytes(sh):
+        g = predict_moe_graph(spec, b200, bc, sh)
+        return sum(n.prediction.bytes for n in g.nodes if n.op == "moe_routed")
+
+    assert expert_bytes(ShardingConfig(tp=8, ep=8)) == pytest.approx(
+        expert_bytes(ShardingConfig(tp=8))
+    )
+
+
+def test_expert_parallel_emits_all_to_all_and_tp_emits_all_reduce(spec, b200):
+    bc = BatchConfig(batch=64, kv_cache_len=4096)
+    ep_ops = {n.op for n in predict_moe_graph(spec, b200, bc, ShardingConfig(tp=8, ep=8)).nodes}
+    tp_ops = {n.op for n in predict_moe_graph(spec, b200, bc, ShardingConfig(tp=8)).nodes}
+    assert "moe_all_to_all" in ep_ops and "tp_all_reduce" in ep_ops
+    assert "moe_all_to_all" not in tp_ops and "tp_all_reduce" in tp_ops
+
+
+def test_single_rank_emits_no_collectives(spec, b200):
+    """The unsharded graph must be unchanged — no phantom collective at TP=1."""
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=8, kv_cache_len=4096))
+    assert not {n.op for n in g.nodes} & {"moe_all_to_all", "tp_all_reduce"}
+
+
+def test_ep_costs_more_cross_rank_traffic_than_tp(spec, b200):
+    """All-to-all ships every routed token; all-reduce ships one hidden state."""
+    bc = BatchConfig(batch=256, kv_cache_len=4096)
+
+    def link_s(sh):
+        g = predict_moe_graph(spec, b200, bc, sh)
+        return sum(
+            n.prediction.t_pred_s
+            for n in g.nodes
+            if n.op in ("moe_all_to_all", "tp_all_reduce")
+        )
+
+    assert link_s(ShardingConfig(tp=8, ep=8)) > link_s(ShardingConfig(tp=8))
+
+
+def test_unknown_interconnect_surfaces_rather_than_pricing_collectives_free(spec):
+    """A SKU with no NVLink figure must not be credited with a free all-to-all."""
+    no_link = HardwareSpec(peak_mem_bw_bytes_per_s=8000e9)  # interconnect stays 0.0
+    g = predict_moe_graph(
+        spec, no_link, BatchConfig(batch=64, kv_cache_len=4096), ShardingConfig(tp=8, ep=8)
+    )
+    assert g.has_unpriced_collectives
+
+
+def test_priced_interconnect_is_not_flagged(spec, b200):
+    g = predict_moe_graph(
+        spec, b200, BatchConfig(batch=64, kv_cache_len=4096), ShardingConfig(tp=8, ep=8)
+    )
+    assert not g.has_unpriced_collectives
+
+
+def test_expert_imbalance_only_applies_under_expert_parallelism(spec, b200):
+    """TP is balanced by construction; EP waits for the unluckiest rank."""
+    bc = BatchConfig(batch=64, kv_cache_len=4096)
+
+    def routed_s(sh):
+        g = predict_moe_graph(spec, b200, bc, sh)
+        return sum(n.prediction.t_pred_s for n in g.nodes if n.op == "moe_routed")
+
+    assert routed_s(ShardingConfig(tp=8, ep=8, ep_imbalance=1.5)) > routed_s(
+        ShardingConfig(tp=8, ep=8)
+    )
+    assert routed_s(ShardingConfig(tp=8, ep_imbalance=1.5)) == pytest.approx(
+        routed_s(ShardingConfig(tp=8))
+    )
+
+
+# ── does it fit ─────────────────────────────────────────────────────────────
+
+
+def test_weight_estimate_validates_against_the_published_checkpoint(base_spec):
+    """The one place this model can be checked against ground truth.
+
+    DeepSeek-V4-Flash publishes at 160 GB of safetensors. Predicting within a few
+    percent of that means the dtype split, the expert count and the attention
+    shapes are all right at once — a model that priced experts at bf16 would come
+    out near 600 GB, and one that missed the fp4 block scales would be 6% low on
+    the dominant term alone.
+    """
+    predicted = model_weight_bytes(base_spec)
+    assert predicted == pytest.approx(V4_BASE_PUBLISHED_BYTES, rel=0.05)
+
+
+def test_dspark_variant_is_a_lower_bound_not_an_estimate(spec, base_spec):
+    """-0731 publishes 7 GB above the base checkpoint; the modelled DSpark is ~6 MB.
+
+    The shape isn't public, so the graph carries a low-rank placeholder that is
+    known to be orders of magnitude small. Pinning the gap here stops anyone
+    reading that checkpoint's footprint as an estimate — and fails loudly if
+    someone later "fixes" it by fitting a number to this one observation.
+    """
+    delta = model_weight_bytes(spec) - model_weight_bytes(base_spec)
+    published_delta = 167e9 - V4_BASE_PUBLISHED_BYTES
+    assert delta < published_delta / 100
+
+
+def test_base_checkpoint_has_no_dspark_nodes(base_spec, b200):
+    """No dspark keys in the config means no dspark work in the graph.
+
+    Which makes the base checkpoint the better pilot target: its only
+    shape-estimated node is the grouped output projection.
+    """
+    g = predict_moe_graph(base_spec, b200, BatchConfig(batch=1, kv_cache_len=1024))
+    assert not [n for n in g.nodes if n.op == "dspark"]
+    assert {n.op for n in g.nodes if n.prediction.estimated} == {"attn_out_proj"}
+
+
+def test_both_checkpoint_variants_yield_identical_per_layer_ratios(spec, base_spec):
+    """44 entries and 46 entries describe the same 43 layers.
+
+    The trailing entries are MTP/padding slots. Keeping them would not error — it
+    would silently suggest layers that don't exist — so both must truncate to the
+    same thing.
+    """
+    assert len(V4_BASE_CONFIG["compress_ratios"]) == 44
+    assert len(V4_CONFIG["compress_ratios"]) == 46
+    assert base_spec.compress_ratios == spec.compress_ratios
+
+
+def test_tensor_parallel_shrinks_the_resident_footprint(spec):
+    """Eight ranks hold roughly an eighth each — this is what makes TP fit."""
+    whole = model_weight_bytes(spec)
+    sharded = model_weight_bytes(spec, ShardingConfig(tp=8))
+    assert sharded < whole / 6  # replicated q_a/kv_a/router keep it above exactly 1/8
+
+
+def test_kv_footprint_sums_per_layer_compression(spec):
+    """Two uncompressed layers dominate a 43-layer cache.
+
+    Applying any single ratio to all layers is wrong by up to 128x, and KV
+    footprint is what sets the concurrency ceiling.
+    """
+    per_token = kv_bytes_per_token(spec)
+    uncompressed = spec.n_layers * (spec.kv_latent_dim + spec.index_head_dim)
+    assert per_token < uncompressed / 5
+    assert per_token > (spec.kv_latent_dim + spec.index_head_dim) * 2  # the two full layers
+
+
+def test_b300_headroom_admits_a_full_replica_where_b200_is_marginal(spec):
+    """The actual B300 value on this checkpoint: memory, not compute.
+
+    156 GB of weights leaves ~21 GB on a 192 GB B200 and ~109 GB on a 288 GB
+    B300 — the difference between a data-parallel replica that can hold a real
+    batch and one that cannot.
+    """
+    resident = model_weight_bytes(spec)
+    b200_free = 192e9 * 0.92 - resident
+    b300_free = 288e9 * 0.92 - resident
+    kv = kv_bytes_per_token(spec)
+    assert b200_free / kv < 5e6  # tokens of KV
+    assert b300_free / kv > 20e6
+
+
+def test_indexer_is_not_misfiled_as_elementwise():
+    """`index` is an elementwise needle in the coarse taxonomy.
+
+    A misfiled kernel is worse than an unrecognised one: `other` is a visible
+    finding, while this would make attention look cheap and elementwise look
+    inexplicably expensive.
+    """
+    from gitm.tracer.kernel_taxonomy import classify_kernel
+
+    assert classify_kernel("lightning_indexer_topk_kernel") == "attention"
+    assert classify_kernel("flash_mla_sparse_fwd_kernel") == "attention"


### PR DESCRIPTION
The dense decode graph cannot describe a DeepSeek-V4-class checkpoint. Every
kernel in a V4 trace classified to `None`, so Phase 2 produced no residuals at
all and everything downstream of capture went quiet. Adds `predict_moe_graph`,
predicted per rank.

## 1. Three terms the dense graph has no place to put

**Expert weight traffic is a set-union, not a multiplication.** FLOPs scale with
`positions x top_k`, but HBM traffic scales with how many *distinct* experts the
batch collectively woke — `E*(1-(1-k/E)^P)`, saturating at `n_routed_experts`.
At batch 1 a step reads 6 of 256 experts; by batch 256 it reads all of them for
the same per-token FLOPs. The dense model has no term that saturates, so it
mispredicts the low-batch floor ~40x and then attributes the gap to a cause.

**Context length stops driving the attention core.** Once `kv_len/compress_ratio`
exceeds `index_topk`, the core's read is constant in sequence length; what grows
is the indexer scan. They are separate nodes with separate bounds, so a
context-scaling residual is no longer blamed on attention. Layers at ratio 4 and
ratio 128 read identically at the core and differ 32x at the scan.

**Precision is per-tensor-class.** The load-bearing half is bytes, not FLOPs:
pricing fp4 experts at bf16 inflates the dominant term 3.3x. The peak-FLOPS half
moves a decode step 1.6% — every node is memory-bound — but governs prefill.

## 2. Sharding

`ShardingConfig` (tp/ep/dp/ep_imbalance) predicts one rank, which is what that
rank's kernels are observed doing. Two results the whole-model graph could not
express:

- **TP does not divide KV traffic.** With `num_key_value_heads: 1` the latent
  cannot be split, so it is replicated and every rank reads all of it. TP
  scaling saturates — the opposite of the GQA intuition, and a lever-ranking
  error waiting to happen.
- **EP vs TP moves identical weight bytes per rank.** It is a collective trade
  (all-to-all vs all-reduce), not a memory trade. A catalog that believed EP
  saved HBM traffic would rank it for the wrong reason.

Collectives are priced against NVLink, bandwidth-only with no latency floor, and
flagged `estimated`. A SKU with no interconnect figure leaves them at zero, which
`Graph.has_unpriced_collectives` surfaces rather than banking as free.

## 3. Two silent failures

- **B300/GB300 were absent from the catalogue** and resolved to `HardwareSpec()`
  — A100 defaults. 2.04 TB/s instead of 8.00, a 3.9x error on the only term that
  matters here, and `has_fallback_peaks` does not catch it because it watches
  FLOP peaks. Added, with B200/GB200 and NVLink bandwidths.
- **`lightning_indexer` matched the "index" needle in the elementwise taxonomy
  rule.** A misfiled kernel is worse than an unrecognised one: `other` is a
  visible finding, whereas this made attention look cheap and elementwise look
  inexplicably expensive.

## Validation

`model_weight_bytes` predicts **156 GB for DeepSeek-V4-Flash against a published
160 GB checkpoint (-2.4%)** — one number constraining the dtype split, expert
count, and attention shapes at once. Pinned as a test.

The `-0731` DSpark variant is documented as a **lower bound, not an estimate**:
it publishes 7 GB above base where the modelled low-rank pair accounts for ~6 MB.
The shape is not public, so no number was fitted to that single observation; a
test pins the discrepancy so nobody later back-solves one.

## Limits, stated rather than hidden

Uniform routing assumed (skew touches fewer experts — under-reports headroom
rather than inventing it). `ep_imbalance` defaults to perfect balance and is
meant to be calibrated from a trace. Grouped output projection, DSpark, and every
collective carry `estimated`.