### PR TITLE
feat: wire live vLLM config through spec_from_hf_config

### DIFF
--- a/gitm/serve/attach.py
+++ b/gitm/serve/attach.py
@@ -244,6 +244,12 @@ def attach_and_capture(opts: AttachOptions) -> tuple[int, CaptureResult | None]:
     print_checks(checks)
     write_preflight(out_dir, checks)
 
+    # Predict what this rank *should* be doing, from the server's own config, so the
+    # measured trace has an honest floor to sit next to. Independent of traceability
+    # and of the window — it reads the loaded model's shape, not the trace — so it
+    # runs here, before the fail/dry-run returns, and never blocks a capture.
+    _emit_predicted_graph(target, out_dir)
+
     if any(c.status == "fail" for c in checks):
         print("\ncannot attach — see the FAILs above.")
         if not target.traceable:
@@ -408,6 +414,80 @@ def attach_and_capture(opts: AttachOptions) -> tuple[int, CaptureResult | None]:
         # should not be reported as a pass by automation.
         return 1, result
     return 0, result
+
+
+def _emit_predicted_graph(target: discover.Target, out_dir: Path) -> None:
+    """Write ``predicted_moe_graph.json`` — a per-rank floor from the live config.
+
+    The first production consumer of :func:`predict_moe_graph`. On a config the
+    planner cannot honestly predict (missing dominant terms, unpriceable dtype) it
+    prints the named-key refusal and writes nothing — a defaulted DeepSeek prediction
+    next to a real trace would be read as a measurement, which is the one outcome the
+    gate exists to prevent. Never raises into the capture path.
+    """
+    from gitm.serve.model_config import LiveSpec, live_moe_spec
+
+    try:
+        resolved = live_moe_spec(target)
+    except Exception as e:  # a prediction sidecar must never sink a real capture
+        print(f"==> predicted graph: skipped ({type(e).__name__}: {e})")
+        return
+
+    if not isinstance(resolved, LiveSpec):
+        print("==> predicted graph: skipped — live config not predictable:")
+        for line in resolved.render().splitlines():
+            print(f"    {line}")
+        return
+
+    from gitm.planner.context import build_planner_context, hardware_spec_for
+    from gitm.planner.moe_graph import predict_moe_graph
+
+    hw = hardware_spec_for(build_planner_context().peak)
+    g = predict_moe_graph(resolved.spec, hw, resolved.batch, resolved.sharding)
+    sh, spec = resolved.sharding, resolved.spec
+
+    payload = {
+        "model_ref": resolved.model_ref,
+        "config_source": str(resolved.source_path),
+        "hardware": hw.name,
+        "sharding": {"tp": sh.tp, "ep": sh.ep, "dp": sh.dp},
+        "dtypes": {
+            "weight": spec.weight_dtype,
+            "expert": spec.expert_dtype,
+            "kv": spec.kv_dtype,
+            "act": spec.act_dtype,
+        },
+        "batch": {"batch": resolved.batch.batch, "kv_cache_len": resolved.batch.kv_cache_len},
+        "applied_overrides": resolved.applied_overrides,
+        "total_pred_s": g.total_pred_s,
+        "has_unpriced_collectives": g.has_unpriced_collectives,
+        "has_fallback_peaks": g.has_fallback_peaks,
+        "nodes": [
+            {
+                "op": n.op,
+                "layer": n.layer,
+                "t_pred_s": n.prediction.t_pred_s,
+                "bound": n.prediction.bound,
+                "dtype": n.prediction.dtype,
+                "flops": n.prediction.flops,
+                "bytes": n.prediction.bytes,
+                "estimated": n.prediction.estimated,
+            }
+            for n in g.nodes
+        ],
+    }
+    (out_dir / "predicted_moe_graph.json").write_text(json.dumps(payload, indent=2))
+
+    print(
+        f"==> predicted graph: {resolved.model_ref} per-rank floor "
+        f"{g.total_pred_s * 1e3:.2f} ms/step "
+        f"(TP={sh.tp} EP={sh.ep} DP={sh.dp}, "
+        f"w={spec.weight_dtype}/e={spec.expert_dtype}/kv={spec.kv_dtype})"
+    )
+    if g.has_unpriced_collectives:
+        print("    - collectives are unpriced (SKU has no interconnect bandwidth in the catalogue)")
+    if g.has_fallback_peaks:
+        print("    - priced against fallback peaks — the ceiling is low in a known direction")
 
 
 def describe_targets(proc: Path = discover.PROC) -> list[dict]:

