### PR TITLE
add no trace path config

### DIFF
--- a/gitm/serve/vllm.py
+++ b/gitm/serve/vllm.py
@@ -37,6 +37,7 @@ cannot run it).
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import random
@@ -617,6 +618,23 @@ def add_serve_arguments(ap: argparse.ArgumentParser) -> argparse.ArgumentParser:
                     help="tensor-parallel size (default: every visible GPU)")
     ap.add_argument("--dry-run", action="store_true", help="preflight only; never starts a server")
     ap.add_argument("--skip-preflight", action="store_true")
+    ap.add_argument("--no-trace", action="store_true",
+                    help="run the identical server and workload with CUPTI collection "
+                         "off, writing no trace. This is the baseline arm of a tracing-"
+                         "overhead measurement: same client, same warmup, same seed, "
+                         "same summary format, so the only difference against a normal "
+                         "run is the collector. Comparing against a separately-driven "
+                         "vllm serve would confound the tracer's cost with a different "
+                         "request stream.")
+    ap.add_argument("--nvtx", action="store_true",
+                    help="collect the NVTX correlation chain, which resolves an "
+                         "anonymous GEMM to a layer and an op. Adds vLLM's "
+                         "--enable-layerwise-nvtx-tracing (emits the ranges) and turns "
+                         "on RUNTIME/DRIVER/MARKER collection (records them). Both "
+                         "halves are required and neither errors alone: ranges nobody "
+                         "collects and collection with no ranges each produce a clean "
+                         "trace with range_op null on every kernel. Costs throughput — "
+                         "capture the same workload with and without to quantify it.")
     ap.add_argument("--keep-server", action="store_true",
                     help="leave the server up after capture — the handoff into "
                          "`gitm capture attach` for further windows")
@@ -638,6 +656,31 @@ def main(argv: list[str] | None = None) -> int:
     return rc
 
 
+def apply_tracing_env(env, trace_path, *, nvtx: bool, no_trace: bool) -> None:
+    """Put ``env`` into the tracing arm this run is supposed to be.
+
+    Separate from :func:`launch_and_capture` because it is the whole difference
+    between the arms of an overhead measurement, and it is the part that fails
+    silently: every arm launches, serves and reports a throughput number whether or
+    not the collector is in the state it claims.
+
+    A no-trace arm *clears* the variables rather than merely not setting them. The
+    CUDA driver reads ``CUDA_INJECTION64_PATH`` out of the inherited environment, so
+    one left exported in this shell from an earlier run — which is exactly how the
+    first NVTX captures were taken — would attach the collector to the one arm whose
+    purpose is to have no collector. The baseline would land on top of the traced
+    arms, and the reading of that is "collection is free".
+    """
+    from gitm.tracer import injection
+
+    if no_trace:
+        for var in (injection.ENV_LIB, injection.ENV_OUT,
+                    injection.ENV_NVTX, injection.ENV_NVTX_INJECT):
+            env.pop(var, None)
+        return
+    env.update(injection.run_env(trace_path, nvtx=nvtx))
+
+
 def launch_and_capture(args, serve_argv: list[str] | None = None):
     """Launch ``vllm serve`` under the collector, capture a window, tear it down.
 
@@ -647,6 +690,15 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
     """
     from gitm._paths import traces_dir
     from gitm.serve.artifacts import print_result, write_capture_artifacts, write_preflight
+
+    nvtx = bool(getattr(args, "nvtx", False))
+    no_trace = bool(getattr(args, "no_trace", False))
+    # Checked before preflight, not after: these are contradictory on their face and
+    # there is no reason to spend a GPU probe discovering it.
+    if no_trace and nvtx:
+        print("--no-trace and --nvtx are contradictory: NVTX correlation records are "
+              "collected by the tracer --no-trace disables.")
+        return 2, None
 
     serve_argv = list(serve_argv) if serve_argv else list(DEFAULT_SERVE_ARGV)
 
@@ -688,11 +740,32 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
         print("\ndry run — preflight only, nothing launched.")
         return 0, None
 
