### PR TITLE
fix: pair residuals per structural layer class, not one representative per op

### DIFF
--- a/gitm/optimizer/monitor.py
+++ b/gitm/optimizer/monitor.py
@@ -29,6 +29,21 @@ class KernelResidual:
     t_obs_s: float | None = None
     t_pred_s: float | None = None
     bound: str | None = None  # the matched op's roofline bound: "compute" | "memory"
+    #: How many structurally distinct predictions the op has across layers. 1 for
+    #: every dense model and for most ops of a heterogeneous one. Above 1 without
+    #: a resolved ``layer`` means this residual was measured against an interval
+    #: rather than a point — see :func:`residuals`.
+    n_classes: int = 1
+
+    @property
+    def interval_based(self) -> bool:
+        """True when the op's layers disagree and this kernel's layer is unknown.
+
+        Such a residual is *conservative*: zero anywhere inside the span of the
+        op's per-layer predictions. It cannot be read as "this kernel matched
+        prediction", only as "it was not outside every prediction".
+        """
+        return self.n_classes > 1 and self.layer is None
 
 
 @dataclass
@@ -39,47 +54,125 @@ class Residuals:
     serialized_concurrency_fraction: float = 0.0
 
 
+def _class_key(pn: PredictedNode) -> tuple[float, float]:
+    """What makes two per-layer nodes of the same op structurally interchangeable.
+
+    Nodes computed by the same formula come out bit-identical, so exact equality
+    would do; the rounding is insurance against a future term that introduces
+    float drift between layers that are meant to be the same.
+    """
+    return (round(pn.prediction.t_pred_s, 15), round(pn.prediction.bytes, 6))
+
+
+def _interval_residual(obs: float, lo: float, hi: float) -> float:
+    """Signed residual against a prediction *interval* instead of a point.
+
+    Zero anywhere inside ``[lo, hi]``; outside, the distance to the nearest edge
+    relative to that edge. Deliberately conservative — when the op's layers
+    disagree and the kernel's layer is unknown, the honest prediction is the span
+    they cover, and only an observation outside all of it is evidence of
+    anything.
+    """
+    if obs < lo:
+        return (obs - lo) / lo if lo > 0 else 0.0
+    if obs > hi:
+        return (obs - hi) / hi if hi > 0 else 0.0
+    return 0.0
+
+
 def residuals(trace: Trace, graph: Graph) -> Residuals:
     """Pair observed kernels to predicted nodes by op identity, not position.
 
-    The old ordinal pairing matched a handful of early kernels against
-    unrelated ops (orders of magnitude fewer predicted nodes than real
-    kernels), producing runaway r_kt ratios. Each kernel is classified by its
-    NVTX-range identity when the capture has one (``range_op``/``range_layer``
-    — see :mod:`gitm.tracer.nvtx_correlate`), else by name
-    (:func:`gitm.optimizer.deviation.classify_op`) against one representative
-    node per op (per-layer nodes share a prediction); unmodeled kernels get no
-    residual. ``layer`` is the real per-kernel layer index when range-
-    identified, else ``None`` (unrecoverable from a name guess alone). Carries
-    the matched op's roofline ``bound`` for bottleneck classification.
+    The old ordinal pairing matched a handful of early kernels against unrelated
+    ops (orders of magnitude fewer predicted nodes than real kernels), producing
+    runaway r_kt ratios. Each kernel is classified by its NVTX-range identity when
+    the capture has one (``range_op``/``range_layer`` — see
+    :mod:`gitm.tracer.nvtx_correlate`), else by name
+    (:func:`gitm.optimizer.deviation.classify_op`).
+
+    **Pairing is per structural class, not one representative per op.** A dense
+    transformer repeats one layer, so any node stands for all of them — that
+    assumption is why this used to keep a single node per op. It does not survive
+    a heterogeneous stack. On a DeepSeek-V4-class model, layers 0-1 are
+    sliding-window (128 tokens, no indexer) while 2-42 are compressed (640
+    tokens), and the compressed layers themselves split 32x apart at the indexer.
+    Taking the first node per op made layer 0 the yardstick for all 43, which
+    scores a perfectly healthy compressed layer at ``r_kt = +4.0`` against a
+    ±0.4 band — and ``check_invariants`` treats a systematic offset as
+    *confirmation*, so multi-basis filtering amplifies the artefact instead of
+    rejecting it.
+
+    Three cases, in order:
+
+    * **Layer known** (NVTX capture): the exact ``(op, layer)`` node. Point
+      residual, and ``layer`` is carried through.
+    * **Layer unknown, op uniform**: the single class. Identical to the previous
+      behaviour, which is every dense model and 8 of V4's 10 per-layer ops.
+    * **Layer unknown, op heterogeneous**: an interval over the op's classes (see
+      :func:`_interval_residual`), flagged by ``n_classes > 1``. Real deviations
+      outside the whole span still surface; deviations *within* it are given up
+      rather than guessed at, because guessing is what produced the artefact.
+
+    The third case degrades to the first the moment NVTX ranges land, with no
+    change here.
     """
     obs = trace.kernels()
     pred = graph.nodes
 
     res = Residuals()
