### PR TITLE
fix: ratio-0 layers are sliding-window attention, not global

### DIFF
--- a/gitm/planner/moe_graph.py
+++ b/gitm/planner/moe_graph.py
@@ -78,28 +78,38 @@ from gitm.planner.roofline import (
 def effective_kv_tokens(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
     """KV positions the attention *core* reads for ``layer`` at ``kv_len`` context.
 
-    Three mechanisms compose, in this order:
+    Two layer kinds, and conflating them is the error this function exists to
+    avoid:
 
-    1. **Compression.** A layer with ratio ``r`` keeps one compressed entry per
-       ``r`` tokens, so the candidate set is ``ceil(kv_len / r)``. Ratio 0 or 1
-       means the layer is uncompressed and attends to everything.
-    2. **Selection.** The indexer scores those candidates and keeps at most
-       ``index_topk``.
-    3. **Sliding window.** The most recent ``sliding_window`` tokens are read
-       uncompressed regardless of what selection chose.
+    **Ratio 0 — sliding-window attention.** The layer is *not* compressed, but it
+    is also not global: it reads at most ``sliding_window`` recent tokens. Reading
+    ``0`` as "uncompressed, therefore attends to everything" is the natural
+    mistake and it is wrong by ``kv_len / sliding_window`` — 512x at 64K, 8192x at
+    1M. It is also self-refuting: if any layer read the whole cache, a
+    million-token context could not be served at all, which is the headline
+    capability of the checkpoint.
 
-    The consequence worth internalising: once ``kv_len / r`` exceeds
-    ``index_topk``, the core's read is *constant in context length*. A layer with
-    ratio 128 and one with ratio 4 read the same number of tokens at 64K context
-    — they differ in KV *storage* and in how much the indexer has to scan, not in
-    what attention itself costs. A residual that scales with context therefore
-    belongs to the indexer node, and blaming it on attention is the mistake this
-    split exists to prevent.
+    **Ratio > 1 — compressed and selected.** The layer keeps one entry per ``r``
+    tokens, an indexer scores those candidates and keeps at most ``index_topk``,
+    and the recent ``sliding_window`` tokens are read regardless.
+
+    (Ratio 1 means genuinely uncompressed global attention. No layer of this
+    checkpoint uses it; it is kept for other architectures.)
+
+    The consequence worth internalising: **no layer's read grows with context.**
+    Once ``kv_len / r`` exceeds ``index_topk``, the core's read is constant, and
+    the sliding-window layers were bounded from the start. A layer with ratio 128
+    and one with ratio 4 read the same number of tokens at 64K — they differ in
+    KV *storage* and in how much the indexer has to scan, not in what attention
+    itself costs. So a residual that scales with context belongs to the indexer
+    node, and blaming it on attention is the mistake this split prevents.
     """
     if kv_len <= 0:
         return 0
     r = spec.compress_ratio(layer)
-    if r <= 1:
+    if r == 0:
+        return min(kv_len, spec.sliding_window)
+    if r == 1:
         return kv_len
     candidates = math.ceil(kv_len / r)
     selected = min(spec.index_topk, candidates)
@@ -109,13 +119,20 @@ def effective_kv_tokens(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> in
 def index_candidates(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
     """Positions the indexer must score for ``layer`` — the compressed set.
 
-    Unbounded in context length, which is what makes this the node that decides
-    whether a million-token deployment is viable.
+    Zero for sliding-window layers: a fixed recent window needs no selection, so
+    those layers run no indexer at all and the graph emits no indexer node for
+    them. Scoring a candidate set there would invent both a kernel and its cost.
+
+    For compressed layers this is unbounded in context length — the node that
+    decides whether a million-token deployment is viable, and now the *only* term
+    in the attention path that still grows with context.
     """
     if kv_len <= 0:
         return 0
     r = spec.compress_ratio(layer)
-    if r <= 1:
+    if r == 0:
+        return 0
+    if r == 1:
         return kv_len
     return math.ceil(kv_len / r)
 
@@ -166,20 +183,44 @@ def model_weight_bytes(
 
 
 def kv_bytes_per_token(spec: SparseMoEModelSpec) -> float:
-    """Resident KV-cache bytes for one token of context, across all layers.
+    """KV bytes that grow with each additional token of context.
 
-    Compression is per-layer, so this is a sum and not a multiplication: on this
-    checkpoint two layers store a full latent, twenty store a quarter of one, and
-    twenty-one store 1/128th. Using any single ratio is wrong by up to 128x, and
-    KV footprint is what sets the concurrency ceiling.
+    Compression is per-layer, so this is a sum and not a multiplication: twenty
+    layers store a quarter of a latent per token and twenty-one store 1/128th.
+    Using any single ratio is wrong by up to 128x, and KV footprint is what sets
+    the concurrency ceiling.
+
+    **Sliding-window layers are excluded.** They hold a fixed
+    ``sliding_window``-sized buffer per sequence however long the context grows,
+    so they belong in :func:`kv_fixed_bytes_per_sequence`, not in a per-token
+    rate. Counting them here would make footprint appear to grow ~4x faster than
+    it does and would cap concurrency far below what the hardware allows.
     """
     kw = weight_bytes(spec.kv_dtype)
     total = 0.0
     for layer in range(spec.n_layers):
-        r = max(1, spec.compress_ratio(layer))
+        r = spec.compress_ratio(layer)
+        if r == 0:
+            continue  # bounded buffer, not per-token growth
         # The latent, plus the indexer's key for the same (compressed) position.
-        total += (spec.kv_latent_dim + spec.index_head_dim) * kw / r
+        total += (spec.kv_latent_dim + spec.index_head_dim) * kw / max(1, r)
     return total
+
+
+def kv_fixed_bytes_per_sequence(spec: SparseMoEModelSpec) -> float:
+    """KV bytes a sequence costs regardless of how long its context grows.
+
+    The sliding-window layers: each holds ``sliding_window`` tokens of latent and
+    nothing more, so their cost is paid once per sequence rather than per token.
+
+    In magnitude this is small — on this checkpoint it is worth about 40 tokens
+    of context, so it never drives a sizing decision. It exists because the
+    *rate* was wrong without it: counting these layers per-token inflated
+    :func:`kv_bytes_per_token` by 37% at every context length.
+    """
+    kw = weight_bytes(spec.kv_dtype)
+    swa_layers = sum(1 for i in range(spec.n_layers) if spec.compress_ratio(i) == 0)
+    return swa_layers * spec.sliding_window * spec.kv_latent_dim * kw
 
 
 def _linear(rows: float, k: int, n: int, act_b: float, w_b: float) -> tuple[float, float]:
@@ -245,18 +286,23 @@ def _emit_layer(
     add("attn_kv_a", f, b + positions * spec.kv_latent_dim * kw, wd)
 
     # ── indexer: project the query, then scan the compressed candidate set ───
-    f, b = _linear(positions, h, spec.index_n_heads * spec.index_head_dim // tp, aw, ww)
-    add("attn_index_proj", f, b, wd)
-
+    # Sliding-window layers have no indexer — a fixed recent window needs no
+    # selection — so they emit neither node. Emitting them anyway would put two
+    # kernels per such layer into the predicted graph that no kernel can ever
+    # align to, which reads downstream as "predicted work that never ran".
     cand = index_candidates(spec, layer, kv_len)
-    add(
-        "attn_index_score",
-        2.0 * positions * (spec.index_n_heads // tp) * spec.index_head_dim * cand,
-        # Index keys live in the cache: read once per sequence, not per position,
-        # and replicated across TP ranks alongside the KV latent.
-        sequences * cand * spec.index_head_dim * kw,
-        wd,
-    )
+    if cand > 0:
+        f, b = _linear(positions, h, spec.index_n_heads * spec.index_head_dim // tp, aw, ww)
+        add("attn_index_proj", f, b, wd)
+
+        add(
+            "attn_index_score",
+            2.0 * positions * (spec.index_n_heads // tp) * spec.index_head_dim * cand,
+            # Index keys live in the cache: read once per sequence, not per
+            # position, and replicated across TP ranks alongside the KV latent.
+            sequences * cand * spec.index_head_dim * kw,
+            wd,
+        )
 
     # ── attention core over the selected positions ──────────────────────────
     t_eff = effective_kv_tokens(spec, layer, kv_len)

--- a/tests/test_moe_graph.py
+++ b/tests/test_moe_graph.py
@@ -23,6 +23,7 @@ from gitm.planner.moe_graph import (
     effective_kv_tokens,
     index_candidates,
     kv_bytes_per_token,
+    kv_fixed_bytes_per_sequence,
     model_weight_bytes,
     predict_moe_graph,
     spec_from_hf_config,
@@ -127,10 +128,43 @@ def test_expert_fetch_is_driven_by_positions_not_sequences(spec, b200):
 # ── compressed, selected attention ──────────────────────────────────────────
 
 
-def test_uncompressed_layer_reads_the_whole_cache(spec):
-    """Layers 0-1 carry ratio 0 — full attention, no selection."""
-    assert spec.compress_ratio(0) == 0
-    assert effective_kv_tokens(spec, 0, 65536) == 65536
+def test_ratio_zero_layers_are_sliding_window_not_global(spec):
+    """Layers 0-1 carry ratio 0, which means sliding-window — *not* global.
+
+    Reading 0 as "uncompressed, therefore attends to everything" is the natural
+    mistake and it is wrong by ``kv_len / sliding_window``: 512x at 64K. It is
+    also self-refuting — if any layer read the whole cache, the 1M context this
+    checkpoint advertises could not be served.
+    """
+    assert spec.compress_ratio(0) == spec.compress_ratio(1) == 0
+    assert effective_kv_tokens(spec, 0, 65536) == spec.sliding_window
+    assert effective_kv_tokens(spec, 1, 1_048_576) == spec.sliding_window
+
+
+def test_no_layer_read_grows_with_context(spec):
+    """The property that makes a million-token deployment possible at all.
+
+    Sliding-window layers are bounded from the start; compressed layers stop
+    growing once selection saturates. So the whole attention path is flat in
+    context length, and any observed growth is a real deviation rather than
+    something the architecture explains away.
+    """
+    at_64k = sum(effective_kv_tokens(spec, i, 65536) for i in range(spec.n_layers))
+    at_1m = sum(effective_kv_tokens(spec, i, 1_048_576) for i in range(spec.n_layers))
+    assert at_64k == at_1m
+
+
+def test_sliding_window_layers_run_no_indexer(spec, b200):
+    """A fixed recent window needs no selection, so no indexer node is emitted.
+
+    Emitting one would put predicted work into the graph that no kernel can align
+    to, which downstream reads as "predicted work that never ran".
+    """
+    assert index_candidates(spec, 0, 65536) == 0
+    g = predict_moe_graph(spec, b200, BatchConfig(batch=1, kv_cache_len=65536))
+    indexer_layers = {n.layer for n in g.nodes if n.op.startswith("attn_index")}
+    assert 0 not in indexer_layers and 1 not in indexer_layers
+    assert 2 in indexer_layers
 
 
 def test_compressed_layer_read_is_bounded_by_window_plus_topk(spec):
@@ -569,31 +603,46 @@ def test_tensor_parallel_shrinks_the_resident_footprint(spec):
     assert sharded < whole / 6  # replicated q_a/kv_a/router keep it above exactly 1/8
 
 
-def test_kv_footprint_sums_per_layer_compression(spec):
-    """Two uncompressed layers dominate a 43-layer cache.
+def test_kv_footprint_splits_growing_from_fixed(spec):
+    """Sliding-window layers cost per *sequence*; compressed layers cost per token.
 
-    Applying any single ratio to all layers is wrong by up to 128x, and KV
-    footprint is what sets the concurrency ceiling.
+    Folding the window layers into the per-token rate inflates it ~37% and caps
+    concurrency well below what the hardware allows. Applying any single ratio to
+    all 41 compressed layers is separately wrong by up to 128x.
     """
     per_token = kv_bytes_per_token(spec)
-    uncompressed = spec.n_layers * (spec.kv_latent_dim + spec.index_head_dim)
-    assert per_token < uncompressed / 5
-    assert per_token > (spec.kv_latent_dim + spec.index_head_dim) * 2  # the two full layers
+    fixed = kv_fixed_bytes_per_sequence(spec)
+
+    # Growth comes only from the 41 compressed layers, at 1/4 or 1/128 of a latent.
+    naive_all_layers = spec.n_layers * (spec.kv_latent_dim + spec.index_head_dim)
+    assert per_token < naive_all_layers / 5
+
+    # The two window layers are real, bounded, and paid once per sequence.
+    assert fixed == 2 * spec.sliding_window * spec.kv_latent_dim * weight_bytes(spec.kv_dtype)
+    # In magnitude the fixed term is tiny — worth ~40 tokens of context, so it
+    # never drives a sizing decision. What mattered was excluding these layers
+    # from the *rate*, which is a 37% error on every sequence at every length.
+    assert fixed < 50 * per_token
+    naive = per_token + 2 * (spec.kv_latent_dim + spec.index_head_dim) * weight_bytes(
+        spec.kv_dtype
+    )
+    assert naive == pytest.approx(1.37 * per_token, rel=0.02)
 
 
 def test_b300_headroom_admits_a_full_replica_where_b200_is_marginal(spec):
     """The actual B300 value on this checkpoint: memory, not compute.
 
     156 GB of weights leaves ~21 GB on a 192 GB B200 and ~109 GB on a 288 GB
-    B300 — the difference between a data-parallel replica that can hold a real
-    batch and one that cannot.
+    B300. Asserted against a concrete serving point rather than a magic token
+    threshold, so the test says what it means: a data-parallel replica holding
+    batch 256 at 32K context fits on one and not the other.
     """
     resident = model_weight_bytes(spec)
-    b200_free = 192e9 * 0.92 - resident
-    b300_free = 288e9 * 0.92 - resident
-    kv = kv_bytes_per_token(spec)
-    assert b200_free / kv < 5e6  # tokens of KV
-    assert b300_free / kv > 20e6
+    batch, ctx = 256, 32768
+    need = batch * (kv_fixed_bytes_per_sequence(spec) + ctx * kv_bytes_per_token(spec))
+
+    assert 192e9 * 0.92 - resident < need  # B200: does not fit
+    assert 288e9 * 0.92 - resident > need  # B300: fits, with room
 
 
 def test_indexer_is_not_misfiled_as_elementwise():


### PR DESCRIPTION
fix: ratio-0 layers are sliding-window attention, not global

`effective_kv_tokens` read `compress_ratio == 0` as "uncompressed, therefore
attends to everything". It means the opposite: the layer is not compressed
*because* it is windowed, reading at most `sliding_window` (128) tokens.

Layers 0-1 of DeepSeek-V4-Flash carry ratio 0, so the graph had them reading the
entire KV cache — 65,536 tokens each at 64K context instead of 128. Those two
layers accounted for **83% of all predicted KV traffic**, and the error grew
linearly with context: 512x at 64K, 8192x at 1M.

The reading was also self-refuting. If any layer read the whole cache, the
million-token context this checkpoint is built around could not be served at all.
That is the tell — a per-layer attention model that does not bound *every* layer
cannot describe a long-context architecture.

**The attention path is flat in context length.** Window layers are bounded from
the start; compressed layers stop growing once selection saturates. Total read
across 43 layers is now 26,496 tokens at 64K *and* at 1M, where before it grew
157K -> 2.1M. This is what makes the deviation monitor useful here: observed
growth in `attn_score_value` is now unambiguously a real deviation, not something
the architecture explains away.

**Window layers emit no indexer.** A fixed recent window needs no candidate
selection, so `index_candidates` returns 0 and `_emit_layer` skips both
`attn_index_proj` and `attn_index_score` for those layers. Previously the graph
predicted two kernels per window layer that no observed kernel could align to,
which downstream reads as "predicted work that never ran".

**KV footprint splits into a rate and a constant.** Window layers hold a fixed
`sliding_window`-sized buffer per sequence however long the context grows, so
they do not belong in a per-token rate. `kv_bytes_per_token` drops 5.09 -> 3.72
KB/token, i.e. 37% more concurrency per GB than the planner previously allowed.
The excluded mass moves to `kv_fixed_bytes_per_sequence` (144 KB, worth ~40
tokens of context — negligible in magnitude; it is the *rate* that was wrong).

Ratio 1 still means genuinely global attention. No layer of this checkpoint uses
it; it is kept for other architectures.

## Tests

`test_uncompressed_layer_reads_the_whole_cache` asserted the bug and is replaced
by `test_ratio_zero_layers_are_sliding_window_not_global`. Added
`test_no_layer_read_grows_with_context` (the property that makes 1M viable) and
`test_sliding_window_layers_run_no_indexer`.

`test_b300_headroom_admits_a_full_replica_where_b200_is_marginal` now asserts
against a concrete serving point — batch 256 at 32K context fits a B300 replica
and not a B200 one — rather than a magic token threshold that silently tracked
the old rate.