### PR TITLE
feat: dispatch sparse-MoE vs dense graph in gitm run

### DIFF
--- a/gitm/planner/moe_graph.py
+++ b/gitm/planner/moe_graph.py
@@ -482,6 +482,21 @@ def predict_moe_graph(
     return g
 
 
+def is_sparse_moe_config(cfg: dict[str, Any]) -> bool:
+    """True for the DeepSeek-V4-class checkpoints :func:`predict_moe_graph` models.
+
+    Routed experts alone are not the signal: a Mixtral declares those too but runs
+    standard attention, which this graph's compressed-KV latent and indexer nodes
+    would mis-price. The discriminator is the sparse-attention machinery — an index
+    top-k or a per-layer compression schedule — which only the DSA family carries.
+    A config without it belongs to the dense graph, whose FFN already prices a
+    mixture.
+    """
+    routed = cfg.get("n_routed_experts") and cfg.get("num_experts_per_tok")
+    sparse_attn = cfg.get("index_topk") is not None or cfg.get("compress_ratios")
+    return bool(routed and sparse_attn)
+
+
 def spec_from_hf_config(cfg: dict[str, Any], *, name: str | None = None) -> SparseMoEModelSpec:
     """Build a :class:`SparseMoEModelSpec` from a HuggingFace ``config.json``.
 

--- a/gitm/planner/moe_graph.py
+++ b/gitm/planner/moe_graph.py
@@ -493,7 +493,7 @@ def is_sparse_moe_config(cfg: dict[str, Any]) -> bool:
     mixture.
     """
     routed = cfg.get("n_routed_experts") and cfg.get("num_experts_per_tok")
-    sparse_attn = cfg.get("index_topk") is not None or cfg.get("compress_ratios")
+    sparse_attn = cfg.get("index_topk") or cfg.get("compress_ratios")
     return bool(routed and sparse_attn)
 
 

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -200,18 +200,16 @@ def _hf_config_dict(hf: Any) -> dict[str, Any]:
     return raw
 
 
-def _model_spec_from_engine(engine: Any):
-    """Build a dense ``ModelSpec`` from a live vLLM engine's HF config, or ``None``.
+def _model_spec_from_hf(hf: Any):
+    """Build a dense ``ModelSpec`` from an HF config object, or ``None``.
 
     ``predict_graph()`` with no model defaults to Llama-2-7B (32 layers). A run
     of a *different* model (e.g. opt-125m, 12 layers) is then scored against the
-    wrong predicted graph, which makes residuals and deviation meaningless. When
-    the loop has the live engine, read the real architecture off its HF config so
-    the predicted graph matches the model that actually ran. Duck-typed across
-    vLLM version drift; any failure returns ``None`` and the caller falls back to
-    the default graph rather than crashing.
+    wrong predicted graph, which makes residuals and deviation meaningless — so
+    read the real architecture off the config. Duck-typed across vLLM version
+    drift; any failure returns ``None`` and the caller falls back to the default
+    graph rather than crashing.
     """
-    hf = _hf_config_from_engine(engine)
     if hf is None:
         return None
     try:
@@ -234,6 +232,11 @@ def _model_spec_from_engine(engine: Any):
         )
     except Exception:
         return None
+
+
+def _model_spec_from_engine(engine: Any):
+    """Dense ``ModelSpec`` for a live engine's model — the config, then the spec."""
+    return _model_spec_from_hf(_hf_config_from_engine(engine))
 
 
 #: HF config field aliases per MoE family — the same quantity is spelled
@@ -361,7 +364,7 @@ def _execution_graph(engine: Any, hw: Any, batch: Any):
         if is_sparse_moe_config(cfg):
             spec = spec_from_hf_config(cfg, name=str(cfg.get("model_type") or "sparse-moe"))
             return predict_moe_graph(spec, hw, batch, ShardingConfig()), True
-    return predict_graph(model=_model_spec_from_engine(engine), hw=hw, batch=batch), False
+    return predict_graph(model=_model_spec_from_hf(hf), hw=hw, batch=batch), False
 
 
 def _clamp_pct(value: float) -> float:

--- a/gitm/scheduler/loop.py
+++ b/gitm/scheduler/loop.py
@@ -55,6 +55,11 @@ from gitm.optimizer.vllm_knobs import (
 )
 from gitm.planner.context import build_planner_context, hardware_spec_for
 from gitm.planner.graph import predict_graph
+from gitm.planner.moe_graph import (
+    is_sparse_moe_config,
+    predict_moe_graph,
+    spec_from_hf_config,
+)
 from gitm.safety.audit import AuditLog, _write_report
 from gitm.tracer.capture import capture
 from gitm.tracer.vllm_stats import sample_scheduler_stats, summarize_requests
@@ -160,20 +165,12 @@ class LoopConfig:
     workload_runner: WorkloadRunner | None = None
 
 
-def _model_spec_from_engine(engine: Any):
-    """Build a ``ModelSpec`` from a live vLLM engine's HF config, or ``None``.
-
-    ``predict_graph()`` with no model defaults to Llama-2-7B (32 layers). A run
-    of a *different* model (e.g. opt-125m, 12 layers) is then scored against the
-    wrong predicted graph, which makes residuals and deviation meaningless. When
-    the loop has the live engine, read the real architecture off its HF config so
-    the predicted graph matches the model that actually ran. Duck-typed across
-    vLLM version drift; any failure returns ``None`` and the caller falls back to
-    the default graph rather than crashing.
-    """
+def _hf_config_from_engine(engine: Any) -> Any:
+    """The live vLLM engine's HF config object, or ``None``. Duck-typed so it
+    survives vLLM version drift; the config is where both graph-selection and the
+    model shape are read from."""
     if engine is None:
         return None
-    hf: Any = None
     for path in (
         "llm_engine.model_config.hf_config",
         "llm_engine.vllm_config.model_config.hf_config",
@@ -185,8 +182,36 @@ def _model_spec_from_engine(engine: Any):
             if obj is None:
                 break
         if obj is not None:
-            hf = obj
-            break
+            return obj
+    return None
+
+
+def _hf_config_dict(hf: Any) -> dict[str, Any]:
+    """A plain dict of the HF config, with ``quantization_config`` flattened.
+
+    ``spec_from_hf_config`` reads the config as a dict and expects
+    ``quantization_config`` to be one too; a live config carries it as a nested
+    object, so normalise it here rather than teaching the dict-based builder about
+    vLLM's object shapes."""
+    raw = hf.to_dict() if hasattr(hf, "to_dict") else dict(vars(hf))
+    q = raw.get("quantization_config")
+    if q is not None and not isinstance(q, dict):
+        raw["quantization_config"] = q.to_dict() if hasattr(q, "to_dict") else dict(vars(q))
+    return raw
+
+
+def _model_spec_from_engine(engine: Any):
+    """Build a dense ``ModelSpec`` from a live vLLM engine's HF config, or ``None``.
+
+    ``predict_graph()`` with no model defaults to Llama-2-7B (32 layers). A run
+    of a *different* model (e.g. opt-125m, 12 layers) is then scored against the
+    wrong predicted graph, which makes residuals and deviation meaningless. When
+    the loop has the live engine, read the real architecture off its HF config so
+    the predicted graph matches the model that actually ran. Duck-typed across
+    vLLM version drift; any failure returns ``None`` and the caller falls back to
+    the default graph rather than crashing.
+    """
+    hf = _hf_config_from_engine(engine)
     if hf is None:
         return None
     try:
@@ -315,6 +340,28 @@ def _moe_fields_from_hf(hf: Any) -> dict[str, Any]:
         if wb:
             out["weight_dtype_bytes"] = wb
     return out
+
+
+def _execution_graph(engine: Any, hw: Any, batch: Any):
+    """The predicted graph for the model that actually ran, and whether it is the
+    sparse-MoE one.
+
+    A DeepSeek-V4-class checkpoint gets :func:`predict_moe_graph` — mixed fp4/fp8
+    precision, compressed/selected attention, MTP — none of which the dense graph
+    can represent; everything else gets the dense graph, whose FFN already prices a
+    mixture (:func:`_moe_fields_from_hf`). Sharding stays whole-model so the MoE
+    prediction shares the dense path's comparison basis against the in-process
+    trace, rather than predicting one rank against an all-rank capture.
+    """
+    from gitm.planner.roofline import ShardingConfig
+
+    hf = _hf_config_from_engine(engine)
+    if hf is not None:
+        cfg = _hf_config_dict(hf)
+        if is_sparse_moe_config(cfg):
+            spec = spec_from_hf_config(cfg, name=str(cfg.get("model_type") or "sparse-moe"))
+            return predict_moe_graph(spec, hw, batch, ShardingConfig()), True
+    return predict_graph(model=_model_spec_from_engine(engine), hw=hw, batch=batch), False
 
 
 def _clamp_pct(value: float) -> float:
@@ -549,10 +596,11 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
             trace_path=trace_path,
         )
 
-    # Predict against the model that ACTUALLY ran (read from the live engine),
-    # not the Llama-2-7B default — otherwise residuals/deviation score the real
-    # kernels against the wrong graph. Falls back to the default graph when there
-    # is no engine or its config can't be read (CPU boxes, tests, dry-run).
+    # Predict against the model that ACTUALLY ran (read from the live engine) with
+    # the graph its architecture needs — the sparse-MoE graph for a V4-class
+    # checkpoint, the dense graph otherwise (_execution_graph). Falls back to the
+    # default dense graph when there is no engine or its config can't be read (CPU
+    # boxes, tests, dry-run), so residuals never score kernels against Llama-2-7B.
     #
     # Same for hardware: predict_graph's own default is A100-SXM4-80GB peaks,
     # which silently over-predicts on anything weaker (T4/L4/...) and
@@ -561,7 +609,6 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     # so its NVML-detected SKU peak feeds the graph before residuals are ever
     # computed against it.
     pctx = build_planner_context(cfg.engine, workload=workload)
-    _spec = _model_spec_from_engine(cfg.engine)
     _hw = hardware_spec_for(pctx.peak)
     # Batch matters for the same reason the model does — and more so on a
     # mixture, where weight traffic follows the *distinct* experts a batch
@@ -570,13 +617,22 @@ def run_loop(cfg: LoopConfig) -> dict[str, Any]:
     # expert traffic ~12x. Read the real concurrency off the sampled scheduler
     # rather than defaulting.
     _batch = _batch_config_from_stats(sched_summary)
-    graph = predict_graph(model=_spec, hw=_hw, batch=_batch)
-    (run_dir / "predicted_graph.json").write_text(
-        json.dumps(
-            {"nodes": len(graph.nodes), "total_pred_s": graph.total_pred_s, "hardware": _hw.name},
-            indent=2,
+    graph, is_moe = _execution_graph(cfg.engine, _hw, _batch)
+    _graph_summary: dict[str, Any] = {
+        "graph": "moe" if is_moe else "dense",
+        "nodes": len(graph.nodes),
+        "total_pred_s": graph.total_pred_s,
+        "hardware": _hw.name,
+    }
+    if is_moe:
+        m = graph.model
+        _graph_summary.update(
+            model=m.name,
+            sharding="whole-model",
+            dtypes={"weight": m.weight_dtype, "expert": m.expert_dtype, "kv": m.kv_dtype},
+            has_unpriced_collectives=graph.has_unpriced_collectives,
         )
-    )
+    (run_dir / "predicted_graph.json").write_text(json.dumps(_graph_summary, indent=2))
 
     # Phase 2 — residuals + attribution
     res = residuals(trace, graph)

--- a/gitm/serve/model_config.py
+++ b/gitm/serve/model_config.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from gitm.planner.moe_graph import spec_from_hf_config
+from gitm.planner.moe_graph import is_sparse_moe_config, spec_from_hf_config
 from gitm.planner.roofline import (
     _WEIGHT_BYTES,
     BatchConfig,
@@ -334,6 +334,20 @@ def live_moe_spec(
         cfg = json.loads(cfg_path.read_text())
     except (OSError, ValueError) as e:
         return LiveSpecError(reason=f"could not read {cfg_path}: {e}", model_ref=model_ref)
+
+    # predict_moe_graph models DeepSeek-V4-class compressed/selected attention;
+    # feeding it a Mixtral-style MoE (standard attention) would mis-price the KV
+    # path. The dense planner is the right tool for those, so decline rather than
+    # emit a confident wrong floor.
+    if not is_sparse_moe_config(cfg):
+        return LiveSpecError(
+            reason=(
+                f"{model_ref!r} at {cfg_path} is not a DeepSeek-V4-class sparse-MoE model "
+                "(no index_topk / compress_ratios); its attention is not what "
+                "predict_moe_graph models."
+            ),
+            model_ref=model_ref,
+        )
 
     missing = validate_moe_config(cfg)
     if missing:

--- a/tests/test_moe_loop_dispatch.py
+++ b/tests/test_moe_loop_dispatch.py
@@ -1,0 +1,76 @@
+"""The loop predicts against the graph the model actually needs.
+
+`gitm run` built the dense graph for every model. A DeepSeek-V4-class checkpoint
+needs the sparse-MoE graph (mixed fp4/fp8, compressed/selected attention, MTP)
+instead — but a Mixtral, which is also a mixture, does *not*, because its
+attention is standard and the MoE graph's compressed-KV nodes would mis-price it.
+These tests pin the dispatch on a fake duck-typed engine (no vLLM/GPU).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gitm.planner.moe_graph import is_sparse_moe_config
+from gitm.planner.roofline import BatchConfig, HardwareSpec, ModelSpec, SparseMoEModelSpec
+from gitm.scheduler.loop import _execution_graph, _hf_config_dict
+
+
+def _engine(**hf_fields):
+    hf = SimpleNamespace(**hf_fields)
+    return SimpleNamespace(llm_engine=SimpleNamespace(model_config=SimpleNamespace(hf_config=hf)))
+
+
+_V4 = dict(
+    model_type="deepseek_v4", num_hidden_layers=4, hidden_size=4096,
+    n_routed_experts=256, num_experts_per_tok=6, moe_intermediate_size=2048,
+    index_topk=512, compress_ratios=[0, 0, 4, 128],
+    quantization_config={"quant_method": "fp8"}, expert_dtype="fp4", torch_dtype="bfloat16",
+)
+_MIXTRAL = dict(
+    model_type="mixtral", num_hidden_layers=4, hidden_size=4096, num_attention_heads=32,
+    num_key_value_heads=8, intermediate_size=14336, vocab_size=32000,
+    num_local_experts=8, num_experts_per_tok=2, sliding_window=4096,
+)
+_OPT_125M = dict(
+    num_hidden_layers=12, hidden_size=768, num_attention_heads=12,
+    intermediate_size=3072, vocab_size=50272,
+)
+
+
+def test_predicate_fires_only_for_dsa_moe():
+    assert is_sparse_moe_config(_V4)
+    assert not is_sparse_moe_config(_MIXTRAL)  # MoE, but standard attention
+    assert not is_sparse_moe_config(_OPT_125M)  # dense
+
+
+def test_v4_engine_routes_to_the_moe_graph():
+    graph, is_moe = _execution_graph(_engine(**_V4), HardwareSpec(), BatchConfig(batch=8))
+    assert is_moe
+    assert isinstance(graph.model, SparseMoEModelSpec)
+    assert graph.total_pred_s > 0
+
+
+def test_mixtral_engine_routes_to_the_dense_graph():
+    _, is_moe = _execution_graph(_engine(**_MIXTRAL), HardwareSpec(), BatchConfig())
+    assert not is_moe
+
+
+def test_dense_engine_routes_to_the_dense_graph():
+    graph, is_moe = _execution_graph(_engine(**_OPT_125M), HardwareSpec(), BatchConfig())
+    assert not is_moe
+    assert isinstance(graph.model, ModelSpec)
+    assert len(graph.nodes) == 12 * 5 + 1  # the real model, not the Llama default
+
+
+def test_no_engine_falls_back_to_the_default_dense_graph():
+    graph, is_moe = _execution_graph(None, HardwareSpec(), BatchConfig())
+    assert not is_moe
+    assert isinstance(graph.model, ModelSpec)
+
+
+def test_object_quantization_config_is_flattened_to_a_dict():
+    # A live HF config carries quantization_config as an object, not a dict;
+    # spec_from_hf_config expects a dict, so the boundary must normalise it.
+    hf = SimpleNamespace(**{**_V4, "quantization_config": SimpleNamespace(quant_method="fp8")})
+    assert _hf_config_dict(hf)["quantization_config"] == {"quant_method": "fp8"}

--- a/tests/test_serve_model_config.py
+++ b/tests/test_serve_model_config.py
@@ -32,6 +32,9 @@ def _deepseek_cfg(**over) -> dict:
         "n_routed_experts": 256,
         "num_experts_per_tok": 6,
         "moe_intermediate_size": 2048,
+        # DeepSeek Sparse Attention markers — what routes this to the MoE graph.
+        "index_topk": 512,
+        "compress_ratios": [0, 0, 4, 128],
         "quantization_config": {"quant_method": "fp8"},
         "expert_dtype": "fp4",
         "torch_dtype": "bfloat16",
@@ -164,13 +167,44 @@ def test_live_moe_spec_applies_config_and_serving_facts(tmp_path):
     assert r.spec.expert_dtype == "fp4"
 
 
-def test_live_moe_spec_refuses_unpredictable_config_with_named_keys(tmp_path):
+def test_live_moe_spec_refuses_dsa_config_missing_a_dominant_term(tmp_path):
+    ckpt = tmp_path / "ckpt"
+    # Passes the architecture gate (index_topk + routed experts) but never
+    # declares the expert intermediate size, which the graph would silently
+    # default — so it is refused with that key named.
+    _write_config(ckpt, {
+        "model_type": "deepseek_v4",
+        "n_routed_experts": 256,
+        "num_experts_per_tok": 6,
+        "index_topk": 512,
+    })
+    r = mc.live_moe_spec(_target(["vllm", "serve", str(ckpt)]), environ={})
+    assert isinstance(r, mc.LiveSpecError)
+    assert any("expert intermediate size" in k for k in r.missing_keys)
+
+
+def test_live_moe_spec_refuses_dense_model_at_the_architecture_gate(tmp_path):
     ckpt = tmp_path / "ckpt"
     _write_config(ckpt, {"model_type": "dense", "hidden_size": 4096})  # no MoE fields
     r = mc.live_moe_spec(_target(["vllm", "serve", str(ckpt)]), environ={})
     assert isinstance(r, mc.LiveSpecError)
-    assert r.missing_keys
-    assert "routed expert count" in r.render()
+    assert "not a DeepSeek-V4-class" in r.reason
+
+
+def test_live_moe_spec_refuses_mixtral_style_moe(tmp_path):
+    # A real MoE, but standard attention — predict_moe_graph would mis-model its
+    # KV path, so the sidecar declines rather than emit a confident wrong floor.
+    ckpt = tmp_path / "ckpt"
+    _write_config(ckpt, {
+        "model_type": "mixtral",
+        "num_local_experts": 8,
+        "num_experts_per_tok": 2,
+        "intermediate_size": 14336,
+        "sliding_window": 4096,
+    })
+    r = mc.live_moe_spec(_target(["vllm", "serve", str(ckpt)]), environ={})
+    assert isinstance(r, mc.LiveSpecError)
+    assert "not a DeepSeek-V4-class" in r.reason
 
 
 def test_live_moe_spec_refuses_when_no_config_found(tmp_path):


### PR DESCRIPTION
## Context

From the V4 long-context thread, the second of Nicholas's two blockers (the first — wiring live config through `spec_from_hf_config` — is #84, which this stacks on):

> gitm run still builds the dense graph — @Nicholas Lawrence dispatch the moe graph versus the dense graph in the actual gitm run loop.

The loop built the dense predicted graph for **every** model, so a DeepSeek-V4-class checkpoint was scored against a graph that can't represent its mixed fp4/fp8 precision, compressed/selected attention, or MTP. Adit's residuals-per-structural-layer fix (#83) also had nothing heterogeneous to pair against — the two are complementary, and this activates it.

> **Stacked on #84** — review/merge that first. Base is `feat/live-config-through-spec-from-hf-config`, so this diff is only the dispatch.

## Change

**`is_sparse_moe_config(cfg)`** (`gitm/planner/moe_graph.py`) — one shared predicate for "does `predict_moe_graph` model this checkpoint." Routed experts alone aren't the signal: a Mixtral declares those but runs standard attention the MoE graph's compressed-KV/indexer nodes would mis-price. The discriminator is the DSA machinery (`index_topk` / `compress_ratios`), derived from the repo's own V4 config fixtures in `tests/test_moe_graph.py`.

**`_execution_graph`** (`gitm/scheduler/loop.py`) — reads the live engine's HF config once (extracted `_hf_config_from_engine`, shared with the dense path's `_model_spec_from_engine`), and routes a V4-class checkpoint to `predict_moe_graph`, everything else to `predict_graph`. The chosen graph is recorded in `predicted_graph.json` (`"graph": "moe"|"dense"`, dtypes, sharding).

- **Sharding basis:** `predict_moe_graph` with real TP/EP predicts *one rank*; the loop's in-process trace shares the dense path's whole-model basis, so passing real sharding would make every residual wrong by ~TP and feed that into every Claim's `residual_value`. The dispatch passes `ShardingConfig()` (whole-model) to preserve the existing basis. Per-rank prediction is a separate change gated on proving the trace is single-rank.
- **Dense path untouched:** kept its `getattr`-based reads (transformers `attribute_map`/property aliases resolve where `cfg.get` wouldn't), sharing only the config-locating traversal.

**Attach sidecar** (`gitm/serve/model_config.py`) — the same predicate now gates `live_moe_spec`, so it declines a Mixtral-style MoE instead of emitting a confident wrong per-rank floor (a latent gap in #84's broader completeness gate).

## Why nothing else changed

`residuals`, `attribute`, `attribute_dr`, `deviation_summary` all consume `Graph` generically and `Graph.model` is already `ModelSpec | SparseMoEModelSpec`, so feeding the MoE graph is all that was needed — and is exactly what engages #83's per-structural-layer pairing (V4: SWA layers 0–1 vs compressed 2–42).

## Tests

- `tests/test_moe_loop_dispatch.py` — predicate fires only for DSA-MoE; V4 engine → MoE graph, Mixtral/opt-125m/no-engine → dense; object `quantization_config` flattened.
- `tests/test_serve_model_config.py` — Mixtral refused at the architecture gate; DSA-class-but-incomplete still refused with named keys.
- Existing `test_predict_graph_from_engine`, `test_moe_graph`, `test_residuals_layer_classes`, `test_run_loop_workload`, vLLM suites stay green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)