-    by_op: dict[str, PredictedNode] = {}
+    by_op_layer: dict[tuple[str, int], PredictedNode] = {}
+    classes: dict[str, dict[tuple[float, float], PredictedNode]] = {}
     for pn in pred:
-        by_op.setdefault(pn.op, pn)
+        if pn.layer is not None:
+            by_op_layer.setdefault((pn.op, pn.layer), pn)
+        classes.setdefault(pn.op, {}).setdefault(_class_key(pn), pn)
 
     for ok in obs:
         op = ok.range_op or classify_op(ok.name)
-        pn = by_op.get(op) if op is not None else None
-        if pn is None:
+        if op is None:
             continue
-        t_obs = max((ok.end_ns - ok.start_ns) / 1e9, 1e-12)
-        t_pred = max(pn.prediction.t_pred_s, 1e-12)
-        r_kt = (t_obs - t_pred) / t_pred
+        cls = list(classes.get(op, {}).values())
+        if not cls:
+            continue
 
-        if ok.bytes_read is not None and ok.bytes_written is not None and pn.prediction.bytes > 0:
-            b_obs = ok.bytes_read + ok.bytes_written
-            r_mt: float | None = (b_obs - pn.prediction.bytes) / pn.prediction.bytes
+        t_obs = max((ok.end_ns - ok.start_ns) / 1e9, 1e-12)
+        b_obs = (
+            ok.bytes_read + ok.bytes_written
+            if ok.bytes_read is not None and ok.bytes_written is not None
+            else None
+        )
+
+        pn: PredictedNode | None = None
+        if ok.range_layer is not None:
+            pn = by_op_layer.get((op, ok.range_layer))
+        if pn is None and len(cls) == 1:
+            pn = cls[0]
+
+        if pn is not None:
+            t_pred = max(pn.prediction.t_pred_s, 1e-12)
+            r_kt = (t_obs - t_pred) / t_pred
+            r_mt = (
+                (b_obs - pn.prediction.bytes) / pn.prediction.bytes
+                if b_obs is not None and pn.prediction.bytes > 0
+                else None
+            )
+            layer, bound = ok.range_layer, pn.prediction.bound
         else:
-            r_mt = None
+            ts = sorted(max(c.prediction.t_pred_s, 1e-12) for c in cls)
+            r_kt = _interval_residual(t_obs, ts[0], ts[-1])
+            bs = sorted(c.prediction.bytes for c in cls if c.prediction.bytes > 0)
+            r_mt = _interval_residual(b_obs, bs[0], bs[-1]) if b_obs is not None and bs else None
+            # Report the class the observation actually sits nearest, so the
+            # bound and t_pred in the record describe a real layer rather than an
+            # average of layers that don't resemble each other.
+            nearest = min(cls, key=lambda c: abs(c.prediction.t_pred_s - t_obs))
+            t_pred = nearest.prediction.t_pred_s
+            layer, bound = None, nearest.prediction.bound
 
         res.per_kernel.append(
             KernelResidual(
-                op=pn.op, layer=ok.range_layer, r_kt=r_kt, r_mt=r_mt,
-                t_obs_s=t_obs, t_pred_s=t_pred, bound=pn.prediction.bound,
+                op=op, layer=layer, r_kt=r_kt, r_mt=r_mt,
+                t_obs_s=t_obs, t_pred_s=t_pred, bound=bound, n_classes=len(cls),
             )
         )
 

