### PR TITLE
feat(deploy): implement the telemetry-shim attach (adopt collector, bounded window)

### DIFF
--- a/gitm/cli.py
+++ b/gitm/cli.py
@@ -140,6 +140,14 @@ def _parser() -> argparse.ArgumentParser:
         "--pid", type=int, default=None, help="Explicit target PID (else resolved locally)."
     )
     attach.add_argument(
+        "--duration", type=float, default=30.0,
+        help="Seconds to hold the telemetry window open (non-dry-run).",
+    )
+    attach.add_argument(
+        "--out", default=None,
+        help="Output dir for the merged trace (default $GITM_SCRATCH/traces/attach-<ts>).",
+    )
+    attach.add_argument(
         "--dry-run",
         action="store_true",
         help="Plan the attach without touching the live process.",
@@ -337,7 +345,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.cmd == "attach":
         from gitm.deploy import attach_job
 
-        plan = attach_job(args.job, workload=args.workload, dry_run=args.dry_run, pid=args.pid)
+        plan = attach_job(
+            args.job,
+            workload=args.workload,
+            dry_run=args.dry_run,
+            pid=args.pid,
+            duration_s=args.duration,
+            out=args.out,
+        )
         print(json.dumps(plan, indent=2))
         # no_target is an operator-actionable miss, not a crash — signal it.
         return 0 if plan.get("status") in {"attached", "planned"} else 4

--- a/gitm/deploy/attach.py
+++ b/gitm/deploy/attach.py
@@ -1,28 +1,10 @@
-"""Minimal standalone attach: point gitm at an already-running job.
+"""Standalone attach: open a bounded telemetry window on an already-running job.
 
-This is the no-orchestrator path. `gitm attach --job <id>`
-It does not start, restart, or own the workload - it attaches the telemetry
-shim to a process that is already running, in the user space:
-
-- no root -attach is via the job's own environment/ user-readable `/proc`,
-never a kernel module or driver swap;
-- fail-open - an attach only arms a removable file marker on a collector the
-job already loaded, so our exit leaves the job untouched;
-- no phone-home - resolution is local (explicit PID or ``GITM_ATTACH_PID``),
-never an external lookup.
-
-The one thing this path cannot do is *inject* a collector into a live process:
-the CUDA driver reads ``CUDA_INJECTION64_PATH`` once, at CUDA init, and never
-again (see :mod:`gitm.serve.discover`). So "attach the telemetry shim" means
-*adopting* the collector the job was already launched under and opening a
-**bounded** window inside its lifetime - arm, watch for ``--duration``, disarm,
-merge the per-process kernel shards. A job that was not started under the
-collector is reported ``unsupported`` with the exact restart that would fix it,
-never a false ``attached``.
-
-``attach_job`` returns a plan dict. ``--dry-run`` stops after planning, before
-anything touches the live process; without it the window is actually opened and
-the merged trace is written under ``out``.
+`gitm attach --job <id>` does not own the workload. Since the CUDA driver reads
+CUDA_INJECTION64_PATH only at CUDA init, a collector cannot be injected into a
+live process; attach instead *adopts* a collector the job was already launched
+under, arms a bounded window, and merges the per-process shards. User-space
+(no root), fail-open, no phone-home. `--dry-run` stops after planning.
 """
 
 from __future__ import annotations
@@ -39,7 +21,7 @@ PROC = Path("/proc")
 class AttachPlan:
     job_id: str
     workload: str | None
-    mode: str  # always "user-space"
+    mode: str
     status: str  # "planned" | "attached" | "busy" | "unsupported" | "no_target"
     pid: int | None
     steps: list[str] = field(default_factory=list)
@@ -52,7 +34,6 @@ class AttachPlan:
 
 
 def _resolve_pid(job_id: str, pid: int | None) -> int | None:
-    """Resolve the job's PID locally: explicit arg > env > none. No remote calls."""
     if pid is not None:
         return pid
     env_pid = os.environ.get("GITM_ATTACH_PID") or os.environ.get(f"GITM_JOB_{job_id}_PID")
@@ -62,7 +43,6 @@ def _resolve_pid(job_id: str, pid: int | None) -> int | None:
 
 
 def _pid_is_live(pid: int, proc: Path = PROC) -> bool:
-    """User-space liveness check via /proc (no signals, no root)."""
     return (proc / str(pid)).exists()
 
 
@@ -85,12 +65,7 @@ def attach_job(
     out: str | Path | None = None,
     proc: Path = PROC,
 ) -> dict:
-    """Build (and, unless ``dry_run``, commit) a user-space attach.
-
-    When ``dry_run`` is false and the target is running under the gitm collector,
-    a bounded ``duration_s`` window is opened on it and the merged trace is written
-    under ``out`` (default ``$GITM_SCRATCH/traces/attach-<ts>/trace.jsonl``).
-    """
+    """Plan (dry-run) or open a bounded ``duration_s`` window on the job's collector."""
     resolved = _resolve_pid(job_id, pid)
 
     def plan(status: str, reason: str, **extra) -> dict:
@@ -117,28 +92,17 @@ def attach_job(
     if not _pid_is_live(resolved, proc):
         return plan("no_target", f"PID {resolved} is not live.")
 
-    # Reuse the injectability verdict the serve path already states plainly, rather
-    # than re-parsing /proc/environ here: classify reads the target's environment,
-    # confirms it is ours to read, and confirms it is being collected by *our*
-    # library (not nsys, not nothing). Everything below trusts target.traceable.
     from gitm.serve.discover import classify
 
     target = classify(resolved, proc)
     if not target.traceable:
-        # Not an error - the job simply cannot be attached in user space. Carry the
-        # exact restart that would make it traceable instead of a bare refusal.
         return plan("unsupported", f"{target.reason}\n\n{target.remedy()}")
 
     return _open_window(target, job_id, workload, duration_s, out, plan)
 
 
 def _open_window(target, job_id, workload, duration_s, out, plan) -> dict:
-    """Arm a bounded window on the adopted collector, merge shards, disarm.
-
-    Borrow-not-adopt the injection environment: point this process at the target's
-    collector only for the duration of the window, and restore the prior values on
-    every exit path so a failed attach never leaves us aimed at another run's shards.
-    """
+    """Borrow the target's injection env for one window; restore it on every exit."""
     from gitm._paths import traces_dir
     from gitm.tracer import injection
     from gitm.tracer.capture import capture
@@ -161,8 +125,7 @@ def _open_window(target, job_id, workload, duration_s, out, plan) -> dict:
         os.environ[injection.ENV_LIB] = str(target.inject_lib)
         os.environ[injection.ENV_OUT] = str(target.trace_out)
 
-        # Two armed windows on one collector is not a partial failure: both traces
-        # end up holding both windows' kernels. Refuse rather than corrupt silently.
+        # Two windows on one collector corrupt both traces; refuse rather than arm.
         if injection.arm_path().exists():
             return plan(
                 "busy",
@@ -173,9 +136,6 @@ def _open_window(target, job_id, workload, duration_s, out, plan) -> dict:
             )
 
         out_dir.mkdir(parents=True, exist_ok=True)
-        # capture() sees the borrowed env, takes the injected/merge path, and owns the
-        # whole window in a finally: clear stale shards, bound the CUPTI clock, arm,
-        # settle, disarm, merge. We only hold it open for the observation window.
         with capture(
             trace_path, workload_id="gitm-attach", fingerprint=workload or job_id
         ) as trace:

--- a/gitm/deploy/attach.py
+++ b/gitm/deploy/attach.py
@@ -6,20 +6,33 @@ shim to a process that is already running, in the user space:
 
 - no root -attach is via the job's own environment/ user-readable `/proc`,
 never a kernel module or driver swap;
-- fail-open - producing a plan has no side effects a real attach installs
-only removable hooks, so our exit leaves the job untouched;
+- fail-open - an attach only arms a removable file marker on a collector the
+job already loaded, so our exit leaves the job untouched;
 - no phone-home - resolution is local (explicit PID or ``GITM_ATTACH_PID``),
 never an external lookup.
 
-`attach_job` returns a plan dict; `--dry-run` stops after planning so an
-operator can review before anything touches the live process.
+The one thing this path cannot do is *inject* a collector into a live process:
+the CUDA driver reads ``CUDA_INJECTION64_PATH`` once, at CUDA init, and never
+again (see :mod:`gitm.serve.discover`). So "attach the telemetry shim" means
+*adopting* the collector the job was already launched under and opening a
+**bounded** window inside its lifetime - arm, watch for ``--duration``, disarm,
+merge the per-process kernel shards. A job that was not started under the
+collector is reported ``unsupported`` with the exact restart that would fix it,
+never a false ``attached``.
+
+``attach_job`` returns a plan dict. ``--dry-run`` stops after planning, before
+anything touches the live process; without it the window is actually opened and
+the merged trace is written under ``out``.
 """
 
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+
+PROC = Path("/proc")
 
 
 @dataclass
@@ -27,10 +40,12 @@ class AttachPlan:
     job_id: str
     workload: str | None
     mode: str  # always "user-space"
-    status: str  # "planned" | "unsupported" | "no_target"
+    status: str  # "planned" | "attached" | "busy" | "unsupported" | "no_target"
     pid: int | None
     steps: list[str] = field(default_factory=list)
     reason: str = ""
+    out: str | None = None
+    n_events: int | None = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -46,9 +61,18 @@ def _resolve_pid(job_id: str, pid: int | None) -> int | None:
     return None
 
 
-def _pid_is_live(pid: int) -> bool:
+def _pid_is_live(pid: int, proc: Path = PROC) -> bool:
     """User-space liveness check via /proc (no signals, no root)."""
-    return Path(f"/proc/{pid}").exists()
+    return (proc / str(pid)).exists()
+
+
+_STEPS = [
+    "resolve job -> PID (explicit/env, local only)",
+    "verify PID is ours and running under the gitm collector (/proc/environ, no root)",
+    "arm a bounded telemetry window on the job's collector (removable file marker)",
+    "merge the window's per-process kernel shards; stream in-cluster only (no egress)",
+    "disarm on exit: window closed, workload untouched (fail-open)",
+]
 
 
 def attach_job(
@@ -57,61 +81,113 @@ def attach_job(
     workload: str | None = None,
     dry_run: bool = True,
     pid: int | None = None,
+    duration_s: float = 30.0,
+    out: str | Path | None = None,
+    proc: Path = PROC,
 ) -> dict:
-    """Build (and, unless ``dry_run``, commit) a user-space attach plan."""
+    """Build (and, unless ``dry_run``, commit) a user-space attach.
+
+    When ``dry_run`` is false and the target is running under the gitm collector,
+    a bounded ``duration_s`` window is opened on it and the merged trace is written
+    under ``out`` (default ``$GITM_SCRATCH/traces/attach-<ts>/trace.jsonl``).
+    """
     resolved = _resolve_pid(job_id, pid)
-    steps = [
-        f"resolve job {job_id!r} -> PID (explicit/env, local only)",
-        "verify PID is live and owned by the current user (/proc, no root)",
-        "install removable telemetry shim into the job's user-space env",
-        "stream telemetry in-cluster only (no SaaS/egress)",
-        "on gitm exit: detach shim, leave workload untouched (fail-open)",
-    ]
+
+    def plan(status: str, reason: str, **extra) -> dict:
+        return AttachPlan(
+            job_id=job_id,
+            workload=workload,
+            mode="user-space",
+            status=status,
+            pid=resolved,
+            steps=list(_STEPS),
+            reason=reason,
+            **extra,
+        ).to_dict()
 
     if resolved is None:
-        return AttachPlan(
-            job_id=job_id,
-            workload=workload,
-            mode="user-space",
-            status="no_target",
-            pid=None,
-            steps=steps,
-            reason="could not resolve a PID locally (pass --pid or set GITM_ATTACH_PID)",
-        ).to_dict()
+        return plan(
+            "no_target",
+            "could not resolve a PID locally (pass --pid or set GITM_ATTACH_PID)",
+        )
 
     if dry_run:
-        return AttachPlan(
-            job_id=job_id,
-            workload=workload,
-            mode="user-space",
-            status="planned",
-            pid=resolved,
-            steps=steps,
-            reason="dry-run: planned, no change made.",
-        ).to_dict()
+        return plan("planned", "dry-run: planned, no change made.")
 
-    if not _pid_is_live(resolved):
-        return AttachPlan(
-            job_id=job_id,
-            workload=workload,
-            mode="user-space",
-            status="no_target",
-            pid=resolved,
-            steps=steps,
-            reason=f"PID {resolved} is not live.",
-        ).to_dict()
+    if not _pid_is_live(resolved, proc):
+        return plan("no_target", f"PID {resolved} is not live.")
 
-    # PID resolution is wired, but no injector or telemetry-shim installation is.
-    # Refuse rather than turning a validated target into a false attach success.
-    return AttachPlan(
-        job_id=job_id,
-        workload=workload,
-        mode="user-space",
-        status="unsupported",
-        pid=resolved,
-        steps=steps,
-        reason=(
-            "target is live, but standalone PID injection is not implemented; "
-            "no telemetry shim was installed"
-        ),
-    ).to_dict()
+    # Reuse the injectability verdict the serve path already states plainly, rather
+    # than re-parsing /proc/environ here: classify reads the target's environment,
+    # confirms it is ours to read, and confirms it is being collected by *our*
+    # library (not nsys, not nothing). Everything below trusts target.traceable.
+    from gitm.serve.discover import classify
+
+    target = classify(resolved, proc)
+    if not target.traceable:
+        # Not an error - the job simply cannot be attached in user space. Carry the
+        # exact restart that would make it traceable instead of a bare refusal.
+        return plan("unsupported", f"{target.reason}\n\n{target.remedy()}")
+
+    return _open_window(target, job_id, workload, duration_s, out, plan)
+
+
+def _open_window(target, job_id, workload, duration_s, out, plan) -> dict:
+    """Arm a bounded window on the adopted collector, merge shards, disarm.
+
+    Borrow-not-adopt the injection environment: point this process at the target's
+    collector only for the duration of the window, and restore the prior values on
+    every exit path so a failed attach never leaves us aimed at another run's shards.
+    """
+    from gitm._paths import traces_dir
+    from gitm.tracer import injection
+    from gitm.tracer.capture import capture
+
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    out_dir = Path(out) if out else traces_dir() / f"attach-{stamp}"
+    trace_path = out_dir / "trace.jsonl"
+
+    prior_lib = os.environ.get(injection.ENV_LIB)
+    prior_out = os.environ.get(injection.ENV_OUT)
+
+    def restore() -> None:
+        for key, val in ((injection.ENV_LIB, prior_lib), (injection.ENV_OUT, prior_out)):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    try:
+        os.environ[injection.ENV_LIB] = str(target.inject_lib)
+        os.environ[injection.ENV_OUT] = str(target.trace_out)
+
+        # Two armed windows on one collector is not a partial failure: both traces
+        # end up holding both windows' kernels. Refuse rather than corrupt silently.
+        if injection.arm_path().exists():
+            return plan(
+                "busy",
+                f"another capture window is already open on this collector "
+                f"({injection.arm_path()}) - wait for it to finish, or remove the "
+                "marker if its owner died.",
+                out=str(out_dir),
+            )
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        # capture() sees the borrowed env, takes the injected/merge path, and owns the
+        # whole window in a finally: clear stale shards, bound the CUPTI clock, arm,
+        # settle, disarm, merge. We only hold it open for the observation window.
+        with capture(
+            trace_path, workload_id="gitm-attach", fingerprint=workload or job_id
+        ) as trace:
+            time.sleep(duration_s)
+        n_events = len(trace.events)
+    finally:
+        restore()
+
+    return plan(
+        "attached",
+        f"attached (user-space, fail-open); captured {n_events} kernel record(s) over "
+        f"{duration_s:.0f}s into {trace_path}.",
+        out=str(out_dir),
+        n_events=n_events,
+    )

--- a/tests/test_cli_attach.py
+++ b/tests/test_cli_attach.py
@@ -3,9 +3,22 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from gitm.cli import _parser, main
 from gitm.deploy import attach_job
+from gitm.tracer import injection
+
+
+def _fake_proc(tmp_path: Path, pid: int, env: dict[str, str]) -> Path:
+    """A minimal /proc/<pid> with an environ file classify() can read."""
+    proc = tmp_path / "proc"
+    d = proc / str(pid)
+    d.mkdir(parents=True)
+    (d / "environ").write_bytes(
+        b"".join(f"{k}={v}\x00".encode() for k, v in env.items())
+    )
+    return proc
 
 
 def test_parser_accepts_attach():
@@ -35,3 +48,68 @@ def test_main_attach_returns_zero_on_plan(capsys):
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
     assert out["job_id"] == "j" and out["status"] == "planned"
+
+
+def test_parser_accepts_duration_and_out():
+    args = _parser().parse_args(
+        ["attach", "--job", "j", "--pid", "7", "--duration", "5", "--out", "/tmp/o"]
+    )
+    assert args.duration == 5.0 and args.out == "/tmp/o"
+
+
+def test_attach_no_target_when_pid_dead(tmp_path):
+    # A committed attach against a PID with no /proc entry is a miss, not a crash.
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    plan = attach_job("job", pid=4242, dry_run=False, proc=proc)
+    assert plan["status"] == "no_target"
+
+
+def test_attach_unsupported_when_not_under_collector(tmp_path):
+    # Live, ours to read, but never launched under libgitm_inject.so: cannot be made
+    # traceable in user space, so refuse with the restart remedy — not a fake attach.
+    proc = _fake_proc(tmp_path, 100, {"PATH": "/usr/bin"})
+    plan = attach_job("job", pid=100, dry_run=False, proc=proc)
+    assert plan["status"] == "unsupported"
+    assert injection.ENV_LIB in plan["reason"]  # remedy names the var to export
+    assert plan["n_events"] is None
+
+
+def test_attach_adopts_collector_and_opens_window(tmp_path):
+    # Target is running under our collector: open a zero-length window and merge.
+    # No GPU and no shards here, so the honest result is a clean 0-kernel capture.
+    base = tmp_path / "collector" / "trace.jsonl"
+    base.parent.mkdir(parents=True)
+    proc = _fake_proc(
+        tmp_path,
+        200,
+        {injection.ENV_LIB: "/lib/libgitm_inject.so", injection.ENV_OUT: str(base)},
+    )
+    out_dir = tmp_path / "out"
+    plan = attach_job(
+        "job", pid=200, dry_run=False, duration_s=0.0, out=out_dir, proc=proc
+    )
+    assert plan["status"] == "attached"
+    assert plan["n_events"] == 0
+    assert plan["out"] == str(out_dir)
+    assert (out_dir / "trace.jsonl").exists()
+    # Fail-open: the borrowed injection env is restored, the window is disarmed.
+    import os
+
+    assert injection.ENV_LIB not in os.environ
+    assert not (base.parent / (base.name + ".arm")).exists()
+
+
+def test_attach_busy_when_window_already_open(tmp_path):
+    base = tmp_path / "collector" / "trace.jsonl"
+    base.parent.mkdir(parents=True)
+    (base.parent / (base.name + ".arm")).touch()  # another window already open
+    proc = _fake_proc(
+        tmp_path,
+        300,
+        {injection.ENV_LIB: "/lib/libgitm_inject.so", injection.ENV_OUT: str(base)},
+    )
+    plan = attach_job(
+        "job", pid=300, dry_run=False, duration_s=0.0, out=tmp_path / "o", proc=proc
+    )
+    assert plan["status"] == "busy"

--- a/tests/test_cli_attach.py
+++ b/tests/test_cli_attach.py
@@ -11,7 +11,6 @@ from gitm.tracer import injection
 
 
 def _fake_proc(tmp_path: Path, pid: int, env: dict[str, str]) -> Path:
-    """A minimal /proc/<pid> with an environ file classify() can read."""
     proc = tmp_path / "proc"
     d = proc / str(pid)
     d.mkdir(parents=True)
@@ -58,7 +57,6 @@ def test_parser_accepts_duration_and_out():
 
 
 def test_attach_no_target_when_pid_dead(tmp_path):
-    # A committed attach against a PID with no /proc entry is a miss, not a crash.
     proc = tmp_path / "proc"
     proc.mkdir()
     plan = attach_job("job", pid=4242, dry_run=False, proc=proc)
@@ -66,18 +64,14 @@ def test_attach_no_target_when_pid_dead(tmp_path):
 
 
 def test_attach_unsupported_when_not_under_collector(tmp_path):
-    # Live, ours to read, but never launched under libgitm_inject.so: cannot be made
-    # traceable in user space, so refuse with the restart remedy — not a fake attach.
     proc = _fake_proc(tmp_path, 100, {"PATH": "/usr/bin"})
     plan = attach_job("job", pid=100, dry_run=False, proc=proc)
     assert plan["status"] == "unsupported"
-    assert injection.ENV_LIB in plan["reason"]  # remedy names the var to export
+    assert injection.ENV_LIB in plan["reason"]
     assert plan["n_events"] is None
 
 
 def test_attach_adopts_collector_and_opens_window(tmp_path):
-    # Target is running under our collector: open a zero-length window and merge.
-    # No GPU and no shards here, so the honest result is a clean 0-kernel capture.
     base = tmp_path / "collector" / "trace.jsonl"
     base.parent.mkdir(parents=True)
     proc = _fake_proc(
@@ -93,7 +87,6 @@ def test_attach_adopts_collector_and_opens_window(tmp_path):
     assert plan["n_events"] == 0
     assert plan["out"] == str(out_dir)
     assert (out_dir / "trace.jsonl").exists()
-    # Fail-open: the borrowed injection env is restored, the window is disarmed.
     import os
 
     assert injection.ENV_LIB not in os.environ
@@ -103,7 +96,7 @@ def test_attach_adopts_collector_and_opens_window(tmp_path):
 def test_attach_busy_when_window_already_open(tmp_path):
     base = tmp_path / "collector" / "trace.jsonl"
     base.parent.mkdir(parents=True)
-    (base.parent / (base.name + ".arm")).touch()  # another window already open
+    (base.parent / (base.name + ".arm")).touch()
     proc = _fake_proc(
         tmp_path,
         300,


### PR DESCRIPTION
Addresses @aditchawdhary's review comment on #91 (`gitm/deploy/attach.py:108`, *"can you try to implement this telemetry shim?"*).

## What it was
`gitm attach --job` documents a user-space telemetry shim, but the non-dry-run path only returned `status="unsupported"` — it resolved a PID and then installed nothing.

## The constraint
The CUDA driver reads `CUDA_INJECTION64_PATH` **once, at CUDA init**, and never again — so a collector cannot be injected into an already-running process without root/ptrace. That would break the module's own "user-space, no root" contract. The only truthful shim is to **adopt** a collector the job was *already launched under* and open a **bounded** window inside its lifetime.

## What this does
Reuses the machinery the serve/attach path already proves out, rather than hand-rolling a parallel copy:

- **`discover.classify()`** reads `/proc/<pid>/environ`, confirms the job is ours to read and is being collected by *our* library (`libgitm_inject.so`, not nsys, not nothing), and exposes `.remedy()` — the exact restart to make a non-injectable job traceable.
- **`capture()`** takes the injected/merge path and owns the whole window in a `finally`: clear stale shards → bound the CUPTI clock → arm → settle → disarm → merge.

`attach_job` now:
- `no_target` — PID unresolvable or dead;
- `unsupported` — live but not under our collector, carrying the restart remedy (honest refusal, not a fake attach);
- `busy` — a window is already open on that collector (two concurrent windows corrupt both traces);
- `attached` — borrow the injection env, open a `--duration` window, merge the shards, and **restore the env on every exit path** (borrow-not-adopt, fail-open).

CLI gains `--duration` / `--out`.

## Tests
`tests/test_cli_attach.py` adds coverage via a fake `/proc`: dead-pid, unsupported, adopt+capture (a clean 0-kernel window on a GPU-less box), and the busy guard. Existing dry-run/no-target tests stay green. `ruff` clean.

## Notes
- Branches off / targets `pr1-primitives` so the diff is only the shim, not all of #91.
- I have **not** replied on the review thread — leaving that to the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)