### PR TITLE
planner: extend the hybrid graph to MiMo-V2.5

### DIFF
--- a/gitm/planner/context.py
+++ b/gitm/planner/context.py
@@ -66,8 +66,16 @@ _QUANT_PEAKS: dict[str, dict[str, float]] = {
     # Hopper has fp8 tensor cores; it has no fp4 path (MXFP4 runs dequantised
     # through Marlin, which is why an fp4 checkpoint traced on H100/H200 prices
     # against fp8 and still shows a compute-bound expert GEMM).
-    "H100": {"fp8": 1979e12},
-    "H200": {"fp8": 1979e12},
+    #
+    # ``fp32`` is the *vector* (non-tensor-core) rate, and it is here because
+    # mixed-precision checkpoints run a genuinely fp32 op: the MoE router casts
+    # to float before scoring. Without an entry the router prices against the
+    # A100 dataclass default of 19.5 TF/s, and unlike a missing fp8 peak this one
+    # is NOT flagged — ``resolve_peak`` returns the fp32 field directly, so
+    # ``peak_is_fallback`` stays False and the wrong ceiling looks measured. On
+    # H200 the difference is 3.4x on that node.
+    "H100": {"fp8": 1979e12, "fp32": 67e12},
+    "H200": {"fp8": 1979e12, "fp32": 67e12},
 }
 
 
@@ -162,8 +170,11 @@ def hardware_spec_for(peak: HardwarePeak | None) -> HardwareSpec:
     ``peak_flops`` covers fp16/bf16; fp8/fp4 come from ``_QUANT_PEAKS`` when the
     SKU has them, and stay ``0.0`` otherwise so ``resolve_peak`` can fall back
     and mark the prediction rather than pricing an fp4 GEMM at the bf16 rate.