--- a/tests/test_residuals_layer_classes.py
+++ b/tests/test_residuals_layer_classes.py
@@ -1,0 +1,221 @@
+"""Residual pairing across structurally different layers.
+
+A dense transformer repeats one layer, so any predicted node stands for every
+other node with the same op. ``residuals()`` relied on that, keeping one
+representative per op. The assumption does not survive a heterogeneous stack:
+on a DeepSeek-V4-class model layers 0-1 are sliding-window (128 tokens, no
+indexer) and 2-42 are compressed (640 tokens), and the compressed layers split a
+further 32x apart at the indexer.
+
+These tests pin three behaviours: dense models are untouched, a resolved layer
+gives an exact comparison, and an unresolved layer on a heterogeneous op falls
+back to an interval rather than to whichever node happened to be emitted first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gitm.optimizer.monitor import residuals
+from gitm.planner.graph import Graph, PredictedNode
+from gitm.planner.moe_graph import predict_moe_graph, spec_from_hf_config
+from gitm.planner.roofline import (
+    BatchConfig,
+    HardwareSpec,
+    ModelSpec,
+    RooflinePrediction,
+)
+from gitm.tracer.schema import KernelEvent, Trace
+
+
+def _node(op: str, layer: int | None, t_pred: float, byts: float = 0.0) -> PredictedNode:
+    return PredictedNode(
+        op, layer,
+        RooflinePrediction(
+            op=op, flops=0.0, bytes=byts, t_compute_s=0.0, t_memory_s=t_pred,
+            t_pred_s=t_pred, bound="memory",
+        ),
+    )
+
+
+def _graph(nodes: list[PredictedNode]) -> Graph:
+    return Graph(model=ModelSpec(), hw=HardwareSpec(), batch=BatchConfig(), nodes=nodes)
+
+
+def _k(name: str, dur_s: float, layer: int | None = None, byts: int | None = None) -> KernelEvent:
+    # Round, not truncate. A trace stores whole nanoseconds, and V4's
+    # sliding-window attention predicts ~3.66 us — truncating drops it below its
+    # own prediction and manufactures a residual out of the helper.
+    return KernelEvent(
+        name=name, start_ns=0, end_ns=round(dur_s * 1e9), stream_id=0, device_id=0,
+        range_layer=layer,
+        bytes_read=byts, bytes_written=0 if byts is not None else None,
+    )
+
+
+#: Nanosecond quantisation floor. Real predictions are not whole nanoseconds, so
+#: a kernel replayed at exactly its predicted time still lands ~1e-4 off it.
+NS_QUANTISATION = 1e-3
+
+
+def _trace(events: list[KernelEvent]) -> Trace:
+    return Trace(
+        workload_id="w", fingerprint="f", run_id="r", device_count=1,
+        vendor="nvidia", captured_at_ns=0, duration_ns=10**9, events=events,
+    )
+
+
+# ── uniform ops: unchanged ──────────────────────────────────────────────────
+
+
+def test_uniform_op_keeps_the_exact_point_residual():
+    """Every dense model, and 8 of V4's 10 per-layer ops, land here.
+
+    All layers agree, so there is one class and the comparison is a point — the
+    behaviour that existed before class-awareness, preserved exactly.
+    """
+    g = _graph([_node("attn_score_value", i, 1e-3) for i in range(4)])
+    res = residuals(_trace([_k("flash_attn_fwd", 2e-3)]), g)
+
+    kr = res.per_kernel[0]
+    assert kr.n_classes == 1
+    assert not kr.interval_based
+    assert kr.r_kt == pytest.approx(1.0)  # 2ms observed against 1ms predicted
+
+
+# ── heterogeneous ops, layer unknown: interval ──────────────────────────────
+
+
+def test_observation_inside_the_class_span_scores_zero():
+    """The core fix. Layers disagree, the kernel's layer is unknown, and the
+    observation is consistent with *some* layer — so there is no evidence of
+    deviation and the residual must not manufacture one."""
+    g = _graph([_node("attn_score_value", 0, 1e-3), _node("attn_score_value", 2, 5e-3)])
+    res = residuals(_trace([_k("flash_attn_fwd", 3e-3)]), g)
+
+    kr = res.per_kernel[0]
+    assert kr.n_classes == 2
+    assert kr.interval_based
+    assert kr.r_kt == 0.0
+
+
+def test_observation_above_the_span_still_deviates():
+    """Conservative is not blind — outside every prediction is still a finding."""
+    g = _graph([_node("attn_score_value", 0, 1e-3), _node("attn_score_value", 2, 5e-3)])
+    res = residuals(_trace([_k("flash_attn_fwd", 10e-3)]), g)
+    assert res.per_kernel[0].r_kt == pytest.approx(1.0)  # (10-5)/5, against the near edge
+
+
+def test_observation_below_the_span_still_deviates():
+    g = _graph([_node("attn_score_value", 0, 1e-3), _node("attn_score_value", 2, 5e-3)])
+    res = residuals(_trace([_k("flash_attn_fwd", 0.5e-3)]), g)
+    assert res.per_kernel[0].r_kt == pytest.approx(-0.5)  # (0.5-1)/1
+
+
+def test_memory_traffic_uses_the_same_interval():
+    g = _graph([
+        _node("attn_score_value", 0, 1e-3, byts=1000.0),
+        _node("attn_score_value", 2, 5e-3, byts=9000.0),
+    ])
+    res = residuals(_trace([_k("flash_attn_fwd", 3e-3, byts=5000)]), g)
+    assert res.per_kernel[0].r_mt == 0.0
+
+
+# ── heterogeneous ops, layer known: exact ───────────────────────────────────
+
+
+def test_resolved_layer_compares_against_that_layer_only():
+    """With NVTX identity there is no ambiguity to be conservative about.
+
+    The same 3ms observation that scored 0.0 as an interval is a real +200%
+    against layer 0's own prediction — which is the point of landing NVTX.
+    """
+    g = _graph([_node("attn_score_value", 0, 1e-3), _node("attn_score_value", 2, 5e-3)])
+    res = residuals(_trace([_k("flash_attn_fwd", 3e-3, layer=0)]), g)
+
+    kr = res.per_kernel[0]
+    assert kr.layer == 0
+    assert not kr.interval_based  # layer resolved, so not interval-based
+    assert kr.r_kt == pytest.approx(2.0)
+
+
+def test_resolved_layer_picks_the_right_one_of_several():
+    g = _graph([_node("attn_score_value", i, (i + 1) * 1e-3) for i in range(4)])
+    res = residuals(_trace([_k("flash_attn_fwd", 3e-3, layer=2)]), g)
+    assert res.per_kernel[0].r_kt == pytest.approx(0.0)  # layer 2 predicts exactly 3ms
+
+
+# ── the regression this exists for ──────────────────────────────────────────
+
+V4_CONFIG = {
+    "model_type": "deepseek_v4", "hidden_size": 4096, "num_hidden_layers": 43,
+    "num_attention_heads": 64, "num_key_value_heads": 1, "head_dim": 512,
+    "qk_rope_head_dim": 64, "q_lora_rank": 1024, "o_lora_rank": 1024, "o_groups": 8,
+    "vocab_size": 129280, "n_routed_experts": 256, "n_shared_experts": 1,
+    "num_experts_per_tok": 6, "moe_intermediate_size": 2048, "index_n_heads": 64,
+    "index_head_dim": 128, "index_topk": 512, "sliding_window": 128,
+    "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0],
+    "num_nextn_predict_layers": 1, "expert_dtype": "fp4",
+    "quantization_config": {"quant_method": "fp8"}, "torch_dtype": "bfloat16",
+}
+
+
+@pytest.fixture
+def v4_graph():
+    spec = spec_from_hf_config(V4_CONFIG, name="DeepSeek-V4-Flash")
+    return predict_moe_graph(
+        spec, HardwareSpec(), BatchConfig(batch=64, kv_cache_len=65536)
+    )
+
+
+def test_healthy_compressed_layer_is_not_flagged(v4_graph):
+    """The artefact this change removes.
+
+    Layer 0 is sliding-window and is emitted first, so it used to become the
+    representative for `attn_score_value` across all 43 layers. A compressed
+    layer running at exactly its own predicted time then scored r_kt = +4.0
+    against a +-0.4 band — and `check_invariants` reads a systematic offset as
+    confirmation, so multi-basis filtering amplified it rather than rejecting it.
+    """
+    compressed = next(
+        n for n in v4_graph.nodes if n.op == "attn_score_value" and n.layer == 2
+    )
+    res = residuals(_trace([_k("flash_mla_sparse_fwd", compressed.prediction.t_pred_s)]), v4_graph)
+
+    kr = res.per_kernel[0]
+    assert kr.n_classes == 2  # sliding-window vs compressed
+    assert abs(kr.r_kt) < NS_QUANTISATION
+    assert abs(kr.r_kt) < 0.4  # comfortably inside the kernel-time band
+
+
+def test_healthy_sliding_window_layer_is_not_flagged(v4_graph):
+    """The other direction: layer 0 running at its own prediction is also fine."""
+    swa = next(n for n in v4_graph.nodes if n.op == "attn_score_value" and n.layer == 0)
+    res = residuals(_trace([_k("flash_mla_sparse_fwd", swa.prediction.t_pred_s)]), v4_graph)
+    assert abs(res.per_kernel[0].r_kt) < NS_QUANTISATION
+
+
+def test_indexer_span_covers_both_compression_ratios(v4_graph):
+    """`attn_index_score` splits 32x between ratio-4 and ratio-128 layers.
+
+    Sliding-window layers emit no indexer at all, so this span is entirely
+    within what the config calls the compressed layers — a different partition
+    from the one `attn_score_value` needs, which is why the fix is per-op rather
+    than one global layer taxonomy.
+    """
+    idx = [n for n in v4_graph.nodes if n.op == "attn_index_score"]
+    assert {n.layer for n in idx}.isdisjoint({0, 1})
+    ts = sorted(n.prediction.t_pred_s for n in idx)
+    assert ts[-1] / ts[0] == pytest.approx(32.0, rel=0.01)
+
+    res = residuals(_trace([_k("lightning_indexer_topk", ts[0]), _k("lightning_indexer_topk", ts[-1])]), v4_graph)
+    assert all(abs(kr.r_kt) < NS_QUANTISATION for kr in res.per_kernel)
+
+
+def test_a_genuinely_slow_kernel_still_surfaces(v4_graph):
+    """Not a blanket suppression — 10x the slowest layer is still a violation."""
+    slowest = max(
+        n.prediction.t_pred_s for n in v4_graph.nodes if n.op == "attn_score_value"
+    )
+    res = residuals(_trace([_k("flash_mla_sparse_fwd", slowest * 10)]), v4_graph)
+    assert res.per_kernel[0].r_kt == pytest.approx(9.0, rel=1e-3)


### PR DESCRIPTION
`residuals()` kept a single representative node per op (`by_op.setdefault`) and
compared every observed kernel of that op against it. That is correct for a dense
transformer — one layer repeated N times, so any node stands for all of them —
and the docstring said as much: "per-layer nodes share a prediction."

It does not survive a heterogeneous stack. On DeepSeek-V4 layers 0-1 are
sliding-window (128 tokens, no indexer) while 2-42 are compressed (640 tokens),
and the compressed layers split a further 32x apart at the indexer. Since layer 0
is emitted first it became the yardstick for all 43 layers, so a compressed layer
running at *exactly its own predicted time* scored `r_kt = +4.0` against a +-0.4
band.

Worse, `check_invariants` treats a systematic offset as confirmation
(`abs(median(vals)) > band_width` promotes every out-of-band member). The error is
perfectly systematic, so multi-basis filtering amplified the artefact rather than
rejecting it ~40 of 43 layers reporting spurious violations in both directions,
which attribution would then explain and a lever would then "fix".


## Three cases

Predicted nodes are now grouped into structural classes per op, keyed on
(t_pred, bytes):

* **layer known** (NVTX capture) exact `(op, layer)` node, point residual, layer
  carried through.
* **layer unknown, op uniform** — the single class. Bit-identical to the previous
  behaviour, which covers every dense model and 8 of V4's 10 per-layer ops.
* **layer unknown, op heterogeneous** — an interval over the op's classes: zero
  inside the span, distance to the nearest edge outside it.

The interval case is the fix. When layers disagree and the kernel's layer is
unknown, the honest prediction is the span they cover; only an observation outside
all of it is evidence of anything. Deviations *within* the span are given up
rather than guessed at, because guessing is what produced the artefact.

`KernelResidual` gains `n_classes` and an `interval_based` property so downstream
can distinguish a conservative residual from an exact one. New fields default to
the uniform case, so the other three construction sites (measure.py,
runtime_driver.py) are unaffected.

## Why classes are derived, not declared

The partition is per-op, and the two affected ops need *different* splits:

* `attn_score_value` -> {SWA} | {CSA + HCA}, since ratio 4 and 128 both read 640
  tokens
* `attn_index_score` -> {CSA} | {HCA}, 32x apart, with SWA absent entirely

A single hardcoded SWA-vs-compressed split would fix the first and leave the 32x
error inside the second. Deriving classes from the predictions themselves handles
both, and picks up DSpark or any future heterogeneity without another change here.

## Cost

This makes residuals honest, not sharp. Inside a span there is now no signal
rather than a wrong one, and on `attn_index_score` that span is 32x wide a
compressed layer could run 20x slow and score zero. That is the right trade while
layer identity is missing, but it does make NVTX ranges load-bearing for V4 rather
than a refinement. The interval path degrades to the exact path automatically once
`range_layer` is populated; no further change needed here.