-    os.environ.update(injection.run_env(trace_path))
-    print(f"==> {injection.ENV_LIB}={os.environ[injection.ENV_LIB]}")
+    apply_tracing_env(os.environ, trace_path, nvtx=nvtx, no_trace=no_trace)
+    if no_trace:
+        print("==> tracing OFF (baseline arm): no CUPTI collection, no trace written")
+    else:
+        print(f"==> {injection.ENV_LIB}={os.environ[injection.ENV_LIB]}")
+    if nvtx:
+        # Report the NVTX injection path rather than assuming it. run_env sets it
+        # only when a libcupti was resolved, and a missing one is the failure that
+        # produces a trace full of markerless kernels with no error anywhere.
+        inject = os.environ.get(injection.ENV_NVTX_INJECT)
+        print(f"==> {injection.ENV_NVTX}=1")
+        if inject:
+            print(f"==> {injection.ENV_NVTX_INJECT}={inject}")
+        else:
+            print(f"!!! {injection.ENV_NVTX_INJECT} unresolved — NVTX will hand no "
+                  "ranges to CUPTI and every kernel will come back unattributed")
 
     base = f"http://{args.host}:{args.port}"
     cmd = list(serve_argv)
+    # The other half of --nvtx. Ours makes CUPTI collect markers; this makes vLLM
+    # push them. Not added when the caller already passed it after `--`, and not
+    # added without --nvtx: pushing ranges nobody collects costs throughput for
+    # nothing, which would silently contaminate the without-NVTX arm of an
+    # overhead measurement.
+    if nvtx and "--enable-layerwise-nvtx-tracing" not in cmd:
+        cmd += ["--enable-layerwise-nvtx-tracing"]
     if not _arg_of(cmd, "--port"):
         cmd += ["--port", str(args.port)]
     if not _arg_of(cmd, "--host"):
@@ -735,8 +808,15 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
 
         from gitm.tracer import capture
 
+        # nullcontext, not capture-with-nothing-enabled: capture() falls back to the
+        # in-process shim when injection is inactive, which would register CUPTI
+        # callbacks in this process. The parent runs no kernels so the trace would be
+        # empty either way, but the baseline arm must not have CUPTI initialized in it
+        # at all — otherwise it is not a baseline.
+        window = (contextlib.nullcontext() if no_trace
+                  else capture(trace_path, workload_id=WORKLOAD_ID, fingerprint=model))
         wall0 = time.time()