--- a/gitm/serve/model_config.py
+++ b/gitm/serve/model_config.py
@@ -1,0 +1,374 @@
+"""Read a live vLLM server's model shape and turn it into a predictable spec.
+
+The attach path (:mod:`gitm.serve.attach`) finds the running server and knows the
+name it serves under, but not its *shape* — and :func:`predict_moe_graph` without a
+model silently falls back to DeepSeek-V4-Flash defaults, so a prediction against
+"whatever is running" is really a prediction against a hardcoded checkpoint. The
+one place the ground-truth config actually lives is the process itself: its argv
+names the model, its environment names the HuggingFace cache, and the `config.json`
+under that cache is the shape the graph should predict against.
+
+This module is the bridge. It is deliberately *only* filesystem and string work —
+no planner imports beyond the pure spec builder, no `/proc` beyond what
+:mod:`gitm.serve.discover` already read — so it stays testable off a real pod (every
+entry point takes an injectable ``environ`` and ``cache_root``) and so the planner
+never grows HF-cache concerns.
+
+The load-bearing decision is the **gate**. :func:`spec_from_hf_config` is written
+for a DeepSeek-V4-class MoE, and every one of its ``cfg.get(key, default)`` calls is
+a DeepSeek default; :func:`gitm.planner.roofline.weight_bytes` falls back to bf16 on
+an unrecognised dtype. Feed either an off-distribution config and you get a
+confident, plausible, wrong spec — exactly the "an estimate read as a measurement"
+failure the graph's own docstrings are written against. So :func:`validate_moe_config`
+refuses a config that is missing a dominant-term field (expert count,
+experts-per-token, expert intermediate size) or carries a quantisation method the
+roofline cannot price, and names the keys it looked for rather than defaulting them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from gitm.planner.moe_graph import spec_from_hf_config
+from gitm.planner.roofline import (
+    _WEIGHT_BYTES,
+    BatchConfig,
+    ShardingConfig,
+    SparseMoEModelSpec,
+)
+from gitm.serve import discover
+
+# Dtype strings the roofline can actually price. ``bf16`` is legitimate for an
+# unquantised checkpoint (no ``quantization_config``); anything outside this set that
+# is *declared* by the config is a silent-mispricing risk, not a default to accept.
+KNOWN_DTYPES = frozenset(_WEIGHT_BYTES)
+
+# Alias -> canonical key that :func:`spec_from_hf_config` reads. Non-DeepSeek MoEs
+# name the same tensors differently; without this a valid Mixtral/Qwen3-MoE config
+# would fail the gate for "missing" experts it declares under another name.
+_EXPERT_COUNT_ALIASES = ("n_routed_experts", "num_local_experts", "num_experts")
+_EXPERT_TOPK_ALIASES = ("num_experts_per_tok", "moe_top_k", "top_k")
+_EXPERT_INTER_ALIASES = ("moe_intermediate_size", "intermediate_size")
+
+
+def model_ref_from_cmdline(cmdline: list[str]) -> str | None:
+    """The model argument a ``vllm serve`` command was launched with.
+
+    ``vllm serve <model> ...`` puts the model first; the module form
+    (``-m vllm.entrypoints...``) passes it as ``--model``. Returns ``None`` when
+    neither is present rather than guessing — a missing model ref becomes a refusal
+    upstream, not a wrong lookup.
+    """
+    if not cmdline:
+        return None
+    # Explicit --model wins wherever it appears. Not ``-m``: that is the Python
+    # interpreter's module flag (``python -m vllm.entrypoints...``), not vLLM's.
+    for i, a in enumerate(cmdline):
+        if a == "--model" and i + 1 < len(cmdline):
+            return cmdline[i + 1]
+        if a.startswith("--model="):
+            return a.split("=", 1)[1]
+    # Positional form: the token right after `serve`.
+    for i, a in enumerate(cmdline[:-1]):
+        if a == "serve":
+            nxt = cmdline[i + 1]
+            if not nxt.startswith("-"):
+                return nxt
+    return None
+
+
+def hub_cache_root(environ: dict[str, str] | None) -> Path:
+    """The HuggingFace hub cache directory the *target* process would use.
+
+    Order matches ``huggingface_hub``: ``HF_HUB_CACHE`` points straight at the hub
+    dir; ``HF_HOME`` puts it at ``$HF_HOME/hub``; the legacy ``TRANSFORMERS_CACHE``
+    is hub-shaped; otherwise ``~/.cache/huggingface/hub``. Read from the target's
+    environment, not this process's — a server started under a relocated cache keeps
+    its models there, and reading our own env would look in the wrong place.
+    """
+    env = environ or {}
+    if env.get("HF_HUB_CACHE"):
+        return Path(env["HF_HUB_CACHE"])
+    if env.get("HF_HOME"):
+        return Path(env["HF_HOME"]) / "hub"
+    if env.get("TRANSFORMERS_CACHE"):
+        return Path(env["TRANSFORMERS_CACHE"])
+    return Path(os.path.expanduser("~/.cache/huggingface/hub"))
+
+
+def resolve_config_path(
+    model_ref: str | None,
+    environ: dict[str, str] | None = None,
+    *,
+    cache_root: Path | None = None,
+) -> Path | None:
+    """Locate the ``config.json`` for ``model_ref`` — a local path or a hub id.
+
+    Returns ``None`` (never a guess) when nothing resolves; the caller turns that
+    into a refusal that names the ref it could not find.
+    """
+    if not model_ref:
+        return None
+
+    # A local checkpoint directory, or a direct path to the config itself.
+    p = Path(model_ref)
+    if p.is_file() and p.name == "config.json":
+        return p
+    if p.is_dir() and (p / "config.json").is_file():
+        return p / "config.json"
+
+    # A hub id: deepseek-ai/DeepSeek-V4 -> models--deepseek-ai--DeepSeek-V4.
+    root = cache_root or hub_cache_root(environ)
+    repo_dir = root / ("models--" + model_ref.replace("/", "--"))
+    snapshots = repo_dir / "snapshots"
+    if not snapshots.is_dir():
+        return None
+    configs = [s / "config.json" for s in snapshots.iterdir() if (s / "config.json").is_file()]
+    if not configs:
+        return None
+    # Most recently materialised snapshot — the one a running server most likely
+    # loaded after a `hf download`.
+    return max(configs, key=lambda c: c.stat().st_mtime)
+
+
+def _kv_dtype_from_flag(value: str, act_dtype: str) -> str:
+    """Map vLLM's ``--kv-cache-dtype`` onto a roofline dtype.
+
+    ``auto`` means the cache follows the model dtype (usually bf16), so it is *not*
+    fp8 — leaving the spec's hardcoded ``fp8`` in place there would overstate the
+    saving. The ``fp8_*`` variants all price identically here.
+    """
+    v = value.lower()
+    if v == "auto":
+        return act_dtype
+    if v.startswith("fp8"):
+        return "fp8"
+    return v
+
+
+def _act_dtype_from_flag(value: str) -> str | None:
+    """Map vLLM's ``--dtype`` onto a roofline dtype, or ``None`` for ``auto``.
+
+    ``auto`` defers to the checkpoint's ``torch_dtype``, which
+    :func:`spec_from_hf_config` already reads — so only an *explicit* dtype overrides.
+    """
+    v = value.lower()
+    if v in ("auto", ""):
+        return None
+    return {"half": "fp16", "float16": "fp16", "bfloat16": "bf16", "float32": "fp32"}.get(v, v)
+
+
+def serving_overrides_from_cmdline(cmdline: list[str]) -> dict[str, Any]:
+    """Serving decisions that live on the launch command, not in the checkpoint.
+
+    Parsed with the same ``_arg_of``/``resolve_dp`` helpers the launch preflight uses
+    (imported lazily so this module does not pull vLLM's serve machinery on import).
+    ``kv_dtype`` here is the strongest reason this whole path exists: the spec builder
+    hardcodes ``fp8`` and comments that it is "a serving decision, not a model fact" —
+    and this is where that fact is recorded.
+    """
+    from gitm.serve.vllm import _arg_of, resolve_dp
+
+    out: dict[str, Any] = {}
+
+    dtype_flag = _arg_of(cmdline, "--dtype")
+    act = _act_dtype_from_flag(dtype_flag) if dtype_flag else None
+    if act:
+        out["act_dtype"] = act
+
+    kv = _arg_of(cmdline, "--kv-cache-dtype")
+    if kv:
+        # Priced against the resolved activation dtype for the ``auto`` case.
+        out["kv_dtype"] = _kv_dtype_from_flag(kv, act or "bf16")
+
+    mml = _arg_of(cmdline, "--max-model-len")
+    if mml and mml.isdigit():
+        out["max_model_len"] = int(mml)
+
+    tp_raw = _arg_of(cmdline, "--tensor-parallel-size") or _arg_of(cmdline, "-tp")
+    tp = int(tp_raw) if tp_raw and tp_raw.isdigit() else 1
+    dp = resolve_dp(cmdline)
+    ep_enabled = "--enable-expert-parallel" in cmdline
+    out["tp"], out["dp"] = tp, dp
+    # vLLM shards whole experts across the parallel ranks when expert parallelism is
+    # on; modelled here as EP over the tensor-parallel group (single-node case). A
+    # multi-node dp>1 EP deployment is approximated by this and flagged as such.
+    out["ep"] = tp if ep_enabled else 1
+    out["ep_enabled"] = ep_enabled
+    return out
+
+
+def _first_present(cfg: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for k in keys:
+        if cfg.get(k) is not None:
+            return cfg[k]
+    return None
+
+
+def validate_moe_config(cfg: dict[str, Any]) -> list[str]:
+    """Dominant-term fields this config fails to declare usably. Empty == usable.
+
+    Refusing here rather than defaulting is the whole point: a missing expert count
+    silently becomes 256, a missing top-k becomes 6, and an unrecognised quant method
+    becomes bf16 — each a large error on a term that dominates the decode step. The
+    strings returned name the aliases looked for so the operator can see what a
+    supported config would carry.
+    """
+    missing: list[str] = []
+    if _first_present(cfg, _EXPERT_COUNT_ALIASES) is None:
+        missing.append(" | ".join(_EXPERT_COUNT_ALIASES) + " (routed expert count)")
+    if _first_present(cfg, _EXPERT_TOPK_ALIASES) is None:
+        missing.append(" | ".join(_EXPERT_TOPK_ALIASES) + " (experts per token)")
+    if _first_present(cfg, _EXPERT_INTER_ALIASES) is None:
+        missing.append(" | ".join(_EXPERT_INTER_ALIASES) + " (expert intermediate size)")
+
+    # Quantisation: a *declared* method must be one the roofline can price. No
+    # ``quantization_config`` is fine — that is an unquantised (bf16) checkpoint.
+    q = cfg.get("quantization_config") or {}
+    method = q.get("quant_method")
+    if method is not None and str(method).lower() not in KNOWN_DTYPES:
+        missing.append(
+            f"quantization_config.quant_method={method!r} "
+            f"(not priceable; known: {', '.join(sorted(KNOWN_DTYPES))})"
+        )
+    expert_dtype = cfg.get("expert_dtype")
+    if expert_dtype is not None and str(expert_dtype).lower() not in KNOWN_DTYPES:
+        missing.append(f"expert_dtype={expert_dtype!r} (not priceable)")
+    return missing
+
+
+def normalize_moe_config(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Copy of ``cfg`` with alias keys mapped onto the canonical DeepSeek names.
+
+    Only fills a canonical key that is absent, so a config that already uses the
+    DeepSeek names is untouched. This keeps :func:`spec_from_hf_config` a pure,
+    single-vocabulary builder — the aliasing lives here, at the edge that reads
+    foreign configs, and its dict-based tests keep passing unchanged.
+    """
+    out = dict(cfg)
+    for canonical, aliases in (
+        ("n_routed_experts", _EXPERT_COUNT_ALIASES),
+        ("num_experts_per_tok", _EXPERT_TOPK_ALIASES),
+        ("moe_intermediate_size", _EXPERT_INTER_ALIASES),
+    ):
+        if out.get(canonical) is None:
+            val = _first_present(cfg, aliases)
+            if val is not None:
+                out[canonical] = val
+    return out
+
+
+@dataclass
+class LiveSpec:
+    """A live server resolved into everything :func:`predict_moe_graph` needs."""
+
+    spec: SparseMoEModelSpec
+    sharding: ShardingConfig
+    batch: BatchConfig
+    source_path: Path
+    model_ref: str
+    applied_overrides: dict[str, Any] = field(default_factory=dict)
+    ok: bool = True
+
+
+@dataclass
+class LiveSpecError:
+    """Why a live server could not be turned into a trustworthy spec.
+
+    ``missing_keys`` is populated only for the gate failure; a missing config or
+    unreadable environment set ``reason`` alone.
+    """
+
+    reason: str
+    model_ref: str | None = None
+    missing_keys: list[str] = field(default_factory=list)
+    ok: bool = False
+
+    def render(self) -> str:
+        lines = [self.reason]
+        if self.missing_keys:
+            lines.append("  the config must declare each of:")
+            lines += [f"    - {k}" for k in self.missing_keys]
+        return "\n".join(lines)
+
+
+def live_moe_spec(
+    target: discover.Target,
+    *,
+    environ: dict[str, str] | None = None,
+    proc: Path = discover.PROC,
+    cache_root: Path | None = None,
+    default_kv_cache_len: int = 4096,
+) -> LiveSpec | LiveSpecError:
+    """Resolve a running server (a discover :class:`Target`) into a MoE spec.
+
+    Reads the target's own environment for the cache location unless ``environ`` is
+    supplied (tests). Returns :class:`LiveSpec` on success or :class:`LiveSpecError`
+    with the reason — never a defaulted spec, so a report can only ever show a
+    prediction against the model that is genuinely loaded.
+    """
+    model_ref = model_ref_from_cmdline(target.cmdline)
+    if not model_ref:
+        return LiveSpecError(
+            reason=f"could not find a model argument on PID {target.pid}'s command line."
+        )
+
+    if environ is None:
+        environ = discover.read_environ(target.pid, proc) or {}
+
+    cfg_path = resolve_config_path(model_ref, environ, cache_root=cache_root)
+    if cfg_path is None:
+        return LiveSpecError(
+            reason=(
+                f"no config.json found for {model_ref!r} — not a local checkpoint dir, "
+                f"and not in the hub cache at {cache_root or hub_cache_root(environ)}."
+            ),
+            model_ref=model_ref,
+        )
+
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except (OSError, ValueError) as e:
+        return LiveSpecError(reason=f"could not read {cfg_path}: {e}", model_ref=model_ref)
+
+    missing = validate_moe_config(cfg)
+    if missing:
+        return LiveSpecError(
+            reason=(
+                f"{model_ref!r} at {cfg_path} is not a sparse-MoE config this planner can "
+                "predict without guessing its dominant terms."
+            ),
+            model_ref=model_ref,
+            missing_keys=missing,
+        )
+
+    spec = spec_from_hf_config(normalize_moe_config(cfg), name=model_ref)
+
+    overrides = serving_overrides_from_cmdline(target.cmdline)
+    spec_changes: dict[str, Any] = {}
+    if "kv_dtype" in overrides:
+        spec_changes["kv_dtype"] = overrides["kv_dtype"]
+    if "act_dtype" in overrides:
+        spec_changes["act_dtype"] = overrides["act_dtype"]
+    if spec_changes:
+        from dataclasses import replace
+
+        spec = replace(spec, **spec_changes)
+
+    sharding = ShardingConfig(
+        tp=overrides.get("tp", 1), ep=overrides.get("ep", 1), dp=overrides.get("dp", 1)
+    )
+    batch = BatchConfig(kv_cache_len=overrides.get("max_model_len", default_kv_cache_len))
+
+    return LiveSpec(
+        spec=spec,
+        sharding=sharding,
+        batch=batch,
+        source_path=cfg_path,
+        model_ref=model_ref,
+        applied_overrides=overrides,
+    )

--- a/tests/test_serve_model_config.py
+++ b/tests/test_serve_model_config.py
@@ -1,0 +1,198 @@
+"""Tests for reading a live vLLM server's model shape (gitm/serve/model_config.py).
+
+Filesystem-only and GPU-free: a fabricated ``config.json`` on disk plus a discover
+``Target`` carrying a fabricated command line stand in for the running server, so the
+config-resolution, aliasing, gate, and serving-override logic run on a dev box exactly
+as on a pod. The behaviour under test is the one that matters for trust: a config the
+planner cannot honestly predict is *refused with the missing keys named*, never
+silently defaulted to DeepSeek-V4 numbers.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gitm.planner.moe_graph import predict_moe_graph
+from gitm.planner.roofline import HardwareSpec
+from gitm.serve import discover
+from gitm.serve import model_config as mc
+
+
+def _write_config(root, cfg: dict, name: str = "config.json"):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / name).write_text(json.dumps(cfg))
+    return root / name
+
+
+def _deepseek_cfg(**over) -> dict:
+    cfg = {
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 4,
+        "hidden_size": 4096,
+        "n_routed_experts": 256,
+        "num_experts_per_tok": 6,
+        "moe_intermediate_size": 2048,
+        "quantization_config": {"quant_method": "fp8"},
+        "expert_dtype": "fp4",
+        "torch_dtype": "bfloat16",
+        "num_nextn_predict_layers": 1,
+    }
+    cfg.update(over)
+    return cfg
+
+
+def _target(cmdline: list[str], pid: int = 100) -> discover.Target:
+    return discover.Target(pid=pid, cmdline=cmdline)
+
+
+# --- model ref extraction ----------------------------------------------------
+
+
+def test_model_ref_from_positional_and_flag_forms():
+    assert mc.model_ref_from_cmdline(["vllm", "serve", "org/model", "--port", "8000"]) == "org/model"
+    assert (
+        mc.model_ref_from_cmdline(
+            ["python", "-m", "vllm.entrypoints.openai.api_server", "--model", "org/model"]
+        )
+        == "org/model"
+    )
+    assert mc.model_ref_from_cmdline(["python", "-m", "x", "--model=org/model"]) == "org/model"
+    assert mc.model_ref_from_cmdline([]) is None
+
+
+# --- config path resolution --------------------------------------------------
+
+
+def test_resolves_local_checkpoint_dir(tmp_path):
+    _write_config(tmp_path / "ckpt", _deepseek_cfg())
+    got = mc.resolve_config_path(str(tmp_path / "ckpt"))
+    assert got == tmp_path / "ckpt" / "config.json"
+
+
+def test_resolves_from_hf_cache_honouring_environ(tmp_path):
+    # A relocated hub cache named by the target's own environment.
+    hub = tmp_path / "custom_hub"
+    snap = hub / "models--org--Model" / "snapshots" / "abc123"
+    _write_config(snap, _deepseek_cfg())
+    environ = {"HF_HUB_CACHE": str(hub)}
+    got = mc.resolve_config_path("org/Model", environ)
+    assert got == snap / "config.json"
+
+
+def test_unresolvable_ref_returns_none(tmp_path):
+    assert mc.resolve_config_path("org/Missing", {"HF_HUB_CACHE": str(tmp_path)}) is None
+    assert mc.resolve_config_path(None) is None
+
+
+# --- the gate ----------------------------------------------------------------
+
+
+def test_deepseek_config_is_usable():
+    assert mc.validate_moe_config(_deepseek_cfg()) == []
+
+
+def test_mixtral_aliases_are_recognized_not_rejected():
+    mixtral = {
+        "model_type": "mixtral",
+        "num_local_experts": 8,
+        "num_experts_per_tok": 2,
+        "intermediate_size": 14336,
+    }
+    assert mc.validate_moe_config(mixtral) == []
+    norm = mc.normalize_moe_config(mixtral)
+    assert norm["n_routed_experts"] == 8
+    assert norm["moe_intermediate_size"] == 14336
+    # The original dict is not mutated.
+    assert "n_routed_experts" not in mixtral
+
+
+def test_missing_topk_is_refused_and_names_the_key():
+    cfg = {"num_local_experts": 8, "intermediate_size": 14336}
+    missing = mc.validate_moe_config(cfg)
+    assert any("experts per token" in m for m in missing)
+
+
+def test_unpriceable_quant_method_is_refused_not_defaulted():
+    cfg = _deepseek_cfg(quantization_config={"quant_method": "awq"})
+    missing = mc.validate_moe_config(cfg)
+    assert any("awq" in m for m in missing)
+
+
+# --- serving overrides -------------------------------------------------------
+
+
+def test_serving_overrides_from_cmdline():
+    cmd = [
+        "vllm", "serve", "org/model",
+        "--tensor-parallel-size", "8",
+        "--enable-expert-parallel",
+        "--kv-cache-dtype", "fp8_e4m3",
+        "--max-model-len", "65536",
+    ]
+    ov = mc.serving_overrides_from_cmdline(cmd)
+    assert ov["tp"] == 8 and ov["ep"] == 8 and ov["dp"] == 1
+    assert ov["kv_dtype"] == "fp8"
+    assert ov["max_model_len"] == 65536
+
+
+def test_kv_cache_auto_follows_model_dtype_not_hardcoded_fp8():
+    ov = mc.serving_overrides_from_cmdline(
+        ["vllm", "serve", "m", "--dtype", "bfloat16", "--kv-cache-dtype", "auto"]
+    )
+    assert ov["act_dtype"] == "bf16"
+    assert ov["kv_dtype"] == "bf16"
+
+
+# --- end-to-end: live_moe_spec ----------------------------------------------
+
+
+def test_live_moe_spec_applies_config_and_serving_facts(tmp_path):
+    ckpt = tmp_path / "ckpt"
+    _write_config(ckpt, _deepseek_cfg())
+    t = _target([
+        "vllm", "serve", str(ckpt),
+        "-tp", "8", "--enable-expert-parallel",
+        "--kv-cache-dtype", "auto", "--dtype", "bfloat16",
+        "--max-model-len", "32768",
+    ])
+    r = mc.live_moe_spec(t, environ={})
+    assert isinstance(r, mc.LiveSpec)
+    assert r.sharding.tp == 8 and r.sharding.ep == 8
+    # --kv-cache-dtype auto + --dtype bfloat16 overrides the spec's hardcoded fp8.
+    assert r.spec.kv_dtype == "bf16"
+    assert r.batch.kv_cache_len == 32768
+    assert r.spec.expert_dtype == "fp4"
+
+
+def test_live_moe_spec_refuses_unpredictable_config_with_named_keys(tmp_path):
+    ckpt = tmp_path / "ckpt"
+    _write_config(ckpt, {"model_type": "dense", "hidden_size": 4096})  # no MoE fields
+    r = mc.live_moe_spec(_target(["vllm", "serve", str(ckpt)]), environ={})
+    assert isinstance(r, mc.LiveSpecError)
+    assert r.missing_keys
+    assert "routed expert count" in r.render()
+
+
+def test_live_moe_spec_refuses_when_no_config_found(tmp_path):
+    r = mc.live_moe_spec(
+        _target(["vllm", "serve", "org/Missing"]),
+        environ={"HF_HUB_CACHE": str(tmp_path)},
+    )
+    assert isinstance(r, mc.LiveSpecError)
+    assert "no config.json" in r.reason
+
+
+def test_live_moe_spec_refuses_when_no_model_ref():
+    r = mc.live_moe_spec(_target(["vllm", "serve"]), environ={})
+    assert isinstance(r, mc.LiveSpecError)
+    assert "model argument" in r.reason
+
+
+def test_resolved_spec_feeds_predict_moe_graph(tmp_path):
+    ckpt = tmp_path / "ckpt"
+    _write_config(ckpt, _deepseek_cfg())
+    r = mc.live_moe_spec(_target(["vllm", "serve", str(ckpt), "-tp", "8"]), environ={})
+    assert isinstance(r, mc.LiveSpec)
+    g = predict_moe_graph(r.spec, HardwareSpec(), r.batch, r.sharding)
+    assert g.total_pred_s > 0
+    assert len(g.nodes) > 0


### PR DESCRIPTION
## Context

From the V4 long-context thread: two blockers were called out on the MoE graph before its predictions are trustworthy in the loop. Adit noted *"It isn't wired into the loop yet, `gitm run` still builds the dense graph"* and that `spec_from_hf_config` needed a real caller.

This PR closes the **first half** of that: the live process → real spec wiring. It does **not** yet dispatch MoE-vs-dense in the `gitm run` loop (see *Remaining* below).

## Problem

`spec_from_hf_config` and `predict_moe_graph` both had only test callers. `predict_moe_graph` with no model silently falls back to `SparseMoEModelSpec()` — DeepSeek-V4-Flash defaults — so a prediction against "whatever is running" was really a prediction against a hardcoded checkpoint. The attach path knew the served model's *name* but never its *shape*, and `kv_dtype` was hardcoded `fp8` with a comment that it's *"a serving decision, not a model fact."*

## Change

**New `gitm/serve/model_config.py`** — turns a live attach target into everything `predict_moe_graph` needs, from the process itself:
- `model_ref_from_cmdline` / `resolve_config_path` — argv names the model; environ (`HF_HUB_CACHE`/`HF_HOME`/`TRANSFORMERS_CACHE`) names the HF cache; read the `config.json` there (or a local checkpoint dir).
- `serving_overrides_from_cmdline` — `--kv-cache-dtype`, `--dtype`, `--max-model-len`, `-tp`/`-dp`/`--enable-expert-parallel`, reusing `vllm.py`'s `_arg_of`/`resolve_dp`.
- **The gate** — `validate_moe_config` refuses a config missing a dominant-term field (expert count / experts-per-token / expert intermediate size) or an unpriceable quant method, **naming the keys** rather than defaulting them (both `spec_from_hf_config` and `weight_bytes` default plausibly-but-wrongly on off-distribution input). `normalize_moe_config` aliases Mixtral/Qwen3-MoE field names so a valid non-DeepSeek MoE is still recognised, keeping `spec_from_hf_config` a single-vocabulary builder (its dict tests are untouched).

**`gitm/serve/attach.py`** — first production consumer of `predict_moe_graph`: emits a per-rank `predicted_moe_graph.json` floor next to the measured trace, or prints the named-key refusal. Never a defaulted prediction read as a measurement. Runs on `--dry-run` too.

## Tests

New `tests/test_serve_model_config.py` (fake `/proc` + fake HF cache, GPU-free): local-dir and cache resolution, alias recognition, refusal-with-named-keys, serving overrides (incl. `--kv-cache-dtype auto` following model dtype instead of hardcoded fp8), and a `predict_moe_graph` round-trip. Full existing MoE/residuals suites stay green; `ruff` clean.

## Remaining (not in this PR)

- **Loop dispatch** — the second half of the assignment: make `gitm run` build the MoE graph vs the dense graph based on the served model. Tracked as a follow-up.
- Feeding the predicted graph into `attribute()` for residual analysis (needs kernel-name alignment); observed-batch from queue depth. Adit's residual-per-layer-class blocker already landed on `main` in #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)