### PR TITLE
feat: model the DeepSeek-V4 architecture

### DIFF
--- a/gitm/planner/moe_graph.py
+++ b/gitm/planner/moe_graph.py
@@ -18,11 +18,14 @@ attributes the difference to a cause. The term itself is
 rather than reimplemented here — it is the same union, and two copies of it would
 drift.
 
-**Context length stops driving the attention core.** Compressed KV plus an indexer
-that keeps ``index_topk`` candidates means the attention core reads a bounded
-number of tokens no matter how long the sequence gets. What grows with context is
-the *indexer scan* — a different node, with a different bound, that the dense graph
-would have folded into attention and then blamed on the wrong kernel.
+**Attention is three mechanisms, not one.** Sliding-window layers read a fixed
+recent window. CSA layers compress by ``m`` and then *select* ``index_topk``
+entries with a lightning indexer, so their core read is bounded and flat in
+context while their indexer scan grows. HCA layers compress by ``m' >> m`` and
+attend *densely* with no indexer, so their read grows with context without bound
+and they dominate the attention cost at long sequence lengths. Folding these into
+one op — as a dense graph must — averages a 13x spread at 1M context and
+attributes deviation to whichever layer happened to be modelled.
 
 **Precision is per-tensor-class.** Experts run fp4, linears fp8, the KV cache fp8.
 The load-bearing half of this is *bytes*, not FLOPs: pricing fp4 expert weights at