-        with capture(trace_path, workload_id=WORKLOAD_ID, fingerprint=model) as trace:
+        with window as trace:
             records, failures = drive_load(
                 base, model, prompts,
                 concurrency=args.concurrency, max_tokens=args.output_tokens,
@@ -768,6 +848,11 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
         had_traffic=bool(records),
         serving_summary={
             "mode": "drive",
+            # Which tracing arm this run is. Without it the result directories are
+            # indistinguishable, and an A/B on tracing overhead is only as good as
+            # knowing which side each number came from.
+            "tracing": "off" if no_trace else ("cupti+nvtx" if nvtx else "cupti"),
+            "nvtx": nvtx,
             "wall_s": wall,
             # Client-side wall clock, NOT vLLM's RequestOutput.metrics: the server path
             # never hands those to an HTTP client. It therefore includes network and

--- a/gitm/tracer/kernel_taxonomy.py
+++ b/gitm/tracer/kernel_taxonomy.py
@@ -10,7 +10,7 @@ and that question has three failure modes this module is built to answer:
   full of kernels no rule recognises, and any conclusion drawn per-op is guesswork.
 * truncated names** — the collector's name field is bounded (``NAME_MAX``).
   Mangled cutlass/MoE template instantiations run long, and two different kernels
-  truncated to the same 255 bytes become one identity. That is silent: the trace
+  truncated to the same ``NAME_MAX`` bytes become one identity. That is silent: the trace
   looks complete and the distinct expert GEMMs have merged.
 * missing device time — kernels that ran but were never attributed (CUDA-graph
   replay is the usual cause) leave the GPU looking idle while throughput says

--- a/tests/test_serve_capture.py
+++ b/tests/test_serve_capture.py
@@ -385,3 +385,60 @@ def test_the_check_is_wired_into_preflight(monkeypatch):
     assert "port" not in {
         c.name for c in vllm.preflight([], devices, 1, skip_args=True)
     }
+
+
+def test_no_trace_and_nvtx_are_rejected_before_anything_launches():
+    """Both flags set is not a config with a sensible reading: --nvtx asks for
+    correlation records that only the collector --no-trace turns off can produce.
+    Rejected ahead of preflight so it costs no GPU probe, and rejected rather than
+    silently resolved — either resolution produces a run whose serving_summary
+    claims an arm it did not measure, which is the one failure an overhead A/B
+    cannot survive."""
+    import argparse
+
+    from gitm.serve.vllm import add_serve_arguments, launch_and_capture
+
+    args = add_serve_arguments(argparse.ArgumentParser()).parse_args(["--no-trace", "--nvtx"])
+    rc, result = launch_and_capture(args)
+    assert rc == 2
+    assert result is None
+
+
+def test_no_trace_clears_an_inherited_injection_path():
+    """The driver reads CUDA_INJECTION64_PATH out of the inherited environment, so a
+    stale export would attach the collector to the arm whose purpose is to have none.
+    That arm still serves and still reports a throughput number, so the corrupted
+    baseline lands on top of the traced arms and reads as "collection is free"."""
+    from gitm.serve.vllm import apply_tracing_env
+    from gitm.tracer import injection
+
+    env = {
+        injection.ENV_LIB: "/stale/libgitm_inject.so",
+        injection.ENV_OUT: "/stale/trace.jsonl",
+        injection.ENV_NVTX: "1",
+        injection.ENV_NVTX_INJECT: "/stale/libcupti.so.12",
+        "UNRELATED": "kept",
+    }
+    apply_tracing_env(env, "/tmp/t.jsonl", nvtx=False, no_trace=True)
+
+    for var in (injection.ENV_LIB, injection.ENV_OUT,
+                injection.ENV_NVTX, injection.ENV_NVTX_INJECT):
+        assert var not in env
+    assert env["UNRELATED"] == "kept"
+
+
+def test_the_traced_arms_differ_only_by_the_nvtx_variables():
+    """cupti and cupti+nvtx must be the same collector on the same output path — if
+    they differed anywhere else the delta between them would not be the NVTX cost."""
+    from gitm.serve.vllm import apply_tracing_env
+    from gitm.tracer import injection
+
+    plain: dict[str, str] = {}
+    correlated: dict[str, str] = {}
+    apply_tracing_env(plain, "/tmp/t.jsonl", nvtx=False, no_trace=False)
+    apply_tracing_env(correlated, "/tmp/t.jsonl", nvtx=True, no_trace=False)
+
+    assert plain[injection.ENV_LIB] == correlated[injection.ENV_LIB]
+    assert plain[injection.ENV_OUT] == correlated[injection.ENV_OUT]
+    assert injection.ENV_NVTX not in plain
+    assert correlated[injection.ENV_NVTX] == "1"


### PR DESCRIPTION
arm | flag | serving_summary.tracing | collector state
-- | -- | -- | --
A | --no-trace | off | injection env cleared, no capture()
B | (none) | cupti | CONCURRENT_KERNEL + MEMCPY + SYNCHRONIZATION
C | --nvtx | cupti+nvtx | + RUNTIME + DRIVER + MARKER, + vLLM's ranges




Run this with 

```
W="--requests 512 --concurrency 256 --input-tokens 1024 --output-tokens 256 --seed 42"

for i in 1 2 3; do
  gitm capture serve --out /workspace/captures/ovh-off-$i   $W --no-trace   # A
  gitm capture serve --out /workspace/captures/ovh-cupti-$i $W              # B
  gitm capture serve --out /workspace/captures/ovh-nvtx-$i  $W --nvtx       # C
done


python - <<'PY'
import json, statistics as st
from pathlib import Path
base = None
for arm in ("off","cupti","nvtx"):
    runs=[json.loads(p.read_text()) for p in sorted(Path("/workspace/captures").glob(f"ovh-{arm}-*/serving_summary.json"))]
    if not runs: continue
    tps=[r["client"]["output_tokens_per_s"] for r in runs]
    med=st.median(tps); base = base or med
    tpot=[r["server"]["tpot_mean_s"]*1e3 for r in runs if r["server"].get("tpot_mean_s")]
    print(f"{arm:>6}  {med:8.1f} tok/s  spread {max(tps)-min(tps):5.1f}"
          f"  vs off {100*(med/base-1):+6.2f}%"
          + (f"   TPOT {st.median(tpot):6.2f} ms" if tpot else ""))
PY
```