-    fp32 peak isn't in the catalogue and stays at the dataclass default since
-    nothing currently predicts fp32 kernels.
+    fp32 comes from the same table where the SKU has a figure; where it does not,
+    it stays at the dataclass default (A100's 19.5 TF/s), which is low for any
+    newer part. This matters now that a checkpoint can declare an fp32 op — the
+    MoE router's ``.float()`` cast — because a missing fp32 peak is *not* flagged
+    the way a missing fp8 one is.
     """
     if peak is None:
         return HardwareSpec()
@@ -174,6 +185,9 @@ def hardware_spec_for(peak: HardwarePeak | None) -> HardwareSpec:
         peak_flops_bf16_per_s=peak.peak_flops,
         peak_flops_fp8_per_s=quant.get("fp8", 0.0),
         peak_flops_fp4_per_s=quant.get("fp4", 0.0),
+        # Falls back to the dataclass default when the SKU has no figure, which
+        # is A100's 19.5 TF/s — correct for A100 and low for everything newer.
+        peak_flops_fp32_per_s=quant.get("fp32", HardwareSpec.peak_flops_fp32_per_s),
         peak_mem_bw_bytes_per_s=peak.peak_bw_bytes_s,
         interconnect_bw_bytes_per_s=interconnect_bw_for_sku(peak.name),
     )

--- a/gitm/planner/graph.py
+++ b/gitm/planner/graph.py
@@ -99,6 +99,20 @@ class PredictedNode:
     # Streams the planner expects to run on — used by the stream-concurrency
     # invariant.
     expected_stream_id: int = 0
+    #: Indices into :attr:`Graph.nodes` this node cannot start before.
+    #:
+    #: Populated **only where the edge is genuinely required**, not everywhere an
+    #: order happens to exist. The graph is otherwise a sum, and a sum is already
+    #: a fully-serial lower bound; adding edges everywhere would restate that at
+    #: greater cost. What edges buy is the ability to tell two *different* kinds
+    #: of serialisation apart — a speculative draft chain, where stage *i+1*
+    #: genuinely cannot begin before stage *i*, versus a run of all-reduces that
+    #: merely happen to be listed in order. Both show up as the same positive
+    #: residual today, and one is recoverable while the other is not.
+    #:
+    #: This is not a scheduler and does not try to be one. It records the edges
+    #: somebody has evidence for; everything else stays unconstrained.
+    depends_on: tuple[int, ...] = ()
 
 
 @dataclass
@@ -118,6 +132,37 @@ class Graph:
     @property
     def total_pred_s(self) -> float:
         return sum(n.prediction.t_pred_s for n in self.nodes)
+
+    @property
+    def serial_chain_s(self) -> float:
+        """Longest chain of nodes joined by a declared dependency edge.
+
+        **This is a floor on the serial part, not an estimate of the step.**
+        Edges are declared only where there is evidence for them, so a node with
+        no edges is *unconstrained*, not known-parallel — and reading this as a
+        whole-step time would treat every unedged node as infinitely
+        overlappable. On a MiMo step with MTP it returns ~0.08 ms against a
+        ~4 ms step: the claim is "at least 0.08 ms of this step cannot be
+        overlapped away", not "this step could take 0.08 ms".
+
+        What it buys is the discriminator §6.1 needs. A speculative draft chain
+        is genuinely serial — stage *i+1* cannot begin before stage *i* — while a
+        run of all-reduces merely happens to be emitted in order. Both show up as
+        the same positive residual today. Time inside this chain is
+        architectural; time outside it is a scheduling question.
+
+        ``0.0`` when no edges are declared, which is every graph that has not
+        opted in.
+        """
+        if not any(n.depends_on for n in self.nodes):
+            return 0.0
+        longest = [0.0] * len(self.nodes)
+        for i, n in enumerate(self.nodes):
+            # Nodes are appended in emission order, so every dependency index is
+            # < i and ``longest`` is already final for it.
+            base = max((longest[d] for d in n.depends_on if 0 <= d < i), default=0.0)
+            longest[i] = base + n.prediction.t_pred_s
+        return max(longest, default=0.0)
 
     @property
     def has_unpriced_collectives(self) -> bool:

--- a/gitm/planner/hybrid_graph.py
+++ b/gitm/planner/hybrid_graph.py
@@ -18,6 +18,13 @@ from gitm.planner.roofline import (
 
 FULL_ATTENTION = "full_attention"
 LINEAR_ATTENTION = "linear_attention"
+#: Softmax attention over a KV cache capped at ``sliding_window`` recent
+#: tokens. Neither of the other two: priced as linear its KV read vanishes
+#: (a fixed recurrent state is not a cache), priced as full it is overstated
+#: by ``kv_len / window`` — 64x at 8k context on a 128-token window. It runs
+#: the *same kernels* as full attention, so it emits the same node names and
+#: ``classify_op`` needs no new rule.
+SLIDING_ATTENTION = "sliding_attention"
 
 #: Chunk width the chunked gated-delta-rule kernels tile prefill with.
 #:
@@ -100,6 +107,37 @@ class HybridMoEModelSpec:
     #: before treating it as read.
     conv_dim: int = 128
 
+    #: Per-head width of **V**, when it differs from K's ``head_dim``. MiMo runs
+    #: K at 192 and V at 128, which makes ``o_proj``'s input ``n_heads *
+    #: v_head_dim`` (8192) rather than ``q_dim`` (12288) — a 1.5x *overstatement*
+    #: of that projection if left conflated, not the understatement one might
+    #: expect. ``None`` means "same as head_dim", under which every expression
+    #: below reduces exactly to what it was before this field existed.
+    v_head_dim: int | None = None
+
+    # ── sliding-window attention (the third layer kind) ──────────────────────
+    #: Tokens a windowed layer may attend to. ``0`` means no window, which is
+    #: what every non-windowed checkpoint wants and leaves the arithmetic
+    #: unchanged.
+    sliding_window: int = 0
+    #: Windowed layers may carry their own GQA geometry. MiMo runs 8 KV heads on
+    #: its sliding-window layers against 4 on its full-attention ones — and the
+    #: KV rate is the quantity decode is bound by, so a single head count for the
+    #: model is wrong on 39 of 48 layers. ``None`` inherits the full-attention
+    #: value.
+    swa_num_kv_heads: int | None = None
+    swa_head_dim: int | None = None
+    swa_v_head_dim: int | None = None
+    #: Windowed layers commonly use a second, much smaller RoPE base (MiMo: 1e4
+    #: against 1e7). Carried because it is a real model fact worth recording, but
+    #: it prices nothing: a second sin/cos table changes no byte count at decode.
+    swa_rope_theta: float = 0.0
+    #: SWA layers add a learned per-head bias to the softmax denominator
+    #: (``add_swa_attention_sink_bias``). Also carried and also free — it is one
+    #: elementwise add already inside the attention kernel. Recorded so the spec
+    #: describes the model, not so a node gets invented for it.
+    swa_attention_sink: bool = False
+
     # ── mixture of experts ───────────────────────────────────────────────────
     num_experts: int = 8
     num_experts_per_tok: int = 2
@@ -120,13 +158,56 @@ class HybridMoEModelSpec:
     #: layer is full attention.
     full_attention_interval: int = 2
 
+    #: Width of the dense FFN on ``dense_layers`` and the draft head. Falls back
+    #: to ``moe_intermediate_size`` when unset, but real checkpoints make the
+    #: dense block far wider than one expert: MiMo runs 16384 against an expert's
+    #: 2048, an 8x difference on the only node in that layer that matters.
+    dense_intermediate_size: int = 0
+
+    #: Layers whose FFN is a plain dense MLP rather than a mixture. DeepSeek and
+    #: MiMo both leave the first block dense; charging it a 256-expert router and
+    #: an expert bank it does not have is pure invention. Empty means every layer
+    #: is MoE, which is what this family did before the field existed.
+    dense_layers: frozenset[int] = frozenset()
+
     # ── multi-token prediction ───────────────────────────────────────────────
     mtp_num_hidden_layers: int = 0
+    #: Attention kind for the draft layers. ``None`` keeps the old behaviour of
+    #: running off the end of ``layer_types`` and taking its last entry — which
+    #: is accidentally right when the final layer matches the draft head and
+    #: silently wrong when it does not. MiMo's last layer is full attention while
+    #: its draft head is windowed, so the fallback prices an O(1)-in-S head with
+    #: a cache growing in S.
+    mtp_layer_kind: str | None = None
+    #: Draft layers whose FFN is dense. Separate from ``dense_layers`` because
+    #: those index the backbone; these index the draft stack.
+    mtp_dense: bool = False
+
+    # ── collectives ──────────────────────────────────────────────────────────
+    #: All-reduces a tensor-parallel layer performs. The conventional transformer
+    #: fires two (post-attention, post-FFN); this family has always priced *two
+    #: reductions' worth of bytes* while emitting *one node* for them. Raising
+    #: this splits the bytes across that many nodes — the total is invariant, the
+    #: node count is not — so a trace with 96 NCCL kernels aligns to 96 predicted
+    #: nodes instead of billing half of them as unmodelled. Defaults to 1 (the
+    #: long-standing behaviour); raise it per checkpoint once a trace confirms.
+    all_reduces_per_layer: int = 1
 
     # ── precision ────────────────────────────────────────────────────────────
     weight_dtype: str = "bf16"
     kv_dtype: str = "bf16"
     act_dtype: str = "bf16"
+    #: Per-op precision, for checkpoints that run more than one width inside a
+    #: single block. MiMo runs three: fp8 ``qkv_proj``, **bf16** ``attn_out_proj``
+    #: (listed in ``quantization_config.ignored_layers``, and carrying no scale
+    #: tensor anywhere in the index), **fp32** ``moe_router`` (an explicit
+    #: ``.float()`` cast). Pricing bf16 weights at one byte understates that
+    #: projection 2x, and it is the second-largest projection byte term in the
+    #: block.
+    #:
+    #: A tuple of pairs rather than a mapping because this dataclass is frozen
+    #: and therefore hashable — a ``dict`` field makes ``hash(spec)`` raise.
+    op_dtype_overrides: tuple[tuple[str, str], ...] = ()
 
     # ── derived shapes ───────────────────────────────────────────────────────
 
@@ -138,6 +219,13 @@ class HybridMoEModelSpec:
         checkpoints are laid out — a naive ``layer % n == 0`` inverts the
         assignment and silently swaps 30 layers for 10.
         """
+        if layer >= self.n_layers and self.mtp_layer_kind is not None:
+            # A draft layer. Taking ``layer_types[-1]`` here reads the *backbone's
+            # last* layer, which is a different mechanism on any checkpoint whose
+            # draft head does not match its final block. MiMo's last layer is full
+            # attention and its draft head is windowed, so the fallback prices a
+            # head that is O(1) in context as one that grows with it.
+            return self.mtp_layer_kind
         if self.layer_types:
             if layer < len(self.layer_types):
                 return self.layer_types[layer]
@@ -150,13 +238,82 @@ class HybridMoEModelSpec:
     def is_full_attention(self, layer: int) -> bool:
         return self.layer_kind(layer) == FULL_ATTENTION
 
+    def is_sliding_attention(self, layer: int) -> bool:
+        return self.layer_kind(layer) == SLIDING_ATTENTION
+
+    def reads_kv_cache(self, layer: int) -> bool:
+        """Whether ``layer`` re-reads a KV cache at all.
+
+        True for both softmax kinds, false only for the recurrent one. *Cache or
+        no cache* is the distinction this answers; *how much of the cache* is
+        :meth:`attention_window`'s business. Conflating the two is what makes a
+        windowed layer priced as linear lose its KV read entirely — a whole
+        mechanism silently costed at zero.
+        """
+        return self.layer_kind(layer) in (FULL_ATTENTION, SLIDING_ATTENTION)
+
+    def attention_window(self, layer: int) -> int:
+        """Cached tokens ``layer`` may attend to; ``0`` means unbounded.
+
+        The same window :func:`gitm.planner.moe_graph.effective_kv_tokens`
+        already prices for the sparse-MoE family — one derivation, not two that
+        drift apart.
+        """
+        if self.layer_kind(layer) != SLIDING_ATTENTION:
+            return 0
+        # A windowed layer whose config forgot the window is not a window layer,
+        # it is global attention, and it reads everything. Returning 0 says
+        # "unbounded" to the caller, which is the conservative answer; the
+        # alternative reads as ``min(kv_len, 0)`` and prices the layer at zero.
+        return max(0, self.sliding_window)
+
+    def attn_geometry(self, layer: int) -> tuple[int, int, int, int]:
+        """``(n_heads, kv_heads, head_dim, v_head_dim)`` for ``layer``.
+
+        Windowed layers may carry their own GQA shape — MiMo runs 8 KV heads on
+        them against 4 on its full-attention layers — and the per-layer KV width
+        *is* the decode KV rate. Every ``swa_*`` field falls back to the
+        full-attention value, so a checkpoint that sets none of them gets
+        byte-identical arithmetic to before this method existed.
+        """
+        head_dim = self.head_dim
+        v_head_dim = self.value_head_dim
+        kv_heads = self.num_kv_heads
+        if self.is_sliding_attention(layer):
+            if self.swa_head_dim is not None:
+                head_dim = self.swa_head_dim
+            if self.swa_v_head_dim is not None:
+                v_head_dim = self.swa_v_head_dim
+            if self.swa_num_kv_heads is not None:
+                kv_heads = self.swa_num_kv_heads
+        return self.n_heads, kv_heads, head_dim, v_head_dim
+
+    def kv_entry_elems(self, layer: int) -> int:
+        """Elements one cached position costs in ``layer`` — K plus V.
+
+        A sum, not ``2 * kv_dim``: K carries ``head_dim`` and V carries
+        ``v_head_dim``, which on MiMo are 192 and 128. They coincide on every
+        checkpoint that leaves ``v_head_dim`` unset, which is why this reduces to
+        the old expression there.
+        """
+        _, kv_heads, head_dim, v_head_dim = self.attn_geometry(layer)
+        return kv_heads * (head_dim + v_head_dim)
+
     @property
     def n_full_attention_layers(self) -> int:
         return sum(1 for i in range(self.n_layers) if self.is_full_attention(i))
 
     @property
+    def n_sliding_attention_layers(self) -> int:
+        return sum(1 for i in range(self.n_layers) if self.is_sliding_attention(i))
+
+    @property
     def n_linear_attention_layers(self) -> int:
-        return self.n_layers - self.n_full_attention_layers
+        return (
+            self.n_layers
+            - self.n_full_attention_layers
+            - self.n_sliding_attention_layers
+        )
 
     @property
     def q_dim(self) -> int:
@@ -164,8 +321,34 @@ class HybridMoEModelSpec:
         return self.n_heads * self.head_dim
 
     @property
+    def value_head_dim(self) -> int:
+        """Per-head V width, defaulting to ``head_dim`` when undeclared."""
+        return self.v_head_dim if self.v_head_dim is not None else self.head_dim
+
+    @property
+    def o_proj_in(self) -> int:
+        """Input width of the output projection — ``n_heads * v_head_dim``.
+
+        **Not** ``q_dim``. Attention returns one ``v_head_dim``-wide result per
+        query head, so on MiMo this is 64x128 = 8192 where ``q_dim`` is
+        64x192 = 12288. Using ``q_dim`` therefore **overstates** this projection
+        by 1.5x — the opposite direction from the intuition that a narrower V
+        means fewer bytes, and worth naming because the sign decides how a
+        residual on ``attn_out_proj`` reads: at 1.5x over-priced, a *near-zero*
+        residual is a kernel running 1.5x slower than the hardware allows.
+
+        Identical to ``q_dim`` whenever ``v_head_dim`` is unset.
+        """
+        return self.n_heads * self.value_head_dim
+
+    @property
     def kv_dim(self) -> int:
-        """Width of K (and separately V) after projection."""
+        """Width of K (and separately V) after projection.
+
+        Answers for the *full-attention* layers, and is kept for callers that
+        predate per-layer geometry. Per-layer widths come from
+        :meth:`attn_geometry`.
+        """
         return self.num_kv_heads * self.head_dim
 
     @property
@@ -228,6 +411,22 @@ class HybridMoEModelSpec:
         return self.n_linear_attention_layers * self.linear_state_bytes_per_layer
 
     @property
+    def dense_ffn_width(self) -> int:
+        """FFN width for a dense block, falling back to the expert width."""
+        return self.dense_intermediate_size or self.moe_intermediate_size
+
+    def dtype_for(self, op: str, default: str) -> str:
+        """Precision ``op`` runs in, falling back to ``default``.
+
+        An empty override table returns ``default`` for everything — exactly what
+        this family did before mixed precision existed in it.
+        """
+        for name, dtype in self.op_dtype_overrides:
+            if name == op:
+                return dtype
+        return default
+
+    @property
     def top_k(self) -> int:
         return min(self.num_experts_per_tok, self.num_experts)
 
@@ -235,13 +434,45 @@ class HybridMoEModelSpec:
 def kv_bytes_per_token(spec: HybridMoEModelSpec) -> float:
     """KV bytes each additional token of context costs, across the whole model.
 
-    **Only the full-attention layers contribute.** The linear layers hold a
-    fixed-size state that does not grow, which is why this is ``n_full`` and not
-    ``n_layers`` — the difference is 4x on this checkpoint and it sets the
-    concurrency ceiling.
+    **Only the full-attention layers contribute.** The other two kinds are both
+    flat in context for different reasons — a linear layer holds a fixed-size
+    recurrent state, a windowed layer holds a fixed-size buffer — and neither
+    grows. Counting either here inflates the rate and caps concurrency far below
+    what the hardware allows.
+
+    A per-layer sum rather than ``n_full x per_layer``: K and V may be different
+    widths, and on a checkpoint that declares neither they coincide, so this
+    reduces to the old expression exactly.
+
+    On MiMo the split is the single most important structural property of the
+    model: 9 full-attention layers grow with context and 39 windowed ones do
+    not, giving ``11,520 x S + 12.78M`` elements rather than a rate 4x higher.
     """
-    per_layer = 2.0 * spec.kv_dim * weight_bytes(spec.kv_dtype)  # K and V
-    return spec.n_full_attention_layers * per_layer
+    kw = weight_bytes(spec.kv_dtype)
+    return sum(
+        spec.kv_entry_elems(i) * kw
+        for i in range(spec.n_layers)
+        if spec.is_full_attention(i)
+    )
+
+
+def kv_fixed_bytes_per_sequence(spec: HybridMoEModelSpec) -> float:
+    """KV bytes a sequence costs however long its context grows.
+
+    The sliding-window layers: each holds ``sliding_window`` tokens and nothing
+    more, so their cost is paid once per sequence rather than per token. Charging
+    them per-token is what makes a windowed model look like it cannot serve long
+    contexts when in fact windowing is precisely how it does.
+
+    Zero for a checkpoint with no windowed layers, which is every checkpoint this
+    family carried before MiMo.
+    """
+    kw = weight_bytes(spec.kv_dtype)
+    return sum(
+        spec.attention_window(i) * spec.kv_entry_elems(i) * kw
+        for i in range(spec.n_layers)
+        if spec.is_sliding_attention(i)
+    )
 
 
 def attention_page_bytes(spec: HybridMoEModelSpec, block_size: int) -> float:
@@ -278,23 +509,41 @@ def model_weight_bytes(
     h = spec.hidden
     inter = spec.moe_intermediate_size
 
-    experts = spec.n_layers * spec.num_experts * 3 * h * inter * ww / es
+    # Layers with a dense FFN carry no expert bank and no router. Counting them
+    # as MoE is not a small error: the expert term is the great majority of the
+    # checkpoint, so one dense layer priced as a mixture adds ~1.6 GB that is not
+    # there.
+    n_moe = sum(1 for i in range(spec.n_layers) if i not in spec.dense_layers)
+    n_dense_ffn = spec.n_layers - n_moe
+
+    experts = n_moe * spec.num_experts * 3 * h * inter * ww / es
     shared = (
-        spec.n_layers * 3 * h * spec.shared_expert_intermediate_size * ww / tp
+        n_moe * 3 * h * spec.shared_expert_intermediate_size * ww / tp
         if spec.shared_expert_intermediate_size > 0
         else 0.0
     )
-    router = spec.n_layers * h * spec.num_experts * ww  # replicated
+    router = n_moe * h * spec.num_experts * ww  # replicated
+    dense_ffn = n_dense_ffn * 3 * h * spec.dense_ffn_width * ww / tp
 
     gate = spec.q_dim if spec.attn_output_gate else 0
-    attn_per_layer = (h * (spec.q_dim + gate + 2 * spec.kv_dim) + spec.q_dim * h) / tp
+
+    def attn_bytes(layer: int) -> float:
+        """Attention weights for one layer, at that layer's own geometry."""
+        n_heads, n_kv, head_dim, v_head_dim = spec.attn_geometry(layer)
+        qkv = h * (n_heads * head_dim + gate + n_kv * (head_dim + v_head_dim))
+        # ``o_proj`` maps n_heads x v_head_dim back to hidden — not q_dim x
+        # hidden. See ``HybridMoEModelSpec.o_proj_in``.
+        out = n_heads * v_head_dim * h
+        return (qkv + out) / tp
 
     lin_per_layer = (
         h * (spec.linear_query_dim + spec.linear_key_dim + 2 * spec.linear_value_dim)
         + spec.linear_value_dim * h
     ) / tp
 
-    n_full = spec.n_full_attention_layers
+    attn = sum(
+        attn_bytes(i) for i in range(spec.n_layers) if spec.reads_kv_cache(i)
+    )
     n_lin = spec.n_linear_attention_layers
     embed = 2.0 * spec.vocab * h / tp  # untied input embedding + lm_head
 
@@ -302,7 +551,8 @@ def model_weight_bytes(
         experts
         + shared
         + router
-        + (n_full * attn_per_layer + n_lin * lin_per_layer + embed) * ww
+        + dense_ffn
+        + (attn + n_lin * lin_per_layer + embed) * ww
     )
 
 
@@ -317,9 +567,9 @@ def _linear(rows: float, k: int, n: int, act_b: float, w_b: float) -> tuple[floa
 
 def _emit_full_attention(
     add, spec: HybridMoEModelSpec, *, rows: float, cache_entries: float,
-    qk_pairs: float, tp: int, aw: float, ww: float,
+    qk_pairs: float, tp: int, aw: float, ww: float, layer: int = 0,
 ) -> None:
-    """Softmax attention over a growing KV cache — the 10-layer minority.
+    """Softmax attention over a KV cache — full-attention and windowed layers.
 
     ``rows`` is every query token the step computes, decode positions and
     prefill chunk together; ``qk_pairs`` is how many query-key products the core
@@ -327,26 +577,37 @@ def _emit_full_attention(
     :attr:`BatchConfig.attention_qk_pairs`); ``cache_entries`` is how many cached
     positions are read, counted once per sequence rather than once per row.
     """
-    heads = max(1, spec.n_heads // tp)
-    kv_heads = max(1, spec.num_kv_heads // tp)
+    # Per-layer geometry: a windowed layer may run a different KV head count and
+    # a different V width from a full-attention one in the same model. Every
+    # ``swa_*`` field falls back to the full-attention value, so a checkpoint
+    # that declares none of them lands on exactly the previous arithmetic.
+    n_heads, n_kv, head_dim, v_head_dim = spec.attn_geometry(layer)
+    heads = max(1, n_heads // tp)
+    kv_heads = max(1, n_kv // tp)
     gate = spec.q_dim if spec.attn_output_gate else 0
 
     # Q, K, V and the output gate come out of one fused projection in vLLM, so
     # they are one node. Splitting them would put four predicted kernels where
     # one runs and leave three permanently unmatched.
-    out_width = (spec.q_dim + gate) // tp + 2 * (spec.kv_dim // max(1, tp))
+    #
+    # K is ``head_dim`` wide and V is ``v_head_dim`` wide — a sum, not ``2 x``
+    # one of them. They coincide unless the checkpoint declares ``v_head_dim``.
+    q_width = n_heads * head_dim
+    kv_width = (n_kv * head_dim + n_kv * v_head_dim) // max(1, tp)
+    out_width = (q_width + gate) // tp + kv_width
     f, b = _linear(rows, spec.hidden, out_width, aw, ww)
-    add("qkv_proj", f, b, spec.weight_dtype)
+    add("qkv_proj", f, b, spec.dtype_for("qkv_proj", spec.weight_dtype))
 
     # QK-norm plus *partial* RoPE. Only ``partial_rotary_factor`` of each head
     # rotates; charging the whole head is a 4x overcount on this family.
-    normed = rows * (heads * spec.head_dim + kv_heads * spec.head_dim)
-    roped = rows * (heads + kv_heads) * spec.rope_dim
+    rope_dim = int(head_dim * spec.partial_rotary_factor)
+    normed = rows * (heads * head_dim + kv_heads * head_dim)
+    roped = rows * (heads + kv_heads) * rope_dim
     add(
         "attn_qnorm_rope_insert",
         3.0 * normed + 6.0 * roped,
-        2.0 * normed * aw + 2.0 * roped * aw + rows * 2.0 * kv_heads
-        * spec.head_dim * weight_bytes(spec.kv_dtype),
+        2.0 * normed * aw + 2.0 * roped * aw
+        + rows * kv_heads * (head_dim + v_head_dim) * weight_bytes(spec.kv_dtype),
         spec.act_dtype,
     )
 
@@ -355,17 +616,24 @@ def _emit_full_attention(
     # what makes a wide step amortise cache reads across many queries and is the
     # reason prefill flips this node from memory-bound to compute-bound.
     kw = weight_bytes(spec.kv_dtype)
-    qk = 2.0 * qk_pairs * heads * spec.head_dim
-    pv = 2.0 * qk_pairs * heads * spec.head_dim
+    # QK contracts over ``head_dim``; PV contracts over ``v_head_dim``. Equal
+    # unless the checkpoint splits them.
+    qk = 2.0 * qk_pairs * heads * head_dim
+    pv = 2.0 * qk_pairs * heads * v_head_dim
     add(
         "attn_score_value",
         qk + pv,
-        cache_entries * 2.0 * kv_heads * spec.head_dim * kw,
-        spec.weight_dtype,
+        cache_entries * kv_heads * (head_dim + v_head_dim) * kw,
+        spec.dtype_for("attn_score_value", spec.weight_dtype),
     )
 
-    f, b = _linear(rows, spec.q_dim // tp, spec.hidden, aw, ww)
-    add("attn_out_proj", f, b, spec.weight_dtype)
+    # ``o_proj``'s input is ``n_heads * v_head_dim`` — one V-width result per
+    # query head — NOT ``q_dim``. On MiMo that is 8192 against q_dim's 12288, so
+    # using q_dim OVERSTATES this projection by 1.5x. The sign matters: an
+    # over-priced node makes a near-zero residual look healthy when the kernel is
+    # actually running 1.5x slower than the hardware allows.
+    f, b = _linear(rows, spec.o_proj_in // tp, spec.hidden, aw, ww)
+    add("attn_out_proj", f, b, spec.dtype_for("attn_out_proj", spec.weight_dtype))
 
 
 def _emit_linear_attention(
@@ -394,7 +662,7 @@ def _emit_linear_attention(
     # that gate the delta rule. vLLM fuses these into in_proj_qkvz / in_proj_ba.
     scalars = 2 * (spec.linear_num_value_heads // max(1, tp))
     f, b = _linear(rows, spec.hidden, q + k + 2 * v + scalars, aw, ww)
-    add("linattn_in_proj", f, b, spec.weight_dtype)
+    add("linattn_in_proj", f, b, spec.dtype_for("linattn_in_proj", spec.weight_dtype))
 
     # Short causal convolution. The state is ``k-1`` previous inputs per channel,
     # read and written every step. Both terms are small; it is emitted separately
@@ -463,7 +731,7 @@ def _emit_linear_attention(
     )
 
     f, b = _linear(rows, v, spec.hidden, aw, ww)
-    add("attn_out_proj", f, b, spec.weight_dtype)
+    add("attn_out_proj", f, b, spec.dtype_for("attn_out_proj", spec.weight_dtype))
 
 
 def _emit_moe(
@@ -477,8 +745,12 @@ def _emit_moe(
     tp = max(1, sh.tp)
     es = max(1, sh.expert_shards)
 
+    # The router runs in fp32 on several checkpoints (an explicit ``.float()``
+    # cast) while the block around it is fp8. It is a small GEMM, but fp32 has
+    # its own — far lower — peak, so pricing it at the weight dtype picks the
+    # wrong ceiling for it.
     f, b = _linear(positions, h, spec.num_experts, aw, ww)
-    add("moe_router", f, b, spec.weight_dtype)
+    add("moe_router", f, b, spec.dtype_for("moe_router", spec.weight_dtype))
 
     per_expert_weights = 3.0 * h * inter
     per_position_flops = 6.0 * h * inter
@@ -503,6 +775,37 @@ def _emit_moe(
         per_expert_weights * distinct * ww * skew / es
         + aw * (positions * h * 2 + positions * inter * 2 * spec.top_k / es),
         spec.weight_dtype,
+    )
+
+
+def _emit_dense_mlp(
+    add, spec: HybridMoEModelSpec, *, positions: float, tp: int,
+    aw: float, ww: float,
+) -> None:
+    """A plain gated FFN, for the layers that are not a mixture.
+
+    Both MiMo's layer 0 and its three draft layers carry one of these. Charging
+    them ``_emit_moe`` invents a 256-way router and an expert bank neither has —
+    and because the expert term dominates a decode step, the invention is not a
+    rounding error but the largest single node in the layer.
+
+    Named ``mlp_gate_up`` / ``mlp_down`` to match the dense graph
+    (:func:`gitm.planner.graph.predict_graph`): it is the same op in the same
+    place, so residuals stay comparable across model families.
+    """
+    h = spec.hidden
+    ff = spec.dense_ffn_width // max(1, tp)
+    add(
+        "mlp_gate_up",
+        2.0 * 2.0 * positions * h * ff,
+        aw * (positions * h + 2.0 * positions * ff) + ww * (2.0 * h * ff),
+        spec.dtype_for("mlp_gate_up", spec.weight_dtype),
+    )
+    add(
+        "mlp_down",
+        2.0 * positions * ff * h,
+        aw * (positions * ff + positions * h) + ww * (ff * h),
+        spec.dtype_for("mlp_down", spec.weight_dtype),
     )
 
 
@@ -555,16 +858,25 @@ def _emit_layer(
     # decode positions plus whatever prefill chunk rides along with them.
     rows = positions + batch.prefill_tokens
 
-    if spec.is_full_attention(layer):
+    if spec.reads_kv_cache(layer):
+        # A windowed layer reads a KV cache like a full-attention one, but only
+        # the last ``window`` entries of it. Priced as linear its cache read
+        # would vanish; priced as unbounded it is overstated by kv_len/window —
+        # 64x at 8k context on a 128-token window.
+        window = spec.attention_window(layer)
+        cached = min(kv_len, window) if window > 0 else kv_len
         # Cached entries read, counted once per sequence rather than once per
         # row. Prefill re-reads its own chunk as it is written, which is why the
-        # chunk appears here as well as its prior context.
-        cache_entries = float(sequences * kv_len)
+        # chunk appears here as well as its prior context — both capped by the
+        # window when there is one.
+        cache_entries = float(sequences * cached)
         if batch.is_prefill:
-            cache_entries += batch.prefill_context + batch.prefill_tokens
+            chunk = batch.prefill_context + batch.prefill_tokens
+            cache_entries += min(chunk, window) if window > 0 else chunk
         _emit_full_attention(
             add, spec, rows=rows, cache_entries=cache_entries,
-            qk_pairs=batch.attention_qk_pairs, tp=tp, aw=aw, ww=ww,
+            qk_pairs=batch.attention_qk_pairs(window), tp=tp, aw=aw, ww=ww,
+            layer=layer,
         )
     else:
         _emit_linear_attention(
@@ -573,7 +885,10 @@ def _emit_layer(
             prefill_requests=batch.prefill_requests, tp=tp, aw=aw, ww=ww,
         )
 
-    _emit_moe(add, spec, positions=rows, sh=sh, aw=aw, ww=ww)
+    if layer in spec.dense_layers or (layer >= spec.n_layers and spec.mtp_dense):
+        _emit_dense_mlp(add, spec, positions=rows, tp=tp, aw=aw, ww=ww)
+    else:
+        _emit_moe(add, spec, positions=rows, sh=sh, aw=aw, ww=ww)
 
     if tp > 1:
         # Priced against the interconnect, not HBM. Bandwidth-only, so optimistic
@@ -581,16 +896,25 @@ def _emit_layer(
         # at zero, which Graph.has_unpriced_collectives surfaces.
         link = replace(hw, peak_mem_bw_bytes_per_s=hw.interconnect_bw_bytes_per_s)
         name = f"{prefix}tp_all_reduce"
-        g.nodes.append(
-            PredictedNode(
-                name, layer,
-                roofline(
-                    name, 0.0,
-                    2.0 * (2.0 * (tp - 1) / tp) * rows * spec.hidden * aw,
-                    link, spec.act_dtype, estimated=True,
-                ),
+        # A conventional TP layer fires two reductions (post-attention,
+        # post-FFN). This family has always priced two reductions' *bytes* — the
+        # leading 2.0 that used to sit in the expression below — while emitting
+        # ONE node for them. Splitting the bytes across ``all_reduces_per_layer``
+        # nodes leaves the total invariant and makes the node count match the
+        # kernel count, so a trace with 96 NCCL kernels stops billing half of
+        # them as unmodelled work.
+        count = max(1, spec.all_reduces_per_layer)
+        per_node = (2.0 / count) * (2.0 * (tp - 1) / tp) * rows * spec.hidden * aw
+        for _ in range(count):
+            g.nodes.append(
+                PredictedNode(
+                    name, layer,
+                    roofline(
+                        name, 0.0, per_node,
+                        link, spec.act_dtype, estimated=True,
+                    ),
+                )
             )
-        )
 
 
 def predict_hybrid_graph(
@@ -621,7 +945,10 @@ def predict_hybrid_graph(
             f"tensor-parallel size {sh.tp} does not divide {spec.n_heads} attention "
             "heads — every head-sharded op would floor to zero work"
         )
-    if spec.linear_num_value_heads % max(1, sh.tp) != 0:
+    # Only meaningful when the model actually has recurrent layers. A windowed
+    # hybrid has none, and refusing its sharding over a head count that governs
+    # no kernel would reject a perfectly valid deployment.
+    if spec.n_linear_attention_layers and spec.linear_num_value_heads % max(1, sh.tp) != 0:
         raise ValueError(
             f"tensor-parallel size {sh.tp} does not divide "
             f"{spec.linear_num_value_heads} linear-attention value heads"
@@ -646,11 +973,45 @@ def predict_hybrid_graph(
             batch=batch,
         )
 
+    aw = weight_bytes(spec.act_dtype)
+    ww = weight_bytes(spec.weight_dtype)
+    lm_dtype = spec.dtype_for("lm_head", spec.weight_dtype)
+
+    def emit_lm_head(rows: float, depends_on: tuple[int, ...] = ()) -> int:
+        """Append the vocabulary projection and return its node index."""
+        f, b = _linear(rows, spec.hidden, spec.vocab // max(1, sh.tp), aw, ww)
+        g.nodes.append(
+            PredictedNode(
+                "lm_head", None, roofline("lm_head", f, b, hw, lm_dtype),
+                depends_on=depends_on,
+            )
+        )
+        return len(g.nodes) - 1
+
+    # Only the final token of a prompt needs logits, so an 8192-token prefill
+    # chunk contributes ONE row here, not 8192. Charging every prefill token
+    # against a 248k-row vocabulary projection is the single largest overcount
+    # available on this path — it would make lm_head dominate a prefill step.
+    last = emit_lm_head(batch.logits_rows)
+
     if with_mtp:
         # Draft layers run one position per sequence. Deliberately not given
         # distinct op names — an MTP layer's qkv projection is a qkv projection;
         # what makes it the draft head is its layer index.
+        #
+        # **One lm_head per stage.** Each draft stage must sample a token before
+        # the next stage can consume it, so every stage runs its own vocabulary
+        # projection. Emitting a single lm_head for the whole step leaves D of
+        # them unmodelled — on a 152k-vocabulary model at TP4 that is ~312 MB of
+        # weight traffic per missing stage, every step.
+        #
+        # The chain is also the one place in this graph where a dependency edge
+        # is *required* rather than incidental: stage i+1 genuinely cannot begin
+        # until stage i has produced a token. Recording it lets a positive
+        # residual here be read as architectural serialisation rather than as
+        # recoverable scheduling slack.
         for i in range(spec.mtp_num_hidden_layers):
+            first = len(g.nodes)
             _emit_layer(
                 g, spec, hw, spec.n_layers + i,
                 positions=sequences, sequences=sequences, kv_len=kv_len, sh=sh,
@@ -658,17 +1019,11 @@ def predict_hybrid_graph(
                 # prefills: it proposes tokens, it does not ingest a prompt.
                 batch=replace(batch, prefill_tokens=0),
             )
+            # The stage's first node waits on the previous stage's logits.
+            if first < len(g.nodes):
+                g.nodes[first].depends_on = (last,)
+            last = emit_lm_head(sequences, depends_on=(len(g.nodes) - 1,))
 
-    aw = weight_bytes(spec.act_dtype)
-    ww = weight_bytes(spec.weight_dtype)
-    # Only the final token of a prompt needs logits, so an 8192-token prefill
-    # chunk contributes ONE row here, not 8192. Charging every prefill token
-    # against a 248k-row vocabulary projection is the single largest overcount
-    # available on this path — it would make lm_head dominate a prefill step.
-    f, b = _linear(batch.logits_rows, spec.hidden, spec.vocab // max(1, sh.tp), aw, ww)
-    g.nodes.append(
-        PredictedNode("lm_head", None, roofline("lm_head", f, b, hw, spec.weight_dtype))
-    )
     return g
 
 
@@ -684,21 +1039,66 @@ def _text_config(cfg: dict[str, Any]) -> dict[str, Any]:
     return inner if isinstance(inner, dict) else cfg
 
 
+#: Checkpoints spell the same two facts differently. Aliased rather than
+#: special-cased so a third checkpoint with a fourth spelling is one line.
+_EXPERT_KEYS = ("num_experts", "n_routed_experts")
+_SCHEDULE_KEYS = ("layer_types", "hybrid_layer_pattern")
+
+
+def _first(cfg: dict[str, Any], keys: tuple[str, ...]):
+    """The first of ``keys`` this config declares, or ``None``."""
+    for k in keys:
+        v = cfg.get(k)
+        if v is not None:
+            return v
+    return None
+
+
+def _schedule(cfg: dict[str, Any]) -> tuple[str, ...]:
+    """The per-layer attention schedule, normalised to this module's names.
+
+    Two spellings, and **they disagree about polarity**:
+
+    * ``layer_types`` — already strings (``full_attention`` /
+      ``linear_attention``), used as-is.
+    * ``hybrid_layer_pattern`` — integers, and **1 means WINDOWED, 0 means
+      FULL** (``modeling_mimo_v2.py:400``: ``is_swa_layer = pattern[i] == 1``).
+      That is the opposite of the intuitive reading, and inverting it silently
+      swaps 39 windowed layers for 9 — producing a graph with the right node
+      count, a plausible total, and every per-layer residual compared against
+      the wrong mechanism.
+    """
+    types = cfg.get("layer_types")
+    if isinstance(types, list | tuple) and types:
+        return tuple(str(t) for t in types)
+    pattern = cfg.get("hybrid_layer_pattern")
+    if isinstance(pattern, list | tuple) and pattern:
+        return tuple(
+            SLIDING_ATTENTION if int(p) == 1 else FULL_ATTENTION for p in pattern
+        )
+    return ()
+
+
 def is_hybrid_moe_config(cfg: dict[str, Any]) -> bool:
-    """True for the hybrid linear-attention MoE checkpoints this module models.
+    """True for the hybrid-schedule MoE checkpoints this module models.
 
     The discriminator is a *mixed* layer schedule: routed experts alone describe
-    a Mixtral, and linear attention alone describes a Mamba. Only a checkpoint
-    that interleaves both — declared either as an explicit ``layer_types`` list
-    containing more than one kind, or as a ``full_attention_interval`` greater
-    than one — has the two-asymptotic structure this graph exists to price.
+    a Mixtral, and one uniform attention kind describes a conventional MoE. Only
+    a checkpoint that interleaves two attention mechanisms — linear with full
+    (Qwen3.6) or windowed with full (MiMo) — has the two-asymptotic structure
+    this graph exists to price.
+
+    ``n_routed_experts`` is accepted alongside ``num_experts``, which matters
+    because **DeepSeek-V4 declares it too** and ``detect_family`` consults this
+    predicate first. V4 declares no schedule under either spelling and no
+    ``full_attention_interval``, so it still falls through to the sparse-MoE
+    family — but that is a property worth a test rather than a comment.
     """
     text = _text_config(cfg)
-    routed = text.get("num_experts") and text.get("num_experts_per_tok")
+    routed = _first(text, _EXPERT_KEYS) and text.get("num_experts_per_tok")
     if not routed:
         return False
-    types = text.get("layer_types")
-    if isinstance(types, list | tuple) and len(set(types)) > 1:
+    if len(set(_schedule(text))) > 1:
         return True
     return bool(text.get("full_attention_interval", 1) and
                 int(text.get("full_attention_interval", 1)) > 1)
@@ -742,9 +1142,35 @@ def spec_from_hf_config(
         except (TypeError, ValueError):
             raise ValueError(f"config field {key!r} is not an integer: {v!r}") from None
 
-    types = text.get("layer_types")
-    layer_types: tuple[str, ...] = (
-        tuple(str(t) for t in types) if isinstance(types, list | tuple) else ()
+    def _req_any(keys: tuple[str, ...]) -> int:
+        """A required field that more than one checkpoint spells differently.
+
+        Raises naming the canonical spelling *and* the aliases, so the message
+        says what to look for rather than only what was absent.
+        """
+        v = _first(text, keys)
+        if v is None:
+            raise ValueError(
+                f"config declares no {keys[0]!r} (nor any of {list(keys[1:])}); "
+                "refusing to substitute a default, which would predict a model "
+                "this checkpoint is not"
+            )
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            raise ValueError(f"config field {keys[0]!r} is not an integer: {v!r}") from None
+
+    layer_types = _schedule(text)
+
+    # ``moe_layer_freq`` marks which layers carry a mixture; a falsy entry is a
+    # dense block. MiMo leaves layer 0 dense. Charging it a 256-expert router and
+    # an expert bank it does not have is the same error as G7's draft head, and
+    # the expert term dominates the layer.
+    freq = text.get("moe_layer_freq")
+    dense_layers = (
+        frozenset(i for i, v in enumerate(freq) if not v)
+        if isinstance(freq, list | tuple)
+        else frozenset()
     )
 
     dtype = str(text.get("dtype") or text.get("torch_dtype") or "bf16").lower()
@@ -754,6 +1180,16 @@ def spec_from_hf_config(
         dtype = "bf16"
     elif dtype.startswith("float32"):
         dtype = "fp32"
+
+    # Weights and activations are genuinely different widths on a quantised
+    # checkpoint, and this reader used to conflate them because the only member
+    # of the family was bf16 throughout. MiMo stores fp8 weights under a
+    # bfloat16 ``dtype``, so reading the torch dtype for weights prices the
+    # entire checkpoint at 2 bytes and doubles the footprint — 617 GB against a
+    # 315 GB index. ``quantization_config.quant_method`` is where the weight
+    # width actually lives; the torch dtype governs activations.
+    q = cfg.get("quantization_config") or text.get("quantization_config") or {}
+    weight_dtype = str(q.get("quant_method") or dtype).lower()
 
     ssm = str(text.get("mamba_ssm_dtype", "fp32")).lower()
     ssm = "fp32" if ssm.startswith("float32") or ssm == "fp32" else ssm
@@ -766,8 +1202,35 @@ def spec_from_hf_config(
 
     hidden = _req("hidden_size")
     n_heads = _req("num_attention_heads")
-    n_value_heads = _req("linear_num_value_heads")
-    value_head_dim = _req("linear_value_head_dim")
+
+    # Linear-attention geometry exists only on the gated-DeltaNet checkpoints. A
+    # windowed hybrid has no recurrent layers at all, so demanding these fields
+    # would refuse a config that is simply a different member of the family.
+    #
+    # The discriminator is the *schedule*, deliberately not the presence of the
+    # fields themselves: keying off ``linear_num_value_heads`` would make the
+    # check disable itself exactly when the field is missing, which is the one
+    # case it exists to catch. Absent a schedule the fields stay required, since
+    # nothing has established that this checkpoint has no recurrent layers.
+    has_linear = (not layer_types) or LINEAR_ATTENTION in layer_types
+    if has_linear:
+        n_value_heads = _req("linear_num_value_heads")
+        value_head_dim = _req("linear_value_head_dim")
+    else:
+        n_value_heads, value_head_dim = 1, 1
+
+    def _opt_int(key: str) -> int | None:
+        """A field whose absence means "same as the full-attention layers"."""
+        v = text.get(key)
+        if v is None:
+            return None
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    # A windowed checkpoint may declare the window under either spelling.
+    window = _opt_int("sliding_window") or _opt_int("sliding_window_size") or 0
 
     return HybridMoEModelSpec(
         name=name or str(cfg.get("_name_or_path") or "hybrid-moe"),
@@ -792,14 +1255,32 @@ def spec_from_hf_config(
         # constant, so a differently-shaped sibling scales with it instead of
         # silently inheriting the width that happened to fit Qwen3.6.
         conv_dim=n_value_heads * value_head_dim,
-        num_experts=_req("num_experts"),
+        v_head_dim=_opt_int("v_head_dim"),
+        sliding_window=window,
+        swa_num_kv_heads=_opt_int("swa_num_key_value_heads"),
+        swa_head_dim=_opt_int("swa_head_dim"),
+        swa_v_head_dim=_opt_int("swa_v_head_dim"),
+        swa_rope_theta=float(text.get("swa_rope_theta") or 0.0),
+        swa_attention_sink=bool(text.get("add_swa_attention_sink_bias", False)),
+        num_experts=_req_any(_EXPERT_KEYS),
         num_experts_per_tok=_req("num_experts_per_tok"),
         moe_intermediate_size=_req("moe_intermediate_size"),
         shared_expert_intermediate_size=_int("shared_expert_intermediate_size", 0),
+        dense_intermediate_size=_int("intermediate_size", 0),
+        dense_layers=dense_layers,
         layer_types=layer_types,
         full_attention_interval=_int("full_attention_interval", 1),
+        # MiMo ships three draft layers but declares them nowhere in
+        # ``config.json`` — they are only visible as tensors in the safetensors
+        # index. Defaulting to 0 from a bare config is the honest answer: the
+        # catalogue entry carries the real count, and inventing one here would
+        # predict a head this reader never saw.
         mtp_num_hidden_layers=_int("mtp_num_hidden_layers", 0),
-        weight_dtype=dtype,
+        weight_dtype=weight_dtype,
+        # The cache dtype is a *serving* decision, not a model fact: no
+        # checkpoint declares it. The torch dtype is the reading the config
+        # supports, and it is the conservative one — an fp8 cache would halve
+        # this. Tracked as an open question rather than assumed away.
         kv_dtype=dtype,
         act_dtype=dtype,
     )

--- a/gitm/planner/model_catalogue.py
+++ b/gitm/planner/model_catalogue.py
@@ -113,6 +113,16 @@ def load_spec(name_or_path: str | Path):
     for key in ("compress_ratios", "dspark_layer_ids"):
         if key in raw and isinstance(raw[key], list):
             raw[key] = tuple(raw[key])
+    # YAML gives lists; the spec is a frozen dataclass and therefore hashable, so
+    # every collection field has to land as something hashable. A list here does
+    # not fail at load — it fails later, at the first ``hash(spec)``, a long way
+    # from the file that caused it.
+    if isinstance(raw.get("dense_layers"), list):
+        raw["dense_layers"] = frozenset(int(i) for i in raw["dense_layers"])
+    if isinstance(raw.get("op_dtype_overrides"), list):
+        raw["op_dtype_overrides"] = tuple(
+            (str(op), str(dt)) for op, dt in raw["op_dtype_overrides"]
+        )
 
     unknown = set(raw) - known
     if unknown:

--- a/gitm/planner/models/mimo-v2.5.yaml
+++ b/gitm/planner/models/mimo-v2.5.yaml
@@ -1,0 +1,170 @@
+# Xiaomi MiMo-V2.5 — hybrid sliding-window / full-attention MoE.
+# Source: the checkpoint's own config.json + model.safetensors.index.json.
+
+name: XiaomiMiMo/MiMo-V2.5
+family: hybrid
+description: >
+  48 layers, 39 sliding-window (W=128) and 9 full attention, top-8 of 256
+  experts with no shared expert. Layer 0 is the only dense MLP. Three dense
+  sliding-window MTP draft layers. Three precisions inside one attention block:
+  fp8 qkv_proj, bf16 o_proj, fp32 router.
+
+spec:
+  hidden: 4096
+  n_layers: 48
+  vocab: 152576
+
+  # Attention. head_dim 192 for Q/K but v_head_dim 128 for V, so o_proj's input
+  # is n_heads * v_head_dim = 8192 — NOT q_dim (12288). Using q_dim overstates
+  # that projection by 1.5x.
+  n_heads: 64
+  num_kv_heads: 4
+  head_dim: 192
+  v_head_dim: 128
+  partial_rotary_factor: 0.334      # 64 of 192 dims rotate
+  attn_output_gate: false
+
+  # Sliding-window layers carry their own GQA shape: 8 KV heads against the
+  # full-attention layers' 4. The per-layer KV width IS the decode KV rate, so a
+  # single head count for the model is wrong on 39 of 48 layers.
+  sliding_window: 128
+  swa_num_kv_heads: 8
+  swa_head_dim: 192
+  swa_v_head_dim: 128
+  swa_rope_theta: 10000.0           # vs 1e7 on full-attention layers
+  swa_attention_sink: true          # add_swa_attention_sink_bias
+
+  # Mixture of experts. n_shared_experts is null in the config — there is no
+  # shared expert, which is unusual for this scale and worth not assuming.
+  num_experts: 256
+  num_experts_per_tok: 8
+  moe_intermediate_size: 2048
+  shared_expert_intermediate_size: 0
+
+  # Layer 0 is the only dense block, and its FFN is 8x an expert's width.
+  dense_intermediate_size: 16384
+  dense_layers: [0]
+
+  # Written out rather than tiled. The full-attention gaps are 5,6,6,6,6,6,6,6 —
+  # layer 0 breaks the stride, so NO {pattern, repeat} form reproduces this
+  # schedule, and a modulo rule guessed from the interval would place all nine
+  # full-attention layers in the wrong positions while producing an entirely
+  # plausible total.
+  layer_types: [
+    full_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+    sliding_attention, sliding_attention, sliding_attention, sliding_attention, sliding_attention, full_attention,
+  ]
+
+  # Dead on this checkpoint — the schedule above is explicit, so no interval is
+  # ever consulted. Stated anyway so the YAML and the config reader agree field
+  # for field, which is what makes the drift test meaningful.
+  full_attention_interval: 1
+
+  # Multi-token prediction. THE COUNT IS NOT IN config.json — it is only visible
+  # as tensors in the safetensors index (48 MTP tensors / 16 per layer = 3), so
+  # the config reader defaults to 0 and this file is where the real number
+  # lives. Each draft layer is DENSE-MLP and SLIDING-window, not a copy of the
+  # backbone's last (full-attention, MoE) layer.
+  mtp_num_hidden_layers: 3
+  mtp_layer_kind: sliding_attention
+  mtp_dense: true
+
+  # Two per layer: post-attention and post-MoE.
+  all_reduces_per_layer: 2
+
+  # Precision. Three of them inside one attention block.
+  weight_dtype: fp8
+  act_dtype: bf16
+  kv_dtype: bf16                    # OPEN — see provenance.open Q1
+  op_dtype_overrides:
+    - [attn_out_proj, bf16]         # in quantization_config.ignored_layers
+    - [moe_router, fp32]            # explicit .float() cast
+    - [lm_head, bf16]               # untied, no scale tensor
+    # The attention core is not one of the fp8 tensors. config.json's
+    # quantization_config covers *linear* weights; the score-value kernel has no
+    # weights at all, and the cache it reads is bf16 (kv_dtype above). Leaving it
+    # at weight_dtype prices it against the fp8 peak — 2x optimistic on a node
+    # that is 3% of a decode step but 3% of prefill's compute too.
+    - [attn_score_value, bf16]
+
+  # Unused by this checkpoint (no linear-attention layers); present because the
+  # spec is shared with the gated-DeltaNet members of the family.
+  linear_num_value_heads: 1
+  linear_value_head_dim: 1
+
+provenance:
+  verified:
+    - claim: the layer schedule reproduces the published structure
+      detail: >
+        hybrid_layer_pattern decodes to full attention at exactly
+        0, 5, 11, 17, 23, 29, 35, 41, 47 — 9 full, 39 windowed. Note the
+        polarity: 1 means WINDOWED (modeling_mimo_v2.py:400,
+        `is_swa_layer = config.hybrid_layer_pattern[layer_idx] == 1`), which is
+        the opposite of how layer_types reads. Inverting it swaps 39 layers for
+        9 while leaving the node count and the total entirely plausible.
+    - claim: the KV rate splits into a growing and a fixed part
+      detail: >
+        9 x 1,280 = 11,520 elements per token of context, plus
+        39 x 2,560 x 128 = 12,779,520 elements fixed per sequence. The 39
+        windowed layers never grow. Counting them per-token inflates the rate
+        ~9.7x and caps concurrency far below what the hardware allows.
+    - claim: predicted weight bytes land near the published checkpoint
+      detail: >
+        308.85 GB predicted against the index's total_size of 315.03 GB
+        (-2.0%). The residual is the vision encoder (~1.46 GB), the audio
+        encoder (~0.52 GB), the MTP head (~1.19 GB) and per-tensor metadata,
+        none of which this spec enumerates. Same class of gap as the -2.4% on
+        DeepSeek-V4 and -3.3% on Qwen3.6.
+
+  estimated:
+    - field: mtp_layer_kind
+      value: sliding_attention
+      detail: >
+        Read from the presence of `self_attn.attention_sink_bias` on every
+        model.mtp.layers.N, which config.json ties to windowed layers
+        (add_swa_attention_sink_bias: true, add_full_attention_sink_bias:
+        false). No declared shape confirms the window size for the draft head.
+        The alternative — inheriting layer 47's full attention, as the old
+        layer_types[-1] fallthrough did — prices a head that is O(1) in context
+        as one that grows with it.
+    - field: all_reduces_per_layer
+      value: 2
+      detail: >
+        A TP convention (post-attention, post-FFN), not an observation. The
+        BYTES were already right before this field existed; what changes is the
+        node count, so 96 NCCL kernels align to 96 predicted nodes instead of
+        billing half of them as unmodelled. Falsifiable by counting NCCL kernels
+        per step in a trace.
+
+  open:
+    - question: KV cache dtype — 1 or 2 bytes per element
+      detail: >
+        config.json declares dtype bfloat16 and quantization_config does not
+        cover the cache, so bf16 is the reading the checkpoint supports. It is
+        a SERVING decision, not a model fact. An fp8 cache halves the KV
+        footprint. Resolve from the engine launch args.
+    - question: is MTP enabled in production, and at what draft length
+      detail: >
+        predict_hybrid_graph emits the draft head only under with_mtp=True,
+        because a node no kernel can match reads as a permanently negative
+        residual. Resolve from the engine launch args.
+    - question: TP-only, or expert parallelism
+      detail: >
+        Changes every collective row. Under EP the all-to-all replaces the
+        all-reduce and ep_imbalance becomes load-bearing — and that figure is
+        calibrated from a trace, not predicted.
+
+  unmodelled:
+    - The vision encoder (28 layers, hidden 1280) and the audio encoder
+      (6 local layers, hidden 1024). A text step never enters either.
+    - The audio codec model, which is not in this checkpoint at all and runs on
+      every audio request.
+    - Prefill IS modelled — see BatchConfig.prefill_tokens and the windowed
+      attention_qk_pairs term, which is banded rather than quadratic for the 39
+      sliding-window layers.

--- a/gitm/planner/registry.py
+++ b/gitm/planner/registry.py
@@ -102,6 +102,10 @@ def add_plan_arguments(ap: argparse.ArgumentParser) -> argparse.ArgumentParser:
                     help="Context already cached before this chunk (0 for a first chunk).")
     ap.add_argument("--prefill-requests", type=int, default=1,
                     help="How many prompts those tokens belong to — sets lm_head rows.")
+    ap.add_argument("--launch-overhead", type=float, default=None,
+                    help="Seconds per dependent kernel launch. Default 2e-6 "
+                         "(CUDA-graph replay); eager is nearer 5e-6, and the "
+                         "2.5x moves where launch-bound work crosses over.")
     ap.add_argument("--tp", type=int, default=1, help="Tensor-parallel size.")
     ap.add_argument("--ep", type=int, default=1, help="Expert-parallel size.")
     ap.add_argument("--dp", type=int, default=1, help="Data-parallel size.")
@@ -166,7 +170,17 @@ def _predict(spec, family: str, hw, batch, sharding):
 
 
 def _render_table(g, hw: HardwareSpec, spec, family: str, note: str) -> str:
+    from gitm.planner.roofline import resolve_peak
+
     agg: dict[str, list[float]] = {}
+    # The op's own bound, rolled up from the nodes rather than recomputed from
+    # the compute/memory totals. Recomputing drops ``"launch"`` entirely — the
+    # third bound the roofline reports for work whose cost is the *number* of
+    # dependent kernel launches, where both classic terms round to zero. An op
+    # that the model says is launch-bound would print "memory" and read as though
+    # bandwidth were the constraint.
+    bounds: dict[str, set[str]] = {}
+    dtypes: dict[str, str] = {}
     for n in g.nodes:
         p = n.prediction
         a = agg.setdefault(n.op, [0, 0.0, 0.0, 0.0, 0.0, 0.0])
@@ -176,10 +190,24 @@ def _render_table(g, hw: HardwareSpec, spec, family: str, note: str) -> str:
         a[3] += p.t_memory_s
         a[4] += p.flops
         a[5] += p.bytes
+        bounds.setdefault(n.op, set()).add(p.bound)
+        dtypes.setdefault(n.op, p.dtype)
 
     total = g.total_pred_s
-    ridge = (hw.peak_flops_bf16_per_s / hw.peak_mem_bw_bytes_per_s
-             if hw.peak_mem_bw_bytes_per_s else 0.0)
+
+    def ridge_for(dtype: str) -> float:
+        """FLOP/byte at which ``dtype`` stops being memory-bound on this SKU.
+
+        Per dtype, not per model. A single bf16 ridge is the wrong yardstick for
+        an fp8 op: on H200 the two are 206 and 412 FLOP/byte, so a node judged
+        against 206 when it answers to 412 is placed on the wrong side of the
+        knee — and every attention layer of a mixed-precision checkpoint is such
+        a node.
+        """
+        peak, _ = resolve_peak(hw, dtype)
+        return peak / hw.peak_mem_bw_bytes_per_s if hw.peak_mem_bw_bytes_per_s else 0.0
+
+    ridges = sorted({dtypes[op] for op in agg}, key=lambda d: ridge_for(d))
 
     out = [
         f"model     {getattr(spec, 'name', '?')}  [{family}]",
@@ -187,14 +215,20 @@ def _render_table(g, hw: HardwareSpec, spec, family: str, note: str) -> str:
         f"hardware  {hw.name}  "
         f"{hw.peak_flops_bf16_per_s / 1e12:.0f} TFLOP/s bf16, "
         f"{hw.peak_mem_bw_bytes_per_s / 1e12:.2f} TB/s",
-        f"ridge     {ridge:.0f} FLOP/byte — a node below this is memory-bound",
+        "ridge     " + ", ".join(
+            f"{ridge_for(d):.0f} ({d})" for d in ridges
+        ) + " FLOP/byte — a node below its own dtype's ridge is memory-bound",
         "",
         f"  {'op':24s} {'xN':>4s} {'t_pred':>9s} {'share':>7s} "
         f"{'t_comp':>9s} {'t_mem':>9s} {'AI':>7s}  bound",
     ]
     for op, (n, tp, tc, tm, fl, by) in sorted(agg.items(), key=lambda kv: -kv[1][1]):
         ai = fl / by if by else 0.0
-        bound = "compute" if tc >= tm else "memory"
+        # Every node of this op agreed, or they did not — say which rather than
+        # picking one. A mixed roll-up is real information: it means the op's
+        # bound flips across layers.
+        kinds = bounds.get(op) or {"memory"}
+        bound = next(iter(kinds)) if len(kinds) == 1 else "/".join(sorted(kinds))
         out.append(
             f"  {op:24s} {int(n):4d} {tp * 1e3:8.3f}m {tp / total:6.1%} "
             f"{tc * 1e3:8.3f}m {tm * 1e3:8.3f}m {ai:7.1f}  {bound}"
@@ -260,6 +294,10 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     hw = _hardware(args.gpu)
+    if args.launch_overhead is not None:
+        from dataclasses import replace as _replace
+
+        hw = _replace(hw, kernel_launch_overhead_s=args.launch_overhead)
     if args.gpu and args.gpu.lower() not in hw.name.lower():
         print(f"warning: --gpu {args.gpu!r} is not in the catalogue; priced against "
               f"{hw.name}, whose bandwidth may differ by more than 2x.")

--- a/gitm/planner/roofline.py
+++ b/gitm/planner/roofline.py
@@ -567,8 +567,7 @@ class BatchConfig:
         """
         return (self.prefill_requests if self.is_prefill else 0) + self.positions_per_step
 
-    @property
-    def attention_qk_pairs(self) -> float:
+    def attention_qk_pairs(self, window: int = 0) -> float:
         """Query-key pairs the attention core evaluates this step.
 
         Decode contributes ``batch x kv_len``: one query against the whole cache.
@@ -578,12 +577,31 @@ class BatchConfig:
         The second term is the quadratic one, and it is why prefill is compute-
         bound where decode is memory-bound — at 8192 tokens it is 33.6M pairs
         against a decode step's 8192.
+
+        ``window`` caps how far back any one query may look, for sliding-window
+        layers. It changes the *asymptotics*, not just the constant: the causal
+        triangle becomes a band, so the quadratic term collapses to a linear one.
+        At P=8192 and W=128 that is 1,040,448 pairs against 33,558,528 — a
+        **32x overcount** if the window is ignored, on the term that decides
+        whether prefill is compute-bound. ``0`` means no window, which reproduces
+        the unwindowed expression exactly.
         """
-        pairs = float(self.positions_per_step * self.kv_cache_len)
-        if self.is_prefill:
-            p = self.prefill_tokens
-            pairs += p * self.prefill_context + p * (p + 1) / 2.0
-        return pairs
+        if window > 0:
+            decode = float(self.positions_per_step * min(self.kv_cache_len, window))
+        else:
+            decode = float(self.positions_per_step * self.kv_cache_len)
+        if not self.is_prefill:
+            return decode
+
+        p, ctx = self.prefill_tokens, self.prefill_context
+        if window <= 0:
+            return decode + p * ctx + p * (p + 1) / 2.0
+        if ctx >= window:
+            # Every chunk token already has a full window behind it.
+            return decode + float(p * window)
+        # ``m`` tokens ramp up from ``ctx+1`` to the window; the rest run flat.
+        m = min(p, window - ctx)
+        return decode + m * ctx + m * (m + 1) / 2.0 + (p - m) * window
 
     @property
     def tokens_per_step(self) -> float:

--- a/gitm/serve/model_config.py
+++ b/gitm/serve/model_config.py
@@ -14,7 +14,7 @@ no planner imports beyond the pure spec builder, no `/proc` beyond what
 entry point takes an injectable ``environ`` and ``cache_root``) and so the planner
 never grows HF-cache concerns.
 
-The load-bearing decision is the **gate**. :func:`spec_from_hf_config` is written
+The load-bearing decision is the **gate**. :func:`sparse_spec_from_hf_config` is written
 for a DeepSeek-V4-class MoE, and every one of its ``cfg.get(key, default)`` calls is
 a DeepSeek default; :func:`gitm.planner.roofline.weight_bytes` falls back to bf16 on
 an unrecognised dtype. Feed either an off-distribution config and you get a
@@ -33,7 +33,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from gitm.planner.moe_graph import spec_from_hf_config
+# Aliased, not bare: ``spec_from_hf_config`` exists in BOTH planner families
+# with different meanings, and this module imports the hybrid one too (below).
+# A bare name here would make the family depend on import order.
+from gitm.planner.moe_graph import spec_from_hf_config as sparse_spec_from_hf_config
 from gitm.planner.roofline import (
     _WEIGHT_BYTES,
     BatchConfig,
@@ -46,7 +49,7 @@ from gitm.serve import discover
 # is *declared* by the config is a silent-mispricing risk, not a default to accept.
 KNOWN_DTYPES = frozenset(_WEIGHT_BYTES)
 
-# Alias -> canonical key that :func:`spec_from_hf_config` reads. Non-DeepSeek MoEs
+# Alias -> canonical key that :func:`sparse_spec_from_hf_config` reads. Non-DeepSeek MoEs
 # name the same tensors differently; without this a valid Mixtral/Qwen3-MoE config
 # would fail the gate for "missing" experts it declares under another name.
 _EXPERT_COUNT_ALIASES = ("n_routed_experts", "num_local_experts", "num_experts")
@@ -153,7 +156,7 @@ def _act_dtype_from_flag(value: str) -> str | None:
     """Map vLLM's ``--dtype`` onto a roofline dtype, or ``None`` for ``auto``.
 
     ``auto`` defers to the checkpoint's ``torch_dtype``, which
-    :func:`spec_from_hf_config` already reads — so only an *explicit* dtype overrides.
+    :func:`sparse_spec_from_hf_config` already reads — so only an *explicit* dtype overrides.
     """
     v = value.lower()
     if v in ("auto", ""):
@@ -244,7 +247,7 @@ def normalize_moe_config(cfg: dict[str, Any]) -> dict[str, Any]:
     """Copy of ``cfg`` with alias keys mapped onto the canonical DeepSeek names.
 
     Only fills a canonical key that is absent, so a config that already uses the
-    DeepSeek names is untouched. This keeps :func:`spec_from_hf_config` a pure,
+    DeepSeek names is untouched. This keeps :func:`sparse_spec_from_hf_config` a pure,
     single-vocabulary builder — the aliasing lives here, at the edge that reads
     foreign configs, and its dict-based tests keep passing unchanged.
     """
@@ -382,7 +385,7 @@ def live_moe_spec(
                 model_ref=model_ref,
                 missing_keys=missing,
             )
-        spec = spec_from_hf_config(normalize_moe_config(cfg), name=model_ref)
+        spec = sparse_spec_from_hf_config(normalize_moe_config(cfg), name=model_ref)
 
     overrides = serving_overrides_from_cmdline(target.cmdline)
     spec_changes: dict[str, Any] = {}

--- a/tests/test_moe_graph.py
+++ b/tests/test_moe_graph.py
@@ -16,6 +16,7 @@ headroom report would then bill against.
 from __future__ import annotations
 
 import textwrap
+from dataclasses import replace
 
 import pytest
 
@@ -29,6 +30,9 @@ from gitm.planner.hybrid_graph import (
     predict_hybrid_graph,
 )
 from gitm.planner.hybrid_graph import kv_bytes_per_token as hybrid_kv_bytes_per_token
+from gitm.planner.hybrid_graph import (
+    kv_fixed_bytes_per_sequence as hybrid_kv_fixed_bytes,
+)
 from gitm.planner.hybrid_graph import model_weight_bytes as hybrid_model_weight_bytes
 from gitm.planner.hybrid_graph import spec_from_hf_config as hybrid_spec_from_hf_config
 from gitm.planner.model_catalogue import available, load_entry, load_spec, predict
@@ -1355,7 +1359,7 @@ def test_a_default_batchconfig_is_still_a_pure_decode_step():
     """Every existing caller predates prefill and must be unaffected."""
     b = BatchConfig(batch=8, kv_cache_len=1024)
     assert not b.is_prefill
-    assert b.attention_qk_pairs == 8 * 1024
+    assert b.attention_qk_pairs() == 8 * 1024
     assert b.logits_rows == 8
 
 
@@ -1364,10 +1368,10 @@ def test_prefill_attention_is_quadratic_in_the_chunk():
     second term is what makes prefill compute-bound; omitting it would price an
     8192-token chunk as if it were 8192 independent decode queries."""
     b = _pre(8192, ctx=0)
-    assert b.attention_qk_pairs == 8192 * 8193 / 2
+    assert b.attention_qk_pairs() == 8192 * 8193 / 2
 
     with_ctx = _pre(8192, ctx=4096)
-    assert with_ctx.attention_qk_pairs == 8192 * 4096 + 8192 * 8193 / 2
+    assert with_ctx.attention_qk_pairs() == 8192 * 4096 + 8192 * 8193 / 2
 
 
 def test_lm_head_charges_one_row_per_prompt_not_one_per_token():
@@ -1480,3 +1484,650 @@ def test_a_pure_prefill_step_reports_prefill_throughput(capsys):
     out = capsys.readouterr().out
     assert "prefilling 8,192 tokens" in out
     assert "0 tok/s at batch 0" not in out
+
+
+# ── MiMo-V2.5: the windowed-attention hybrid ─────────────────────────────────
+#
+# A third member of the hybrid family, and the one that breaks the family's
+# founding assumption that "not full attention" means "recurrent". MiMo's 39
+# sliding-window layers re-read a KV cache exactly as full attention does — they
+# just read at most 128 entries of it. Priced as linear their cache read
+# vanishes; priced as unbounded it is overstated 64x at 8k context. Each test
+# below pins one number that would otherwise be confidently wrong.
+#
+# Aliased imports, as above: this module hosts three families whose readers share
+# function names.
+
+# The shape of XiaomiMiMo/MiMo-V2.5, trimmed to the keys the planner reads —
+# the same convention as ``V4_CONFIG`` above, and for the same reason: a test
+# that reads a checkpoint off a developer's disk skips everywhere else, so the
+# tests that matter most (the family it classifies as, and the inverted
+# ``hybrid_layer_pattern`` polarity) would never run in CI.
+#
+# ``test_the_two_readers_agree`` is what keeps this honest: it compares every
+# non-exempt field of the spec built from here against the catalogue YAML, so a
+# key dropped in trimming fails loudly rather than quietly weakening the check.
+# Verified spec-identical to the full 57-key config.json at the time of writing.
+MIMO_CONFIG = {
+    'model_type': 'mimo_v2',
+    'hidden_size': 4096,
+    'num_hidden_layers': 48,
+    'vocab_size': 152576,
+    'num_attention_heads': 64,
+    'num_key_value_heads': 4,
+    'head_dim': 192,
+    'v_head_dim': 128,
+    'partial_rotary_factor': 0.334,
+    'sliding_window': 128,
+    'sliding_window_size': 128,
+    'swa_num_key_value_heads': 8,
+    'swa_head_dim': 192,
+    'swa_v_head_dim': 128,
+    'swa_rope_theta': 10000,
+    'add_swa_attention_sink_bias': True,
+    'n_routed_experts': 256,
+    'num_experts_per_tok': 8,
+    'moe_intermediate_size': 2048,
+    'intermediate_size': 16384,
+    'moe_layer_freq': [
+        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    ],
+    'hybrid_layer_pattern': [
+        0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1,
+        1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0
+    ],
+    'dtype': 'bfloat16',
+    'quantization_config': {'quant_method': 'fp8'},
+}
+
+
+@pytest.fixture
+def mimo():
+    """Read from the catalogue, as an offline caller does."""
+    return load_spec("mimo-v2.5")
+
+
+@pytest.fixture
+def mimo_cfg():
+    """Read from the checkpoint's own config, as the attach path does."""
+    return MIMO_CONFIG
+
+
+# ── G1: it classifies at all ────────────────────────────────────────────────
+
+
+def test_mimo_classifies_as_hybrid_not_dense(mimo_cfg):
+    """Before the key aliases, ``detect_family`` returned ``dense`` and the
+    planner raised NotImplementedError: ``is_hybrid_moe_config`` wanted
+    ``num_experts`` + ``layer_types`` and MiMo declares neither key, while
+    ``is_sparse_moe_config`` wanted ``index_topk``/``compress_ratios``. The most
+    interesting model in the brief landed in the one family with no reader."""
+    from gitm.planner.registry import detect_family
+
+    assert detect_family(mimo_cfg) == "hybrid"
+
+
+def test_deepseek_v4_still_classifies_as_sparse_moe():
+    """The G1 alias widened ``is_hybrid_moe_config`` to accept
+    ``n_routed_experts`` — which **DeepSeek-V4 also declares**, and
+    ``detect_family`` consults the hybrid predicate first. V4 declares no
+    schedule under either spelling, so it must still fall through. If this ever
+    fails, every V4 prediction is being produced by the wrong graph."""
+    from gitm.planner.registry import detect_family
+
+    assert detect_family(V4_CONFIG) == "sparse_moe"
+
+
+def test_hybrid_layer_pattern_polarity_is_inverted(mimo_cfg):
+    """``hybrid_layer_pattern[i] == 1`` means WINDOWED, the opposite of how
+    ``layer_types`` reads (modeling_mimo_v2.py:400). Reading it the intuitive way
+    swaps 39 layers for 9 — the right node count, a plausible total, and every
+    per-layer residual compared against the wrong mechanism."""
+    spec = hybrid_spec_from_hf_config(mimo_cfg, name="MiMo")
+    full = [i for i in range(spec.n_layers) if spec.is_full_attention(i)]
+    assert full == [0, 5, 11, 17, 23, 29, 35, 41, 47]
+    assert spec.n_sliding_attention_layers == 39
+    assert spec.n_linear_attention_layers == 0
+
+
+def test_no_modulo_rule_reproduces_the_schedule(mimo):
+    """The gaps are 5,6,6,6,6,6,6,6 — layer 0 breaks the stride. This is why the
+    catalogue writes 48 entries out instead of using {pattern, repeat}: an
+    interval of 6 would place full attention at 5,11,...,47 and *miss layer 0*,
+    which is also the only dense-MLP layer."""
+    full = [i for i in range(mimo.n_layers) if mimo.is_full_attention(i)]
+    gaps = [b - a for a, b in zip(full, full[1:], strict=False)]
+    assert gaps == [5, 6, 6, 6, 6, 6, 6, 6]
+    assert 0 in full
+
+
+def test_the_two_readers_agree(mimo, mimo_cfg):
+    """A hand-written YAML and the checkpoint's own config, compared field by
+    field. Drift is what makes a stale catalogue dangerous: it keeps producing
+    confident predictions for a model that changed underneath it."""
+    from dataclasses import fields
+
+    read = hybrid_spec_from_hf_config(mimo_cfg, name=mimo.name)
+    # Fields the config genuinely cannot carry: the MTP head is visible only in
+    # the safetensors index, and the collective count is a TP convention.
+    exempt = {
+        "name",
+        # Visible only as tensors in the safetensors index.
+        "mtp_num_hidden_layers", "mtp_layer_kind", "mtp_dense",
+        # A TP convention and a precision reading, neither declared as a shape.
+        "all_reduces_per_layer", "op_dtype_overrides",
+        # Gated-DeltaNet geometry: MiMo has no recurrent layers, so the reader
+        # leaves these at placeholders rather than demanding fields that govern
+        # no kernel.
+        "linear_num_value_heads", "linear_value_head_dim",
+        "linear_num_key_heads", "linear_key_head_dim", "conv_dim",
+    }
+    differing = {
+        f.name: (getattr(read, f.name), getattr(mimo, f.name))
+        for f in fields(HybridMoEModelSpec)
+        if f.name not in exempt and getattr(read, f.name) != getattr(mimo, f.name)
+    }
+    assert differing == {}
+
+
+def test_mtp_count_is_not_config_derivable(mimo_cfg):
+    """MiMo ships three draft layers and declares them nowhere in config.json —
+    they exist only as tensors in the safetensors index. A reader that invented a
+    count here would predict a head it never saw, so a bare config must yield 0
+    and the catalogue must carry the real number."""
+    assert "mtp_num_hidden_layers" not in mimo_cfg
+    assert hybrid_spec_from_hf_config(mimo_cfg).mtp_num_hidden_layers == 0
+    assert load_spec("mimo-v2.5").mtp_num_hidden_layers == 3
+
+
+# ── G2: the window is a third asymptotic ────────────────────────────────────
+
+
+def test_sliding_window_layers_are_flat_in_context(mimo):
+    """The defining property. A windowed layer reads at most W entries however
+    long the context grows; a full-attention layer's read grows without bound.
+    If these ever move together, the third layer kind has collapsed back into one
+    of the other two."""
+    def core_bytes(kv_len, pred):
+        by_layer = {}
+        for n in pred.nodes:
+            if n.op == "attn_score_value":
+                by_layer[n.layer] = n.prediction.bytes
+        return by_layer
+
+    short = core_bytes(8192, predict_hybrid_graph(
+        mimo, H200, BatchConfig(batch=4, kv_cache_len=8192)))
+    long = core_bytes(131072, predict_hybrid_graph(
+        mimo, H200, BatchConfig(batch=4, kv_cache_len=131072)))
+
+    # 16x the context.
+    assert short[1] == pytest.approx(long[1])          # windowed: unchanged
+    assert long[0] == pytest.approx(short[0] * 16)     # full: grows with it
+
+
+def test_priced_as_unbounded_the_window_costs_64x_too_much(mimo):
+    """The error the window prevents, stated as a number. At 8k context against a
+    128-token window the ratio is exactly kv_len/window."""
+    windowed = predict_hybrid_graph(mimo, H200, BatchConfig(batch=1, kv_cache_len=8192))
+    unwindowed = predict_hybrid_graph(
+        replace(mimo, sliding_window=0), H200, BatchConfig(batch=1, kv_cache_len=8192))
+
+    def swa_core(g):
+        return sum(n.prediction.bytes for n in g.nodes
+                   if n.op == "attn_score_value" and n.layer == 1)
+
+    assert swa_core(unwindowed) / swa_core(windowed) == pytest.approx(8192 / 128)
+
+
+def test_a_windowed_layer_priced_as_linear_would_lose_its_cache_read(mimo):
+    """The §7.2 failure mode: alias the config keys without adding the third kind
+    and MiMo classifies as hybrid, runs, and prices 39 of 48 layers as
+    gated-DeltaNet recurrent state — which is *also* flat in context, so even the
+    qualitative behaviour looks right while the number is wrong and nothing says
+    so. A windowed layer must emit a real cache read."""
+    g = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8, kv_cache_len=8192))
+    swa = [n for n in g.nodes if n.op == "attn_score_value" and n.layer == 1]
+    assert swa and swa[0].prediction.bytes > 0
+    # ...and no recurrent nodes anywhere, since there are no linear layers.
+    assert not [n for n in g.nodes if n.op == "linattn_recurrent"]
+
+
+def test_windowed_prefill_is_banded_not_quadratic():
+    """Prefill's causal triangle becomes a band once a window caps it. At P=8192
+    and W=128 that is 1,040,448 query-key pairs against 33,558,528 — a **32x
+    overcount** on the term that decides whether prefill is compute-bound."""
+    b = BatchConfig(batch=1, kv_cache_len=0, prefill_tokens=8192, prefill_requests=1)
+    assert b.attention_qk_pairs() == 8192 * 8193 / 2          # unwindowed
+    assert b.attention_qk_pairs(window=128) == 1_040_448
+    assert b.attention_qk_pairs() / b.attention_qk_pairs(128) == pytest.approx(32.3, abs=0.1)
+
+
+def test_banded_pair_count_matches_a_brute_force_sum():
+    """The closed form is an optimisation of a sum over tokens; if they ever
+    disagree the closed form is wrong, not the sum."""
+    for p, ctx, w in [(100, 0, 128), (100, 50, 128), (100, 500, 128), (37, 7, 13)]:
+        b = BatchConfig(batch=0, kv_cache_len=0, prefill_tokens=p,
+                        prefill_context=ctx, prefill_requests=1)
+        brute = sum(min(ctx + i + 1, w) for i in range(p))
+        assert b.attention_qk_pairs(window=w) == pytest.approx(brute)
+
+
+# ── G3: geometry, and the direction of its error ────────────────────────────
+
+
+def test_o_proj_input_is_n_heads_times_v_head_dim(mimo):
+    """**The current code OVERSTATES this projection, it does not understate
+    it.** o_proj maps one v_head_dim-wide result per query head back to hidden:
+    64 x 128 = 8192. Using q_dim gives 64 x 192 = 12288, which is 1.5x too
+    *large*.
+
+    The sign is the point. Over-priced, a near-zero residual on this node means a
+    kernel running 1.5x slower than the hardware allows — it reads as healthy
+    when it is not."""
+    assert mimo.o_proj_in == 8192
+    assert mimo.q_dim == 12288
+    assert mimo.q_dim > mimo.o_proj_in          # OVERSTATED, not understated
+    assert mimo.q_dim / mimo.o_proj_in == pytest.approx(1.5)
+
+
+def test_kv_geometry_differs_between_the_two_layer_families(mimo):
+    """8 KV heads on windowed layers against 4 on full-attention ones, and K is
+    192 wide where V is 128. One head count and one width for the model is wrong
+    on 39 of 48 layers — and this is the KV rate, the quantity decode is bound
+    by."""
+    assert mimo.attn_geometry(0) == (64, 4, 192, 128)     # full
+    assert mimo.attn_geometry(1) == (64, 8, 192, 128)     # windowed
+    assert mimo.kv_entry_elems(0) == 1280
+    assert mimo.kv_entry_elems(1) == 2560
+
+
+def test_kv_rate_splits_growing_from_fixed(mimo):
+    """9 layers linear in S, 39 flat: ``11,520 x S + 12.78M`` elements. Counting
+    the windowed layers per-token inflates the rate ~9.7x and caps concurrency
+    far below what the hardware allows."""
+    kw = weight_bytes(mimo.kv_dtype)
+    assert hybrid_kv_bytes_per_token(mimo) / kw == pytest.approx(9 * 1280)
+    assert hybrid_kv_bytes_per_token(mimo) / kw == pytest.approx(11_520)
+    assert hybrid_kv_fixed_bytes(mimo) / kw == pytest.approx(39 * 2560 * 128)
+
+
+def test_mimo_predicted_weights_land_near_the_published_checkpoint(mimo):
+    """308.85 GB against the index's total_size of 315.03 GB, -2.0%. The residual
+    is the two encoders, the MTP head and per-tensor metadata, none of which this
+    spec enumerates — the same class of gap as -2.4% on V4 and -3.3% on Qwen."""
+    whole = hybrid_model_weight_bytes(mimo, ShardingConfig(tp=1))
+    assert whole / 315.031102208e9 == pytest.approx(1.0, abs=0.04)
+
+
+def test_weight_footprint_would_double_at_the_wrong_dtype(mimo):
+    """MiMo stores fp8 weights under a ``bfloat16`` torch dtype. The reader used
+    to take the torch dtype for weights, because every previous member of this
+    family was bf16 throughout — which prices the whole checkpoint at 2 bytes and
+    predicts 617 GB against a 315 GB index."""
+    assert mimo.weight_dtype == "fp8"
+    assert mimo.act_dtype == "bf16"
+    wrong = hybrid_model_weight_bytes(replace(mimo, weight_dtype="bf16"),
+                                      ShardingConfig(tp=1))
+    right = hybrid_model_weight_bytes(mimo, ShardingConfig(tp=1))
+    assert wrong / right == pytest.approx(2.0, abs=0.01)
+
+
+# ── G5: three precisions in one block ───────────────────────────────────────
+
+
+def test_three_precisions_inside_one_attention_block(mimo):
+    """fp8 qkv_proj, bf16 o_proj (in ``ignored_layers``, no scale tensor
+    anywhere), fp32 router (an explicit ``.float()`` cast). One weight_dtype for
+    the model prices o_proj at 1 byte when it is 2."""
+    g = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8, kv_cache_len=4096))
+    seen = {n.op: n.prediction.dtype for n in g.nodes}
+    assert seen["qkv_proj"] == "fp8"
+    assert seen["attn_out_proj"] == "bf16"
+    assert seen["moe_router"] == "fp32"
+    assert seen["lm_head"] == "bf16"
+
+
+def test_an_fp32_router_prices_against_an_fp32_peak(mimo):
+    """Unlike a missing fp8 peak, a missing fp32 one is **not flagged** —
+    ``resolve_peak`` returns the field directly, so ``peak_is_fallback`` stays
+    False and the wrong ceiling looks measured. Without an H200 fp32 entry the
+    router priced against A100's 19.5 TF/s: 3.4x slow, enough to move it from
+    5th to 3rd in the ranked node table."""
+    hw = hardware_spec_for(peak_for_sku("H200"))
+    assert hw.peak_flops_fp32_per_s == pytest.approx(67e12)
+    g = predict_hybrid_graph(mimo, hw, BatchConfig(batch=32, kv_cache_len=8192))
+    router = next(n for n in g.nodes if n.op == "moe_router")
+    assert router.prediction.peak_flops_per_s == pytest.approx(67e12)
+    assert not router.prediction.peak_is_fallback
+
+
+# ── G7: the dense layer and the draft head ──────────────────────────────────
+
+
+def test_layer_zero_is_dense_and_runs_no_router(mimo):
+    """MiMo's layer 0 has a 16384-wide dense MLP, not a mixture. Charging it a
+    256-expert router and an expert bank it does not have is not a rounding
+    error: the expert term dominates the layer."""
+    g = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8, kv_cache_len=4096))
+    layer0 = {n.op for n in g.nodes if n.layer == 0}
+    assert "mlp_gate_up" in layer0 and "mlp_down" in layer0
+    assert "moe_router" not in layer0 and "moe_routed" not in layer0
+    # ...and exactly 47 of the 48 layers do have a mixture.
+    assert len([n for n in g.nodes if n.op == "moe_routed"]) == 47
+
+
+def test_the_draft_head_is_windowed_and_dense(mimo):
+    """Three errors the old MTP path made at once: ``_emit_moe`` unconditionally
+    (the expert-free draft charged a 256-expert router), ``layer_kind`` running
+    off the end of ``layer_types`` and returning layer 47's FULL attention (an
+    O(1)-in-S head priced with a cache growing in S), and one ``lm_head`` for the
+    whole step."""
+    g = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8, kv_cache_len=4096),
+                             with_mtp=True)
+    draft = [n for n in g.nodes if n.layer is not None and n.layer >= mimo.n_layers]
+    assert draft, "no draft nodes emitted"
+    ops = {n.op for n in draft}
+    assert "mlp_gate_up" in ops and "moe_routed" not in ops
+    assert mimo.layer_kind(mimo.n_layers) == "sliding_attention"
+
+
+def test_the_draft_head_is_flat_in_context(mimo):
+    """The consequence of the kind being right. Priced as full attention the
+    draft's cache read grows with S; it is windowed, so it does not."""
+    def draft_core(kv):
+        g = predict_hybrid_graph(mimo, H200, BatchConfig(batch=4, kv_cache_len=kv),
+                                 with_mtp=True)
+        return sum(n.prediction.bytes for n in g.nodes
+                   if n.op == "attn_score_value" and n.layer >= mimo.n_layers)
+
+    assert draft_core(8192) == pytest.approx(draft_core(131072))
+
+
+def test_one_lm_head_per_draft_stage(mimo):
+    """Each stage samples a token before the next can consume it, so each runs
+    its own vocabulary projection. Emitting one for the whole step leaves D of
+    them unmodelled — ~312 MB of weight traffic per missing stage at TP4."""
+    sh = ShardingConfig(tp=4)
+    plain = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8), sh)
+    with_mtp = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8), sh, with_mtp=True)
+    assert len([n for n in plain.nodes if n.op == "lm_head"]) == 1
+    assert len([n for n in with_mtp.nodes if n.op == "lm_head"]) == 1 + 3
+
+
+# ── G6: the one edge that is genuinely required ─────────────────────────────
+
+
+def test_the_draft_chain_is_serial_but_the_backbone_is_not(mimo):
+    """MiMo puts both kinds of serialisation in one step: the MTP chain is
+    genuinely serial (stage i+1 cannot begin before stage i), the 96 all-reduces
+    are not — and today both show up as the same positive residual. Edges are
+    declared only where the evidence is; with none declared the critical path is
+    the sum, which is the honest answer."""
+    plain = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8))
+    assert not any(n.depends_on for n in plain.nodes)
+    assert plain.serial_chain_s == 0.0        # nothing claimed, nothing declared
+
+    mtp = predict_hybrid_graph(mimo, H200, BatchConfig(batch=8), with_mtp=True)
+    assert any(n.depends_on for n in mtp.nodes)
+    # A floor on the serial part, NOT an estimate of the step: unedged nodes are
+    # unconstrained, not known-parallel. Reading this as a step time would treat
+    # the whole backbone as infinitely overlappable.
+    assert 0 < mtp.serial_chain_s < mtp.total_pred_s
+
+
+# ── the collective count, without moving the bytes ──────────────────────────
+
+
+def test_two_all_reduce_nodes_move_the_same_bytes_as_one_did(mimo):
+    """A7 says 96 all-reduces per step (2 per layer x 48); the graph emitted 48.
+    But the BYTES were already right — the expression carried a leading 2.0 for
+    the second reduction. Splitting them must leave the total invariant, or every
+    predicted collective doubles. This is the likeliest way to break the thing
+    while 'fixing' it."""
+    sh = ShardingConfig(tp=4)
+    b = BatchConfig(batch=32, kv_cache_len=8192)
+    two = predict_hybrid_graph(mimo, H200, b, sh)
+    one = predict_hybrid_graph(replace(mimo, all_reduces_per_layer=1), H200, b, sh)
+
+    def coll(g):
+        ns = [n for n in g.nodes if n.op == "tp_all_reduce"]
+        return len(ns), sum(n.prediction.bytes for n in ns)
+
+    n_two, bytes_two = coll(two)
+    n_one, bytes_one = coll(one)
+    assert n_two == 2 * n_one == 96
+    assert bytes_two == pytest.approx(bytes_one)
+
+
+def test_qwen_keeps_one_all_reduce_per_layer():
+    """The field defaults to the long-standing behaviour. Raising it for every
+    model would perturb kernel-to-node alignment on checkpoints nobody has
+    counted NCCL kernels for."""
+    q = load_spec("qwen3.6-35b-a3b")
+    assert q.all_reduces_per_layer == 1
+    g = predict_hybrid_graph(q, H200, BatchConfig(batch=8), ShardingConfig(tp=4))
+    assert len([n for n in g.nodes if n.op == "tp_all_reduce"]) == q.n_layers
+
+
+# ── the regression guard ────────────────────────────────────────────────────
+
+
+def test_new_geometry_fields_are_a_no_op_when_unset():
+    """Every G2/G3 expression must reduce algebraically to the one it replaced
+    when the new fields are unset. This is what makes the change safe for the
+    checkpoints already in the catalogue, and it is checked rather than argued."""
+    q = load_spec("qwen3.6-35b-a3b")
+    assert q.v_head_dim is None
+    assert q.o_proj_in == q.q_dim == 4096
+    assert q.kv_entry_elems(0) == 2 * q.kv_dim
+    assert q.sliding_window == 0
+    assert all(q.attention_window(i) == 0 for i in range(q.n_layers))
+    assert q.dtype_for("attn_out_proj", "bf16") == "bf16"
+    assert q.n_sliding_attention_layers == 0
+    # The reference shape too — it sets none of the new fields either.
+    r = HybridMoEModelSpec()
+    assert r.o_proj_in == r.q_dim
+    assert r.kv_entry_elems(0) == 2 * r.kv_dim
+
+
+def test_the_spec_stays_hashable(mimo):
+    """The dataclass is frozen and therefore hashable, and a Mapping field would
+    make ``hash(spec)`` raise — a long way from the YAML that caused it. Hence
+    the tuple-of-pairs for the dtype overrides and the frozenset for the dense
+    layers."""
+    assert hash(mimo)
+    assert isinstance(mimo.op_dtype_overrides, tuple)
+    assert isinstance(mimo.dense_layers, frozenset)
+
+
+# ── end to end ──────────────────────────────────────────────────────────────
+
+
+def test_mimo_decode_is_dominated_by_expert_weight_traffic(mimo):
+    """The shape of the answer, not just its parts. At batch 32 the union of
+    distinct experts the step must fetch is the overwhelming majority of the
+    step, and it is memory-bound."""
+    hw = hardware_spec_for(peak_for_sku("H200"))
+    g = predict_hybrid_graph(mimo, hw, BatchConfig(batch=32, kv_cache_len=8192),
+                             ShardingConfig(tp=4))
+    routed = sum(n.prediction.t_pred_s for n in g.nodes if n.op == "moe_routed")
+    assert routed / g.total_pred_s > 0.85
+    assert all(n.prediction.bound == "memory"
+               for n in g.nodes if n.op == "moe_routed")
+
+
+def test_prefill_flips_the_step_compute_bound(mimo):
+    """Decode is memory-bound on the expert bank; an 8192-token prefill chunk is
+    compute-bound on the same weights, because the arithmetic scales with tokens
+    while the weight fetch does not."""
+    hw = hardware_spec_for(peak_for_sku("H200"))
+    sh = ShardingConfig(tp=4)
+    dec = predict_hybrid_graph(mimo, hw, BatchConfig(batch=32, kv_cache_len=8192), sh)
+    pre = predict_hybrid_graph(mimo, hw, BatchConfig(
+        batch=1, kv_cache_len=0, prefill_tokens=8192, prefill_requests=1), sh)
+
+    def routed_bound(g):
+        return {n.prediction.bound for n in g.nodes if n.op == "moe_routed"}
+
+    assert routed_bound(dec) == {"memory"}
+    assert routed_bound(pre) == {"compute"}
+
+
+def test_mimo_step_time_is_strongly_sublinear_in_batch(mimo):
+    """The MoE property: 32x the tokens for well under 32x the time, because
+    weight traffic follows the *distinct* experts touched and that saturates."""
+    hw = hardware_spec_for(peak_for_sku("H200"))
+    sh = ShardingConfig(tp=4)
+    t1 = predict_hybrid_graph(mimo, hw, BatchConfig(batch=1, kv_cache_len=8192), sh)
+    t32 = predict_hybrid_graph(mimo, hw, BatchConfig(batch=32, kv_cache_len=8192), sh)
+    assert t32.total_pred_s / t1.total_pred_s < 32 / 2
+
+
+# ── import hygiene between the two families ──────────────────────────────────
+
+
+def _colliding_planner_names() -> set[str]:
+    """Public top-level names defined in BOTH planner graph modules.
+
+    Derived from the source, not hardcoded, so a collision introduced later is
+    caught by the same test rather than needing this list updated.
+    """
+    import ast
+    from pathlib import Path
+
+    planner = Path(__file__).resolve().parent.parent / "gitm" / "planner"
+
+    def public_tops(module: str) -> set[str]:
+        tree = ast.parse((planner / f"{module}.py").read_text(encoding="utf-8"))
+        return {
+            n.name for n in tree.body
+            if isinstance(n, ast.FunctionDef | ast.ClassDef)
+            and not n.name.startswith("_")
+        }
+
+    return public_tops("hybrid_graph") & public_tops("moe_graph")
+
+
+def test_the_two_families_still_collide_on_names():
+    """If this ever comes back empty the guard below is protecting nothing.
+
+    Four functions exist in both families with the same name and different
+    meanings — they take different spec types and answer different questions.
+    That is not itself a defect: each is the right name inside its own module.
+    It only becomes a defect at an import site that pulls both in.
+    """
+    assert _colliding_planner_names() >= {
+        "kv_bytes_per_token",
+        "kv_fixed_bytes_per_sequence",
+        "model_weight_bytes",
+        "spec_from_hf_config",
+    }
+
+
+def test_no_module_imports_a_colliding_planner_name_unaliased():
+    """A file that imports from BOTH planner families must alias the collisions.
+
+    ``from gitm.planner.hybrid_graph import kv_bytes_per_token`` and its
+    sparse-MoE twin bind the same name. Whichever is imported second silently
+    wins for the whole module, and every call afterwards runs against the wrong
+    family — producing a number rather than an error.
+
+    **This is not hypothetical.** It happened in this file: a bare
+    ``kv_fixed_bytes_per_sequence`` was shadowed by the sparse-MoE version, and a
+    MiMo assertion called into ``moe_graph`` and raised
+    ``AttributeError: 'HybridMoEModelSpec' object has no attribute
+    'compress_ratio'``. That one failed loudly because the two specs have
+    different fields; ``kv_bytes_per_token`` would have returned a plausible
+    float instead.
+
+    Aliasing was already the documented convention. A convention that has been
+    violated once is worth a test — this is the mechanical version.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    colliding = _colliding_planner_names()
+    families = {"gitm.planner.hybrid_graph", "gitm.planner.moe_graph"}
+    offences = []
+
+    for path in list((root / "gitm").rglob("*.py")) + list((root / "tests").rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        # Every unaliased binding of a colliding name, grouped by name.
+        bare: dict[str, list[str]] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module not in families:
+                continue
+            for alias in node.names:
+                if alias.name in colliding and alias.asname is None:
+                    bare.setdefault(alias.name, []).append(
+                        f"{node.module.rsplit('.', 1)[-1]}:{node.lineno}"
+                    )
+
+        # ONE bare binding is a deliberate default - the file has chosen which
+        # family that name means. TWO is shadowing: the second silently wins for
+        # the whole module, and every call written before it now runs against
+        # the wrong family.
+        for name, sites in bare.items():
+            if len(sites) > 1:
+                offences.append(
+                    f"{path.relative_to(root).as_posix()}: {name!r} bound "
+                    f"unaliased {len(sites)}x ({', '.join(sites)})"
+                )
+
+    assert not offences, (
+        "a colliding planner name is bound unaliased more than once in the "
+        "same file, so the family it resolves to depends on import order:"
+        + "; ".join(offences)
+    )
+
+
+def test_no_test_module_defines_the_same_test_name_twice():
+    """The same shadowing hazard, one level up: two ``def test_x`` in one file.
+
+    Python keeps the later definition and discards the earlier one, so pytest
+    collects one test and reports green while the other stops running. Nothing
+    fails and nothing warns — the count just quietly drops.
+
+    **This is not hypothetical either.** It happened in this file: the MiMo
+    additions reused ``test_predicted_weights_land_near_the_published_checkpoint``
+    and ``test_step_time_is_strongly_sublinear_in_batch``, silently retiring the
+    Qwen footprint check and the sparse-MoE batch curve — the Qwen one being the
+    exact counterpart of the arithmetic the MiMo work was changing.
+    """
+    import ast
+    from collections import Counter
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    offences = []
+
+    for path in sorted((root / "tests").rglob("test_*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        # Module scope only: a name inside a class or function shadows nothing
+        # that pytest would otherwise have collected.
+        names = Counter(
+            n.name
+            for n in tree.body
+            if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)
+            and n.name.startswith("test_")
+        )
+        offences += [
+            f"{path.relative_to(root).as_posix()}: {name!r} defined {count}x"
+            for name, count in sorted(names.items())
+            if count > 1
+        ]
+
+    assert not offences, (
+        "a test name is defined more than once at module scope, so only the "
+        "last definition runs and the earlier one is silently dead: "
+        + "; ".join(offences)
+    )


### PR DESCRIPTION
## MiMo

Adds Xiaomi MiMo-V2.5 to the planner and closes §7's seven planner gaps (G1–G7).

MiMo fitted none of the three model families — `detect_family` returned `dense`
and the planner raised `NotImplementedError`. It is a 48-layer hybrid of full
attention (9 layers) and sliding-window attention (39 layers, W=128) over a
256-expert top-8 MoE, with GQA geometry that differs between the two layer
families, one dense MLP at layer 0, three dense SWA draft layers, and three
precisions inside a single attention block.

Hosted in `hybrid_graph.py` rather than `moe_graph.py`: `moe_graph`'s node set
(MLA latent, lightning indexer, mHC, DSpark) does not describe MiMo, while
`hybrid_graph`'s does op for op — and G7's three bugs were live defects there
that needed fixing regardless.

**G8 (prefill) needed no work.** #94–96 landed it upstream; MiMo inherits it. The
only prefill work here is G2's windowed `qk_pairs`.

## The gaps

| gap                         | what changed                                                                                                                                                                                                                                                                       |
| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **G1** detector       | `is_hybrid_moe_config` learns `n_routed_experts` and `hybrid_layer_pattern` as aliases. The pattern's polarity is **inverted** from `layer_types` (`1` means windowed) — reading it the intuitive way swaps 39 layers for 9 and still produces a plausible total. |
| **G2** sliding window | `SLIDING_ATTENTION` as a third layer kind. `reads_kv_cache` asks *cache or not*; `attention_window` asks *how much*. Windowed prefill is banded, not quadratic — 1,040,448 QK pairs against 33,558,528, a **32.3× overcount**.                                   |
| **G3** geometry       | Per-layer`v_head_dim` and the `swa_*` widths. `o_proj`'s input is `n_heads * v_head_dim` (8192), not `q_dim` (12288).                                                                                                                                                    |
| **G4** reporting      | `bound` rolled up from the nodes instead of recomputed; per-dtype ridge; `--launch-overhead`.                                                                                                                                                                                  |
| **G5** precision      | `op_dtype_overrides`, consulted by every emitted node.                                                                                                                                                                                                                           |
| **G6** dependencies   | `PredictedNode.depends_on` and `Graph.serial_chain_s`, populated for the MTP draft chain only. Not a scheduler.                                                                                                                                                                |
| **G7** dense / MTP    | `dense_layers` with a real `_emit_dense_mlp`, `mtp_layer_kind`, one `lm_head` per draft stage.                                                                                                                                                                             |

Fixed at source

- **The reader never read `quantization_config`.** MiMo stores fp8 weights under
  a `bfloat16` torch dtype, so the whole checkpoint priced at 2 bytes and the
  footprint came out 617 GB against a 315 GB index. Correct for every previous
  member of the family, all bf16 throughout.
- **`predict_hybrid_graph` refused TP4** because `linear_num_value_heads % 4 != 0`
  — on a model with no linear layers at all. The guard is now scoped to models
  that have them.
- **fp32 SKU peaks.** Pricing the router at fp32 exposed that no SKU carried an
  fp32 peak, so it fell back to A100's 19.5 TF/s against H200's 67. Unlike a
  missing fp8 peak this is **not flagged** — `peak_is_fallback` stays False and
  the wrong ceiling looks measured.

## Verification

**32 new tests**, each pinning a specific wrong number the gap would otherwise
produce. Cross-checks that hold exactly:

| check                        | predicted           | reference                            |
| ---------------------------- | ------------------- | ------------------------------------ |
| weight footprint             | 308.85 GB           | 315.03 GB (index) —**−2.0%** |
| KV growing rate              | 11,520 elem/token   | exact                                |
| KV fixed                     | 12,779,520 elem/seq | exact                                |
| full-attention layers        | `[0,5,11,…,47]`  | exact                                |
| `Lfull`/`Lswa` attention | **32.0×**    | `(8192×4)/(128×8)`               |
| banded prefill pairs         | 1,040,448           | brute force                          |

Decode B=32/S=8192/TP4: **10.81 ms**, 2,960 tok/s, 385 nodes, `moe_routed` 93%
and memory-bound. Prefill 8192-token chunk: **60.58 ms**, every dominant node
compute-bound — same weights, opposite bound. Batch 1 → 512: 512× the tokens for
**30×** the time.

`ruff check .` passes. The 11 remaining full-suite failures are pre-existing —
verified by reproducing the identical list on clean `edcb02b` — and are missing
optional deps plus two importer goldens. None are in the planner.

## Test hygiene, found along the way

**Two upstream tests were silently dead.** The MiMo additions reused
`test_predicted_weights_land_near_the_published_checkpoint` and
`test_step_time_is_strongly_sublinear_in_batch`, both already defined at module
scope. Python keeps the later definition, so pytest collected one of each and
reported green while Qwen's footprint check and the sparse-MoE batch curve
stopped running — the Qwen one being the direct counterpart of the arithmetic
the `quantization_config` fix changed.

Renamed the new ones, and added
`test_no_test_module_defines_the_same_test_name_twice`, which walks every
`tests/test_*.py` at module scope and fails on a repeated `def test_x`. Its
sibling `test_no_module_imports_a_colliding_planner_name_unaliased` catches
shadowing *between* modules and could never have caught this one.

**MiMo's config is inlined** as `MIMO_CONFIG`, trimmed to the keys the reader
consults and verified spec-identical to the full checkpoint config — the
`V4_CONFIG` convention already in the file. It previously read an absolute path
on one developer's disk, which left four tests skipping everywhere else,
including G1's classifier and the inverted-polarity check. The file now has zero
skips. `test_the_two_readers_agree` compares every non-exempt spec field against the catalogue YAML, so a key lost in trimming fails loudly.