@@ -78,42 +81,53 @@ from gitm.planner.roofline import (
 def effective_kv_tokens(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
     """KV positions the attention *core* reads for ``layer`` at ``kv_len`` context.
 
-    Two layer kinds, and conflating them is the error this function exists to
-    avoid:
+    Three layer kinds (paper §2.3), and conflating any two of them is the error
+    this function exists to avoid:
 
-    **Ratio 0 — sliding-window attention.** The layer is *not* compressed, but it
-    is also not global: it reads at most ``sliding_window`` recent tokens. Reading
-    ``0`` as "uncompressed, therefore attends to everything" is the natural
-    mistake and it is wrong by ``kv_len / sliding_window`` — 512x at 64K, 8192x at
-    1M. It is also self-refuting: if any layer read the whole cache, a
-    million-token context could not be served at all, which is the headline
-    capability of the checkpoint.
+    **swa — ratio 0.** Not compressed, but not global either: at most
+    ``sliding_window`` recent tokens. Reading ``0`` as "uncompressed, therefore
+    attends to everything" is wrong by ``kv_len / sliding_window`` — 512x at 64K.
 
-    **Ratio > 1 — compressed and selected.** The layer keeps one entry per ``r``
-    tokens, an indexer scores those candidates and keeps at most ``index_topk``,
-    and the recent ``sliding_window`` tokens are read regardless.
+    **csa — the smaller compression rate.** One entry per ``m`` tokens, then a
+    lightning indexer scores those entries and keeps ``index_topk``. Bounded, so
+    **flat in context** once selection saturates.
+
+    **hca — the larger rate.** One entry per ``m' >> m`` tokens, attended
+    **densely** — no indexer, no selection. So its read is ``kv_len / m'`` and
+    **grows with context without bound**. HCA buys efficiency from the
+    compression rate alone; CSA buys it from selection. That is the whole point
+    of interleaving them, and it means the two cannot share a cost model.
 
     (Ratio 1 means genuinely uncompressed global attention. No layer of this
     checkpoint uses it; it is kept for other architectures.)
 
-    The consequence worth internalising: **no layer's read grows with context.**
-    Once ``kv_len / r`` exceeds ``index_topk``, the core's read is constant, and
-    the sliding-window layers were bounded from the start. A layer with ratio 128
-    and one with ratio 4 read the same number of tokens at 64K — they differ in
-    KV *storage* and in how much the indexer has to scan, not in what attention
-    itself costs. So a residual that scales with context belongs to the indexer
-    node, and blaming it on attention is the mistake this split prevents.
+    The consequence worth internalising: **HCA is what makes long context
+    expensive.** At 64K every layer reads 640 entries and the stack looks flat;
+    by 1M the HCA layers read 8,320 each and account for the great majority of
+    all attention traffic. A residual that scales with context therefore belongs
+    to HCA or to the CSA indexer — never to a CSA core, which is genuinely
+    constant.
     """
     if kv_len <= 0:
         return 0
-    r = spec.compress_ratio(layer)
-    if r == 0:
+    kind = spec.attention_kind(layer)
+    if kind == "swa":
+        # An uncompressed layer with no window is not a window layer — it is
+        # global attention, and it reads everything. Returning
+        # ``min(kv_len, 0) == 0`` there would say attention is free, which is
+        # the failure mode a config missing ``sliding_window`` walks straight
+        # into: a plausible total with a whole mechanism silently costed at zero.
+        if spec.sliding_window <= 0:
+            return kv_len
         return min(kv_len, spec.sliding_window)
-    if r == 1:
-        return kv_len
-    candidates = math.ceil(kv_len / r)
-    selected = min(spec.index_topk, candidates)
-    return min(kv_len, spec.sliding_window + selected)
+    r = max(1, spec.compress_ratio(layer))
+    compressed = math.ceil(kv_len / r)
+    if kind == "hca":
+        # Dense over every compressed entry — no selection, so this grows with
+        # context. HCA buys its efficiency from the compression rate alone.
+        return min(kv_len, spec.sliding_window + compressed)
+    # CSA: the indexer keeps at most index_topk of the compressed entries.
+    return min(kv_len, spec.sliding_window + min(spec.index_topk, compressed))
 
 
 def index_candidates(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
@@ -127,14 +141,9 @@ def index_candidates(spec: SparseMoEModelSpec, layer: int, kv_len: int) -> int:
     decides whether a million-token deployment is viable, and now the *only* term
     in the attention path that still grows with context.
     """
-    if kv_len <= 0:
+    if kv_len <= 0 or spec.attention_kind(layer) != "csa":
         return 0
-    r = spec.compress_ratio(layer)
-    if r == 0:
-        return 0
-    if r == 1:
-        return kv_len
-    return math.ceil(kv_len / r)
+    return math.ceil(kv_len / max(1, spec.compress_ratio(layer)))
 
 
 def model_weight_bytes(
@@ -203,7 +212,7 @@ def kv_bytes_per_token(spec: SparseMoEModelSpec) -> float:
         if r == 0:
             continue  # bounded buffer, not per-token growth
         # The latent, plus the indexer's key for the same (compressed) position.
-        total += (spec.kv_latent_dim + spec.index_head_dim) * kw / max(1, r)
+        total += (kv_entry_bytes(spec) + spec.index_head_dim * kw) / max(1, r)
     return total
 
 
@@ -218,9 +227,21 @@ def kv_fixed_bytes_per_sequence(spec: SparseMoEModelSpec) -> float:
     *rate* was wrong without it: counting these layers per-token inflated
     :func:`kv_bytes_per_token` by 37% at every context length.
     """
-    kw = weight_bytes(spec.kv_dtype)
     swa_layers = sum(1 for i in range(spec.n_layers) if spec.compress_ratio(i) == 0)
-    return swa_layers * spec.sliding_window * spec.kv_latent_dim * kw
+    return swa_layers * spec.sliding_window * kv_entry_bytes(spec)
+
+
+def kv_entry_bytes(spec: SparseMoEModelSpec) -> float:
+    """Bytes one cached KV entry occupies, across its mixed storage format.
+
+    Paper §2.3.4: the RoPE dimensions are kept in BF16 while the rest is FP8,
+    "reducing the KV cache size by nearly half compared with pure BF16". Pricing
+    the whole entry at FP8 understates it — on this checkpoint by 11%, since 64
+    of the 576 dimensions carry double width.
+    """
+    rope = spec.qk_rope_head_dim * spec.num_kv_heads
+    rest = spec.kv_latent_dim - rope
+    return rest * weight_bytes(spec.kv_dtype) + rope * weight_bytes("bf16")
 
 
 def _linear(rows: float, k: int, n: int, act_b: float, w_b: float) -> tuple[float, float]:
@@ -258,13 +279,21 @@ def _emit_layer(
     aw = weight_bytes(spec.act_dtype)
     ww = weight_bytes(spec.weight_dtype)
     ew = weight_bytes(spec.expert_dtype)
-    kw = weight_bytes(spec.kv_dtype)
     wd, ed = spec.weight_dtype, spec.expert_dtype
 
-    def add(op: str, flops: float, byts: float, dtype: str, *, estimated: bool = False) -> None:
+    def add(
+        op: str, flops: float, byts: float, dtype: str,
+        *, estimated: bool = False, serial_launches: int = 0,
+    ) -> None:
         name = f"{prefix}{op}"
         g.nodes.append(
-            PredictedNode(name, layer, roofline(name, flops, byts, hw, dtype, estimated=estimated))
+            PredictedNode(
+                name, layer,
+                roofline(
+                    name, flops, byts, hw, dtype,
+                    estimated=estimated, serial_launches=serial_launches,
+                ),
+            )
         )
 
     tp = max(1, sh.tp)
@@ -281,27 +310,58 @@ def _emit_layer(
     f, b = _linear(positions, spec.q_lora_rank, spec.n_heads * spec.q_head_dim // tp, aw, ww)
     add("attn_q_b", f, b, wd)
 
-    # KV down-projection, plus the cache write for the positions just computed.
-    f, b = _linear(positions, h, spec.kv_latent_dim, aw, ww)
-    add("attn_kv_a", f, b + positions * spec.kv_latent_dim * kw, wd)
+    # KV entries and their compression weights, plus the cache write for the
+    # positions just computed. CSA computes *two* KV series and two weight series
+    # (W^aKV, W^bKV, W^aZ, W^bZ) because its compression windows overlap; HCA
+    # computes one of each; a window layer caches raw entries and compresses
+    # nothing. Modelling one projection everywhere understates CSA 4x on this op.
+    kind = spec.attention_kind(layer)
+    n_kv_proj = {"csa": 4, "hca": 2}.get(kind, 1)
+    f, b = _linear(positions, h, spec.kv_latent_dim * n_kv_proj, aw, ww)
+    add("attn_kv_a", f, b + positions * kv_entry_bytes(spec), wd)
+
+    if kind != "swa":
+        # The compressor itself: a row-softmax over the window's weights and the
+        # weighted sum that collapses it to one entry. One compressed entry per
+        # ``r`` tokens, so at decode this fires on a 1/r duty cycle.
+        r = max(1, spec.compress_ratio(layer))
+        window = 2 * r if kind == "csa" else r  # CSA windows overlap
+        add(
+            "attn_kv_compress",
+            3.0 * positions * window * spec.kv_latent_dim / r,
+            2.0 * positions * window * spec.kv_latent_dim * aw / r,
+            spec.act_dtype,
+        )
 
     # ── indexer: project the query, then scan the compressed candidate set ───
-    # Sliding-window layers have no indexer — a fixed recent window needs no
-    # selection — so they emit neither node. Emitting them anyway would put two
-    # kernels per such layer into the predicted graph that no kernel can ever
-    # align to, which reads downstream as "predicted work that never ran".
+    # Only CSA layers run one. Window layers need no selection, and HCA attends
+    # densely over its (far more aggressively compressed) entries — emitting an
+    # indexer for either would put kernels in the graph that never ran.
     cand = index_candidates(spec, layer, kv_len)
     if cand > 0:
-        f, b = _linear(positions, h, spec.index_n_heads * spec.index_head_dim // tp, aw, ww)
+        # The indexer query comes off the *same* latent as the attention query
+        # (paper eq. 13-14: both are c_t^Q @ W^UQ variants), so only the
+        # up-projection is charged here — the down-projection is attn_q_a.
+        #
+        # Not divided by ``tp``: vLLM builds the indexer's ``wq_b`` and
+        # ``weights_proj`` as ReplicatedLinear, so every rank runs the whole
+        # indexer. Sharding it here would predict a speedup the deployment does
+        # not get, and would under-predict this node by ``tp``.
+        f, b = _linear(
+            positions, spec.q_lora_rank, spec.index_n_heads * spec.index_head_dim, aw, ww
+        )
         add("attn_index_proj", f, b, wd)
 
         add(
             "attn_index_score",
-            2.0 * positions * (spec.index_n_heads // tp) * spec.index_head_dim * cand,
+            2.0 * positions * spec.index_n_heads * spec.index_head_dim * cand,
             # Index keys live in the cache: read once per sequence, not per
-            # position, and replicated across TP ranks alongside the KV latent.
-            sequences * cand * spec.index_head_dim * kw,
-            wd,
+            # position, and replicated across ranks alongside the KV latent.
+            # vLLM quantises this cache to uint8, so a byte per element — the
+            # FP4 in the paper (§2.3.4) is the *arithmetic* precision, which is
+            # why the dtype and the byte width disagree here.
+            sequences * cand * spec.index_head_dim * 1.0,
+            "fp4",
         )
 
     # ── attention core over the selected positions ──────────────────────────
@@ -320,8 +380,25 @@ def _emit_layer(
         # parallelism buys no KV bandwidth on this architecture — the opposite of
         # the intuition carried over from GQA models, and a lever-ranking error
         # waiting to happen if the graph divided here.
-        sequences * t_eff * spec.kv_latent_dim * kw,
+        sequences * t_eff * kv_entry_bytes(spec),
         wd,
+    )
+
+    # RMSNorm on every query head and on the single compressed KV head, plus
+    # partial RoPE on the last ``qk_rope_head_dim`` dimensions and the cache
+    # insert — one node because vLLM runs them as one kernel
+    # (``fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert``, and
+    # ``fused_q_kv_rmsnorm`` for the pair of norms). Emitting a node per
+    # mathematical step would put three predicted kernels where one runs, and
+    # nothing would align to two of them.
+    heads = spec.n_heads // tp
+    normed = positions * (heads * spec.q_head_dim + spec.kv_latent_dim)
+    roped = positions * (2 * heads + 1) * spec.qk_rope_head_dim
+    add(
+        "attn_qnorm_rope_insert",
+        3.0 * normed + 6.0 * roped,
+        2.0 * normed * aw + 2.0 * roped * aw,
+        spec.act_dtype,
     )
 
     # Output projection, grouped and low-rank. ``o_groups`` partitions the head
@@ -335,11 +412,50 @@ def _emit_layer(
     # the same place, so residuals for it stay comparable across model families.
     add("attn_out_proj", f_a + f_b, b_a + b_b, wd, estimated=True)
 
+    # ── manifold-constrained hyper-connections ──────────────────────────────
+    # Two per block (around attention, around the MoE). The residual stream is
+    # n_hc times as wide as the hidden size, so the *activation* traffic here is
+    # the cost — the three generated mappings are tiny in weights but every one
+    # of them reads a flattened n_hc*d state.
+    if spec.hc_width > 1:
+        n_hc = spec.hc_width
+        wide = n_hc * h
+        # A (1 x n_hc), B (n_hc x n_hc) and C (n_hc x 1), all generated from the
+        # same normalised state, so one (wide -> 2*n_hc + n_hc**2) projection.
+        gen_out = 2 * n_hc + n_hc * n_hc
+        # One fused kernel per instance, not one per stage. vLLM's
+        # ``mhc_pre_big_fuse_tilelang`` folds the RMSNorm, the Sinkhorn-Knopp
+        # projection and the residual mixing together, so the 20 iterations run
+        # *inside* a single launch and cost arithmetic rather than launch depth.
+        #
+        # Worth stating because the unfused reading is not a small error: two
+        # dependent launches per iteration, twice per layer, would be ~3.5k
+        # serialised launches per step and would dominate a short-context step
+        # entirely. The iteration count is real; the launch depth is not.
+        iters = max(1, spec.hc_sinkhorn_iters)
+        for _ in range(max(1, spec.hc_blocks_per_layer)):
+            f_gen, b_gen = _linear(positions, wide, gen_out, aw, ww)
+            norm_bytes = 2.0 * positions * wide * aw
+            mix_flops = 2.0 * positions * n_hc * n_hc * h
+            mix_bytes = 2.0 * positions * wide * aw
+            # Sinkhorn arithmetic: alternating row/column normalisation of a
+            # per-token n_hc x n_hc matrix, `iters` times, register-resident.
+            sinkhorn_flops = 4.0 * positions * n_hc * n_hc * iters
+            add(
+                "mhc_mix",
+                f_gen + mix_flops + sinkhorn_flops,
+                b_gen + norm_bytes + mix_bytes,
+                wd,
+                serial_launches=1,
+            )
+
     # ── mixture of experts ──────────────────────────────────────────────────
     # Routing is replicated: every rank scores every expert so it knows what to
-    # keep and what to ship.
-    f, b = _linear(positions, h, spec.n_routed_experts, aw, ww)
-    add("moe_router", f, b, wd)
+    # keep and what to ship. Hash-routed layers pick experts from the token id
+    # alone (paper §2.1), so they run no router GEMM at all.
+    if layer >= spec.num_hash_layers:
+        f, b = _linear(positions, h, spec.n_routed_experts, aw, ww)
+        add("moe_router", f, b, wd)
 
     inter = spec.moe_intermediate_size
     # gate + up + down == three h x inter matrices per expert.
@@ -441,6 +557,22 @@ def predict_moe_graph(
     batch = batch or BatchConfig()
     sh = sharding or ShardingConfig()
 
+    # Refuse a sharding the model cannot actually take. Head counts are floor-
+    # divided throughout, so ``tp > n_heads`` silently yields zero heads per rank
+    # and prices the entire attention path at zero FLOPs — a cheap, confident,
+    # completely wrong graph. vLLM rejects this at construction; so does this.
+    if spec.n_heads % max(1, sh.tp) != 0:
+        raise ValueError(
+            f"tensor-parallel size {sh.tp} does not divide {spec.n_heads} attention "
+            "heads — every head-sharded op would floor to zero work"
+        )
+    if spec.qk_rope_head_dim > spec.head_dim:
+        raise ValueError(
+            f"qk_rope_head_dim ({spec.qk_rope_head_dim}) exceeds head_dim "
+            f"({spec.head_dim}) — the RoPE slice cannot be larger than the head "
+            "it is a slice of, and the KV-entry byte split goes negative"
+        )
+
     g = Graph(model=spec, hw=hw, batch=batch, sharding=sh)
     positions = batch.positions_per_step
     sequences = batch.batch
@@ -522,6 +654,10 @@ def spec_from_hf_config(cfg: dict[str, Any], *, name: str | None = None) -> Spar
         sliding_window=int(cfg.get("sliding_window", 0) or 0),
         compress_ratios=ratios,
         num_nextn_predict_layers=int(cfg.get("num_nextn_predict_layers", 0)),
+        # mHC: ``hc_mult`` is n_hc, the residual-stream widening factor.
+        hc_width=int(cfg.get("hc_mult", 1) or 1),
+        hc_sinkhorn_iters=int(cfg.get("hc_sinkhorn_iters", 0) or 0),
+        num_hash_layers=int(cfg.get("num_hash_layers", 0) or 0),
         dspark_layer_ids=tuple(int(i) for i in (cfg.get("dspark_target_layer_ids") or ())),
         dspark_markov_rank=int(cfg.get("dspark_markov_rank", 0)),
         weight_dtype=weight_dtype,

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -73,6 +73,12 @@ class HardwareSpec:
     # ``0.0`` means unknown, which makes a sharded graph refuse to guess rather
     # than predict a free all-to-all.
     interconnect_bw_bytes_per_s: float = 0.0
+    # Wall time to issue one dependent kernel, for work whose cost is the *number
+    # of launches* rather than the arithmetic in them. ~2 us is a CUDA-graph
+    # replay figure; eager launch is nearer 5 us. Calibrate from a trace — an
+    # iteration count multiplied by a wrong constant is still the right shape,
+    # which is more than a pure roofline offers here.
+    kernel_launch_overhead_s: float = 2.0e-6
     eff_lo: float = 0.55
     eff_hi: float = 0.95
 
@@ -374,6 +380,20 @@ class SparseMoEModelSpec:
     # Multi-token prediction (speculative decoding head)
     num_nextn_predict_layers: int = 1
 
+    # Manifold-Constrained Hyper-Connections (paper §2.2). ``hc_width`` is n_hc,
+    # the factor the residual stream is widened by — 1 disables every mHC term.
+    # Two instances per transformer block (one around attention, one around the
+    # MoE), each projecting a flattened n_hc*d residual state down to the three
+    # small mappings A (1 x n_hc), B (n_hc x n_hc) and C (n_hc x 1), then
+    # projecting B onto the doubly-stochastic manifold by Sinkhorn-Knopp.
+    hc_width: int = 1
+    hc_sinkhorn_iters: int = 0
+    hc_blocks_per_layer: int = 2
+
+    # Leading layers that route to experts by a hash of the token id rather than
+    # a learned router (paper §2.1) — those layers run no router GEMM.
+    num_hash_layers: int = 0
+
     # Low-rank state update on a subset of layers (DeepSeek "DSpark").
     dspark_layer_ids: tuple[int, ...] = ()
     dspark_markov_rank: int = 256
@@ -391,6 +411,42 @@ class SparseMoEModelSpec:
         if layer < len(self.compress_ratios):
             return self.compress_ratios[layer]
         return self.compress_ratios[-1]
+
+    @property
+    def compression_levels(self) -> tuple[int, ...]:
+        """The distinct compression rates this checkpoint interleaves, ascending.
+
+        DeepSeek-V4 uses two: ``m`` for Compressed Sparse Attention and
+        ``m' >> m`` for Heavily Compressed Attention. Derived from the config
+        rather than hardcoded, so a checkpoint with different rates — or only
+        one — still classifies.
+        """
+        return tuple(sorted({r for r in self.compress_ratios if r > 1}))
+
+    def attention_kind(self, layer: int) -> str:
+        """``"swa"`` | ``"csa"`` | ``"hca"`` — which attention this layer runs.
+
+        The three differ in ways that change the cost model qualitatively, not
+        just numerically (paper §2.3):
+
+        * **swa** — uncompressed and windowed. Only the sliding-window branch.
+        * **csa** — compress by ``m``, then *sparse* attention: a lightning
+          indexer scores the compressed entries and keeps ``index_topk``. Read is
+          bounded, so it is flat in context once selection saturates.
+        * **hca** — compress by ``m' >> m`` and attend **densely** over every
+          compressed entry. No indexer. Read is ``kv_len / m'``, so unlike CSA it
+          *grows with context* — HCA trades a bigger compression rate for not
+          having to select.
+
+        The largest compression level is HCA; anything else compressed is CSA.
+        """
+        r = self.compress_ratio(layer)
+        if r == 0:
+            return "swa"
+        levels = self.compression_levels
+        if len(levels) >= 2 and r == levels[-1]:
+            return "hca"
+        return "csa"
 
     @property
     def q_head_dim(self) -> int:
@@ -488,7 +544,7 @@ class RooflinePrediction:
     t_compute_s: float
     t_memory_s: float
     t_pred_s: float
-    bound: str  # "compute" | "memory"
+    bound: str  # "compute" | "memory" | "launch"
     # Which dtype the op runs in, and which peak was actually available to price
     # it. They differ only on a catalogue miss; see ``peak_is_fallback``.
     dtype: str = "fp16"
@@ -498,6 +554,9 @@ class RooflinePrediction:
     # derivation from published shapes — carried through to the report so an
     # estimate is never read as a measurement.
     estimated: bool = False
+    #: Dependent kernel launches this op costs. Non-zero only for iterative work
+    #: that cannot be overlapped with itself; see ``bound == "launch"``.
+    serial_launches: int = 0
 
     @property
     def peak_is_fallback(self) -> bool:
@@ -555,22 +614,37 @@ def roofline(
     dtype: str = "fp16",
     *,
     estimated: bool = False,
+    serial_launches: int = 0,
 ) -> RooflinePrediction:
-    """Compute the roofline prediction for a single op."""
+    """Compute the roofline prediction for a single op.
+
+    ``serial_launches`` adds a third bound for work whose cost is the number of
+    *dependent* kernel launches rather than the arithmetic inside them. A
+    roofline cannot see this: 20 Sinkhorn iterations over a 4x4 matrix move a few
+    hundred bytes and do a few hundred FLOPs, so both classic terms round to
+    zero, while the wall time is 20 launches deep and cannot be overlapped
+    because each iteration consumes the previous one's output. Ignoring it does
+    not make the prediction slightly optimistic — it makes it absent.
+    """
     peak_flops, peak_dtype = resolve_peak(hw, dtype)
     t_c = flops / peak_flops if peak_flops > 0 else 0.0
     t_m = bytes_moved / hw.peak_mem_bw_bytes_per_s if hw.peak_mem_bw_bytes_per_s > 0 else 0.0
-    bound = "compute" if t_c >= t_m else "memory"
+    t_l = max(0, serial_launches) * hw.kernel_launch_overhead_s
+    t_pred = max(t_c, t_m, t_l)
+    bound = "launch" if t_l >= max(t_c, t_m) and t_l > 0 else (
+        "compute" if t_c >= t_m else "memory"
+    )
     return RooflinePrediction(
         op=op,
         flops=flops,
         bytes=bytes_moved,
         t_compute_s=t_c,
         t_memory_s=t_m,
-        t_pred_s=max(t_c, t_m),
+        t_pred_s=t_pred,
         bound=bound,
         dtype=dtype,
         peak_dtype=peak_dtype,
         peak_flops_per_s=peak_flops,
         estimated=estimated,
+        serial_launches=max(0, serial_launches),
     )

--- a/tests/test_moe_graph.py
+++ b/tests/test_moe_graph.py
@@ -23,6 +23,7 @@ from gitm.planner.moe_graph import (
     effective_kv_tokens,
     index_candidates,
     kv_bytes_per_token,
+    kv_entry_bytes,
     kv_fixed_bytes_per_sequence,
     model_weight_bytes,
     predict_moe_graph,
@@ -60,6 +61,10 @@ V4_CONFIG = {
     # Ships 46 long for 43 layers — the tail is MTP/padding, not layers.
     "compress_ratios": [0, 0] + [4, 128] * 20 + [4, 0, 0, 0],
     "num_nextn_predict_layers": 1,
+    # Manifold-Constrained Hyper-Connections + hash-routed leading layers.
+    "hc_mult": 4,
+    "hc_sinkhorn_iters": 20,
+    "num_hash_layers": 3,
     "dspark_target_layer_ids": [40, 41, 42],
     "dspark_markov_rank": 256,
     "expert_dtype": "fp4",
@@ -141,17 +146,26 @@ def test_ratio_zero_layers_are_sliding_window_not_global(spec):
     assert effective_kv_tokens(spec, 1, 1_048_576) == spec.sliding_window
 
 
-def test_no_layer_read_grows_with_context(spec):
-    """The property that makes a million-token deployment possible at all.
+def test_csa_is_flat_in_context_but_hca_is_not(spec):
+    """The two compressed mechanisms scale differently, and that is the point.
 
-    Sliding-window layers are bounded from the start; compressed layers stop
-    growing once selection saturates. So the whole attention path is flat in
-    context length, and any observed growth is a real deviation rather than
-    something the architecture explains away.
+    CSA selects ``index_topk`` entries, so once selection saturates its core read
+    is constant however long the context grows. HCA attends densely over its
+    compressed entries, so its read scales as ``kv_len / m'`` without bound. They
+    happen to coincide at 64K, which is exactly why a model that assumed one
+    mechanism looked correct there and was 13x wrong at 1M.
     """
+    assert effective_kv_tokens(spec, 2, 65536) == effective_kv_tokens(spec, 2, 1_048_576)
+
+    hca_64k = effective_kv_tokens(spec, 3, 65536)
+    hca_1m = effective_kv_tokens(spec, 3, 1_048_576)
+    assert hca_1m > 10 * hca_64k
+
+    # So the stack as a whole is not flat, and any claim that it is comes from
+    # having modelled only one of the two.
     at_64k = sum(effective_kv_tokens(spec, i, 65536) for i in range(spec.n_layers))
     at_1m = sum(effective_kv_tokens(spec, i, 1_048_576) for i in range(spec.n_layers))
-    assert at_64k == at_1m
+    assert at_1m > 5 * at_64k
 
 
 def test_sliding_window_layers_run_no_indexer(spec, b200):
@@ -185,14 +199,25 @@ def test_attention_core_read_is_constant_in_context_once_selection_saturates(spe
     assert at_64k == at_1m
 
 
-def test_compress_ratio_moves_indexer_cost_not_attention_cost(spec):
-    """Ratios 4 and 128 read identically at the core but differ 32x at the scan.
+def test_csa_and_hca_differ_in_kind_not_degree(spec):
+    """They are two mechanisms, not one mechanism at two settings.
 
-    This is why they are separate nodes. Folding them together would average away
-    the only signal that distinguishes the two layer types.
+    CSA compresses lightly and *selects*; HCA compresses heavily and attends
+    densely with no indexer at all. Treating the compression ratio as a single
+    dial — which the config's flat list of numbers invites — produces an indexer
+    on every compressed layer, half of which never run one.
     """
-    assert effective_kv_tokens(spec, 2, 65536) == effective_kv_tokens(spec, 3, 65536)
-    assert index_candidates(spec, 2, 65536) == 32 * index_candidates(spec, 3, 65536)
+    assert spec.attention_kind(0) == "swa"
+    assert spec.attention_kind(2) == "csa"
+    assert spec.attention_kind(3) == "hca"
+
+    assert index_candidates(spec, 2, 65536) > 0
+    assert index_candidates(spec, 3, 65536) == 0  # HCA runs no indexer
+
+    # And at long context the dense HCA read dwarfs the selected CSA one.
+    assert effective_kv_tokens(spec, 3, 1_048_576) > 10 * effective_kv_tokens(
+        spec, 2, 1_048_576
+    )
 
 
 def test_indexer_candidates_grow_with_context(spec):
@@ -618,13 +643,13 @@ def test_kv_footprint_splits_growing_from_fixed(spec):
     assert per_token < naive_all_layers / 5
 
     # The two window layers are real, bounded, and paid once per sequence.
-    assert fixed == 2 * spec.sliding_window * spec.kv_latent_dim * weight_bytes(spec.kv_dtype)
+    assert fixed == 2 * spec.sliding_window * kv_entry_bytes(spec)
     # In magnitude the fixed term is tiny — worth ~40 tokens of context, so it
     # never drives a sizing decision. What mattered was excluding these layers
     # from the *rate*, which is a 37% error on every sequence at every length.
     assert fixed < 50 * per_token
-    naive = per_token + 2 * (spec.kv_latent_dim + spec.index_head_dim) * weight_bytes(
-        spec.kv_dtype
+    naive = per_token + 2 * (
+        kv_entry_bytes(spec) + spec.index_head_dim * weight_bytes(spec.kv_dtype)
     )
     assert naive == pytest.approx(1.37 * per_token, rel=0.02)
 

--- a/tests/test_moe_graph_degenerate.py
+++ b/tests/test_moe_graph_degenerate.py
@@ -1,0 +1,163 @@
+"""Degenerate inputs must fail loudly or stay sane — never collapse quietly.
+
+The graph branches on layer kind, compression level, sharding degree and a dozen
+config fields. Every branch is an opportunity to produce a *plausible* total with
+a whole mechanism costed at zero, which is worse than a crash: a crash gets
+fixed, a cheap confident number gets believed and then billed against.
+
+Three real collapses this file pins, all found by sweeping rather than reasoning:
+
+* ``tp > n_heads`` floor-divided heads to zero and priced the entire attention
+  path at 0 FLOPs;
+* a config without ``sliding_window`` made every uncompressed layer read
+  ``min(kv_len, 0)`` tokens, so attention was free;
+* ``qk_rope_head_dim > head_dim`` drove the KV-entry byte split negative.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import pytest
+
+from gitm.planner.moe_graph import (
+    effective_kv_tokens,
+    index_candidates,
+    kv_bytes_per_token,
+    kv_entry_bytes,
+    model_weight_bytes,
+    predict_moe_graph,
+    spec_from_hf_config,
+)
+from gitm.planner.roofline import BatchConfig, HardwareSpec, ShardingConfig
+from tests.test_moe_graph import V4_BASE_CONFIG
+
+
+@pytest.fixture
+def spec():
+    return spec_from_hf_config(V4_BASE_CONFIG)
+
+
+@pytest.fixture
+def hw():
+    return HardwareSpec()
+
+
+# ── refused rather than mispriced ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tp", [7, 128, 96])
+def test_sharding_the_model_cannot_take_is_refused(spec, hw, tp):
+    """Head counts floor-divide, so an indivisible TP silently zeroes attention."""
+    with pytest.raises(ValueError, match="does not divide"):
+        predict_moe_graph(spec, hw, BatchConfig(batch=8), ShardingConfig(tp=tp))
+
+
+def test_rope_slice_larger_than_the_head_is_refused(spec, hw):
+    """It would make ``kv_entry_bytes`` negative on the FP8 portion."""
+    bad = replace(spec, qk_rope_head_dim=spec.head_dim + 1)
+    with pytest.raises(ValueError, match="exceeds head_dim"):
+        predict_moe_graph(bad, hw, BatchConfig(batch=8))
+
+
+@pytest.mark.parametrize("tp", [1, 2, 4, 8, 16, 32, 64])
+def test_every_divisor_of_the_head_count_is_accepted(spec, hw, tp):
+    g = predict_moe_graph(spec, hw, BatchConfig(batch=8), ShardingConfig(tp=tp))
+    attn = sum(n.prediction.flops for n in g.nodes if n.op == "attn_score_value")
+    assert attn > 0
+
+
+# ── uncompressed without a window is global, not free ───────────────────────
+
+
+def test_no_sliding_window_means_global_not_zero(spec, hw):
+    """``min(kv_len, 0)`` is the trap. An uncompressed layer with no window
+    attends to everything; it does not attend to nothing."""
+    no_win = replace(spec, sliding_window=0)
+    assert effective_kv_tokens(no_win, 0, 4096) == 4096
+
+    g = predict_moe_graph(no_win, hw, BatchConfig(batch=8, kv_cache_len=4096))
+    attn = sum(n.prediction.flops for n in g.nodes if n.op == "attn_score_value")
+    assert attn > 0
+
+
+def test_a_config_stripped_to_nothing_still_prices_attention(hw):
+    """``spec_from_hf_config({})`` takes every default, including no
+    compression and no window — the exact shape that used to cost zero."""
+    g = predict_moe_graph(spec_from_hf_config({}), hw, BatchConfig(batch=8, kv_cache_len=4096))
+    attn = sum(n.prediction.flops for n in g.nodes if n.op == "attn_score_value")
+    assert attn > 0
+
+
+# ── degenerate but legal shapes stay finite and non-negative ────────────────
+
+
+def _all_finite(g) -> bool:
+    return all(
+        math.isfinite(n.prediction.t_pred_s)
+        and n.prediction.t_pred_s >= 0
+        and n.prediction.bytes >= 0
+        and n.prediction.flops >= 0
+        for n in g.nodes
+    )
+
+
+@pytest.mark.parametrize(
+    "label,mutation",
+    [
+        ("no compression at all", {"compress_ratios": ()}),
+        ("one compression level", {"compress_ratios": tuple([4] * 43)}),
+        ("all sliding-window", {"compress_ratios": tuple([0] * 43)}),
+        ("mHC disabled", {"hc_width": 1}),
+        ("every layer hash-routed", {"num_hash_layers": 99}),
+        ("no top-k selection", {"index_topk": 0}),
+        ("single layer", {"n_layers": 1}),
+        ("no experts", {"n_routed_experts": 0, "num_experts_per_tok": 0}),
+        ("no shared expert", {"n_shared_experts": 0}),
+        ("no MTP head", {"num_nextn_predict_layers": 0}),
+        ("no o-grouping", {"o_groups": 1}),
+    ],
+)
+def test_degenerate_shapes_stay_finite(spec, hw, label, mutation):
+    g = predict_moe_graph(replace(spec, **mutation), hw, BatchConfig(batch=8, kv_cache_len=4096))
+    assert _all_finite(g), label
+    assert g.total_pred_s > 0, label
+
+
+@pytest.mark.parametrize("batch,ctx", [(1, 0), (1, 1), (0, 4096), (1, 1 << 24), (4096, 1)])
+def test_extreme_batch_and_context_stay_finite(spec, hw, batch, ctx):
+    g = predict_moe_graph(spec, hw, BatchConfig(batch=batch, kv_cache_len=ctx))
+    assert _all_finite(g)
+    assert math.isfinite(g.total_pred_s)
+
+
+def test_expert_parallelism_beyond_the_expert_count_stays_finite(spec, hw):
+    g = predict_moe_graph(
+        spec, hw, BatchConfig(batch=8, kv_cache_len=4096), ShardingConfig(tp=8, ep=512)
+    )
+    assert _all_finite(g)
+
+
+# ── the scalar helpers ──────────────────────────────────────────────────────
+
+
+def test_kv_helpers_are_non_negative_on_every_layer_kind(spec):
+    assert kv_entry_bytes(spec) > 0
+    assert kv_bytes_per_token(spec) > 0
+    assert model_weight_bytes(spec) > 0
+    for layer in range(spec.n_layers):
+        assert effective_kv_tokens(spec, layer, 65536) > 0
+        assert index_candidates(spec, layer, 65536) >= 0
+
+
+def test_zero_context_reads_nothing(spec):
+    """The one case where zero is the right answer."""
+    assert effective_kv_tokens(spec, 0, 0) == 0
+    assert index_candidates(spec, 2, 0) == 0
+
+
+def test_layers_past_the_ratio_list_reuse_the_last_entry(spec):
+    """The MTP head sits at ``layer == n_layers`` and must classify as something."""
+    assert spec.attention_kind(spec.n_layers) in {"swa", "csa", "hca"}
+    assert effective_kv_tokens(spec, spec.n_layers, 4096) > 0

--- a/tests/test_residuals_layer_classes.py
+++ b/tests/test_residuals_layer_classes.py
@@ -161,6 +161,16 @@ V4_CONFIG = {
 
 
 @pytest.fixture
+def spec_v4():
+    return spec_from_hf_config(V4_CONFIG, name="DeepSeek-V4-Flash")
+
+
+@pytest.fixture
+def b200_hw():
+    return HardwareSpec()
+
+
+@pytest.fixture
 def v4_graph():
     spec = spec_from_hf_config(V4_CONFIG, name="DeepSeek-V4-Flash")
     return predict_moe_graph(
@@ -195,21 +205,43 @@ def test_healthy_sliding_window_layer_is_not_flagged(v4_graph):
     assert abs(res.per_kernel[0].r_kt) < NS_QUANTISATION
 
 
-def test_indexer_span_covers_both_compression_ratios(v4_graph):
-    """`attn_index_score` splits 32x between ratio-4 and ratio-128 layers.
+def test_indexer_is_uniform_because_only_csa_runs_one(v4_graph):
+    """Getting CSA/HCA right made this op *simpler*, not harder.
 
-    Sliding-window layers emit no indexer at all, so this span is entirely
-    within what the config calls the compressed layers — a different partition
-    from the one `attn_score_value` needs, which is why the fix is per-op rather
-    than one global layer taxonomy.
+    While the graph put an indexer on every compressed layer, `attn_index_score`
+    spanned 32x between the two compression rates. Only CSA layers actually run
+    an indexer, and they all share one rate — so the op is uniform and needs no
+    class split at all. The heterogeneity moved to `attn_score_value`.
     """
     idx = [n for n in v4_graph.nodes if n.op == "attn_index_score"]
-    assert {n.layer for n in idx}.isdisjoint({0, 1})
-    ts = sorted(n.prediction.t_pred_s for n in idx)
-    assert ts[-1] / ts[0] == pytest.approx(32.0, rel=0.01)
+    assert idx
+    assert {n.layer for n in idx}.isdisjoint({0, 1, 3, 5})  # not swa, not hca
+    assert len({round(n.prediction.t_pred_s, 15) for n in idx}) == 1
 
-    res = residuals(_trace([_k("lightning_indexer_topk", ts[0]), _k("lightning_indexer_topk", ts[-1])]), v4_graph)
-    assert all(abs(kr.r_kt) < NS_QUANTISATION for kr in res.per_kernel)
+    res = residuals(_trace([_k("lightning_indexer_topk", idx[0].prediction.t_pred_s)]), v4_graph)
+    kr = res.per_kernel[0]
+    assert kr.n_classes == 1
+    assert abs(kr.r_kt) < NS_QUANTISATION
+
+
+def test_attention_core_has_three_classes_at_long_context(spec_v4, b200_hw):
+    """swa / csa / hca read 128 / 640 / 8320 tokens at 1M — three distinct costs.
+
+    They collapse to two at 64K, where csa and hca coincide. A class split
+    derived from the predictions tracks that; a hardcoded taxonomy would not.
+    """
+    g = predict_moe_graph(
+        spec_v4, b200_hw, BatchConfig(batch=64, kv_cache_len=1_048_576)
+    )
+    classes = {round(n.prediction.t_pred_s, 15)
+               for n in g.nodes if n.op == "attn_score_value"}
+    assert len(classes) == 3
+
+    at_64k = predict_moe_graph(
+        spec_v4, b200_hw, BatchConfig(batch=64, kv_cache_len=65536)
+    )
+    assert len({round(n.prediction.t_pred_s, 15)
+                for n in at_64k.nodes if n.op == "attn_score_value"}) == 2
 
 
 def test_a_genuinely_slow_kernel_still_surfaces(v4_graph):


### PR DESCRIPTION
## CSA and HCA are two mechanisms, not one dial
CSA compresses the KV cache by `m` and then applies *sparse* attention a lightning indexer scores the compressed entries and keeps `index_topk`. HCA compresses by `m' >> m` and attends **densely**, with no indexer at all.

The graph had been putting an indexer on all 41 compressed layers and capping every read at `sliding_window + index_topk`. Half those layers run no indexer, and HCA's read is `kv_len / m'`, which *grows with context without bound*. Total attention read at 1M context goes from a claimed-flat 26,496 tokens to 180,096.

This retires "no layer's read grows with context", which was only ever true because one mechanism had been modelled twice. `attention_kind()` derives swa/csa/hca from the distinct compression levels rather than hardcoding rates.

## mHC was missing entirely, and the `hc_*` keys were misread
`hc_mult` is n_hc — the factor the residual stream is widened by not a hierarchy rate. Two hyper-connection instances per block (`attn_hc` and `ffn_hc` on `DeepseekV4HyperConnection`), each normalising a
flattened n_hc*d state, generating the A/B/C mappings from it, and projecting B onto the doubly-stochastic manifold by Sinkhorn-Knopp.

Modelled unfused, that is ~3.5k dependent launches per step and 59% of a short-context step. vLLM fuses it  `mhc_pre_big_fuse_tilelang` combines RMSNorm, Sinkhorn and residual mixing in one kernel so the 20 iterations cost arithmetic inside a single launch, and the real figure is 18%. Both readings are recorded at the node, because the difference between them is exactly what a roofline cannot see on its own.


