### PR TITLE
rocm tracer port + mi355x kimi k2.5 deploy

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,0 +1,48 @@
+# GITM reproducible runtime image — ROCm variant, for MI300X/MI355X hosts.
+#
+# Same contract as the CUDA Dockerfile: build ONCE, push, share the *digest*.
+# The base must be a ROCm >= 6.2 image (rocprofiler-sdk is the tracer's
+# collection API); MI355X (gfx950) needs ROCm 7.x. Keep the ROCm minor version
+# aligned with the serving image the tracer tool gets copied into
+# (deploy/k8s/mi355x-kimi.yaml copies libgitm_rocm_inject.so across containers,
+# so its rocprofiler-sdk ABI must match the serving runtime's).
+#
+#   docker build -f Dockerfile.rocm -t <registry>/gitm-rocm:<tag> .
+#   docker push <registry>/gitm-rocm:<tag>
+#   docker inspect --format='{{index .RepoDigests 0}}' <registry>/gitm-rocm:<tag>
+
+FROM rocm/pytorch:latest
+# ^ Pin to a dated tag before the first shared build (e.g. a rocm7.x_ubuntu24.04
+# _py3.12 tag); "latest" is only acceptable until the digest is frozen.
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    ROCM_PATH=/opt/rocm \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /opt/gitm
+
+# The package + its CPU deps, pinned via constraints.txt for reproducibility.
+# No [nvidia] extra here — torch/ROCm comes from the base image.
+COPY pyproject.toml constraints.txt README.md ./
+COPY gitm ./gitm
+COPY benchmarks ./benchmarks
+COPY tests ./tests
+COPY docs ./docs
+COPY scripts ./scripts
+RUN python -m pip install -e ".[dev,bench]" -c constraints.txt
+
+# Build the ROCm tracer tool against this image's rocprofiler-sdk.
+RUN python -m gitm.tracer._rocm.build
+
+# Freeze the fully-resolved stack into the image for auditing / exact re-pin.
+RUN python -m pip freeze > /opt/gitm/requirements.lock
+
+# Same sealed/least-privilege runtime as the CUDA image: uid 10001, no root.
+# GPU access comes from the device plugin's mounts + the pod's video/render
+# supplementalGroups, not from privilege here.
+RUN useradd --create-home --uid 10001 gitm \
+    && chown -R gitm:gitm /opt/gitm
+USER gitm
+
+CMD ["./scripts/verify_infra.sh"]

--- a/deploy/k8s/mi355x-kimi.yaml
+++ b/deploy/k8s/mi355x-kimi.yaml
@@ -1,0 +1,199 @@
+# Kimi K2.5 on 8x MI355X with the GITM ROCm tracer — one `kubectl apply -f` unit.
+#
+# Architecture (one pod, because the tracer's arming protocol requires it):
+#
+#   initContainer  gitm-tool     copies libgitm_rocm_inject.so (built into the
+#                                gitm ROCm image) into the shared volume, so the
+#                                serving image needs no gitm install.
+#   container      sglang        serves Kimi K2.5; ROCP_TOOL_LIBRARIES makes the
+#                                HIP runtime load our collector into EVERY
+#                                process it spawns (scheduler + TP workers).
+#                                Writes trace shards to /scratch — only while
+#                                armed, so an idle server writes nothing.
+#   container      gitm          the harness. `kubectl exec` into it to run
+#                                benchmarks; gitm.tracer.capture() arms the
+#                                window by touching /scratch/trace/kimi.jsonl.arm
+#                                and merges the per-pid shards on close. Shard
+#                                and arm files must be the SAME files the server
+#                                sees — hence the shared emptyDir, hence one pod.
+#
+# Cluster prerequisites (once per cluster, not part of this file):
+#   * AMD GPU device plugin (exposes amd.com/gpu):
+#       kubectl create -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+#   * A StorageClass able to provision RWO volumes >= 1.5Ti for the weights
+#     (Kimi K2.5 is ~600GB+ at its native precision; first pull is slow — the
+#     PVC keeps it across pod restarts).
+#
+# Before applying, replace:
+#   * REGISTRY/gitm-rocm@sha256:...   build from Dockerfile.rocm, pin by digest
+#   * SGLANG_IMAGE                    a ROCm gfx950 (MI35x) SGLang build — check
+#                                     lmsysorg/sglang -rocm / rocm/sgl-dev tags;
+#                                     ROCm minor version should match the gitm
+#                                     image so the copied tool's rocprofiler-sdk
+#                                     ABI matches the runtime's.
+#   * MODEL_ID                        confirm against `GET /v1/models` once up.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitm-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kimi-weights
+  namespace: gitm-system
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1536Gi
+  # storageClassName: <set for your cluster>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-k25-mi355x
+  namespace: gitm-system
+  labels:
+    app: kimi-k25
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate   # 8 GPUs + a 1.5Ti RWO volume: never two pods at once
+  selector:
+    matchLabels:
+      app: kimi-k25
+  template:
+    metadata:
+      labels:
+        app: kimi-k25
+    spec:
+      automountServiceAccountToken: false
+      # Required for correctness, not convenience: injection.clear_stale_shards
+      # decides whether a shard's owning process is alive with os.kill(pid, 0).
+      # Without a shared pid namespace the gitm container cannot see the
+      # server's pids, judges every live shard stale, and unlinks the file out
+      # from under a writing EngineCore — the empty-trace failure mode the
+      # injection docstring documents.
+      shareProcessNamespace: true
+      securityContext:
+        # /dev/kfd and /dev/dri (mounted by the device plugin) are group
+        # video/render on ROCm hosts.
+        supplementalGroups: [44, 110]
+      volumes:
+        - name: weights
+          persistentVolumeClaim:
+            claimName: kimi-weights
+        - name: scratch          # trace shards + arm file + the copied tool
+          emptyDir: {}
+        - name: dshm             # RCCL/tensor-parallel shared memory
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Gi
+      initContainers:
+        - name: gitm-tool
+          image: REGISTRY/gitm-rocm@sha256:REPLACE_WITH_DIGEST
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              mkdir -p /scratch/lib /scratch/trace
+              cp "$(python -c 'from gitm.tracer._rocm import lib_path; print(lib_path())')" /scratch/lib/
+          volumeMounts:
+            - name: scratch
+              mountPath: /scratch
+      containers:
+        - name: sglang
+          image: SGLANG_IMAGE
+          command: ["python3", "-m", "sglang.launch_server"]
+          args:
+            - --model-path=$(MODEL_ID)
+            - --tp=8
+            - --trust-remote-code
+            - --host=0.0.0.0
+            - --port=8000
+            # Kimi K2.5's MTP head, via SGLang's NextN-style speculative path.
+            # Without these the server decodes autoregressively and streams
+            # avg_decoded_tokens_per_iter: 1.0 — plain decode, no spec decode
+            # experiment. Acceptance shows up in that same field (>1.0).
+            - --speculative-algorithm=NEXTN
+            - --speculative-num-steps=1
+            - --speculative-eagle-topk=1
+            - --speculative-num-draft-tokens=2
+          env:
+            - name: MODEL_ID
+              value: moonshotai/Kimi-K2.5
+            - name: HF_HOME
+              value: /weights/hf
+            # --- GITM tracer hook. Dormant until the gitm container arms. ---
+            # The HIP runtime (rocprofiler-register) loads this tool into every
+            # process that initializes HIP — the AMD equivalent of
+            # CUDA_INJECTION64_PATH, inherited by all TP worker children.
+            - name: ROCP_TOOL_LIBRARIES
+              value: /scratch/lib/libgitm_rocm_inject.so
+            - name: GITM_TRACE_OUT
+              value: /scratch/trace/kimi.jsonl
+            # Correlation (HIP-API + rocTX records) costs real throughput.
+            # Leave it "0" for clean perf numbers; set "1" only for the runs
+            # whose job is layer/op attribution, and restart the pod — it is
+            # read once at HIP init. (No NVTX_INJECTION64_PATH analog exists:
+            # rocTX flows through the same tool.)
+            - name: GITM_TRACE_NVTX
+              value: "0"
+          ports:
+            - containerPort: 8000
+          resources:
+            limits:
+              amd.com/gpu: 8
+          volumeMounts:
+            - name: weights
+              mountPath: /weights
+            - name: scratch
+              mountPath: /scratch
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet: { path: /health, port: 8000 }
+            # ~600GB of weights: allow up to 60min for first load from cold PVC
+            periodSeconds: 30
+            failureThreshold: 120
+          readinessProbe:
+            httpGet: { path: /health, port: 8000 }
+            periodSeconds: 10
+        - name: gitm
+          image: REGISTRY/gitm-rocm@sha256:REPLACE_WITH_DIGEST
+          # The harness idles; runs are launched by hand (or by a Job) with:
+          #   kubectl exec -it deploy/kimi-k25-mi355x -c gitm -- \
+          #     python -m gitm.bench ... --endpoint http://localhost:8000
+          # capture() arms/merges against the same /scratch the server writes.
+          command: ["sleep", "infinity"]
+          env:
+            - name: GITM_TRACE_OUT
+              value: /scratch/trace/kimi.jsonl
+            - name: GITM_SCRATCH
+              value: /scratch
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            limits:
+              cpu: "8"
+              memory: 32Gi
+          volumeMounts:
+            - name: scratch
+              mountPath: /scratch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25
+  namespace: gitm-system
+spec:
+  selector:
+    app: kimi-k25
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/docs/rocm.md
+++ b/docs/rocm.md
@@ -1,0 +1,109 @@
+# ROCm / MI355X port — tracer + Kimi K2.5 deployment
+
+How the GITM experiments run on AMD (MI300X/MI355X), what maps to what, and the
+bring-up order on a fresh box. The NVIDIA path is unchanged; everything here is
+additive.
+
+## Mechanism map
+
+| NVIDIA | AMD | Notes |
+|---|---|---|
+| CUPTI Activity API | rocprofiler-sdk buffer tracing | ROCm ≥ 6.2; MI355X ships ROCm 7.x. `roctracer`/`rocprofiler` v1 are the deprecated predecessors — we do not use them. |
+| `CUDA_INJECTION64_PATH` | `ROCP_TOOL_LIBRARIES` | Same follows-children property: the HIP runtime (via rocprofiler-register) dlopens the tool in **every** process that initializes HIP, so vLLM/SGLang engine-core children are covered. Colon-separated list, unlike the single NVIDIA path. |
+| `libgitm_inject.so` | `libgitm_rocm_inject.so` | Built by `python -m gitm.tracer._rocm.build`. Emits the identical per-pid JSONL shards; `injection.read_shards` and `_cupti_decode` are shared, unmodified. |
+| NVTX + `NVTX_INJECTION64_PATH` | rocTX (no extra env var) | The B200 gotcha does not exist on AMD: markers are a tracing service of the same tool, so `GITM_TRACE_NVTX=1` alone enables correlation. `torch.cuda.nvtx.range_push` maps to `roctxRangePushA` under ROCm — vLLM's layerwise instrumentation works untouched. |
+| `CUPTI_ACTIVITY_KIND_RUNTIME` + `DRIVER` | `HIP_RUNTIME_API` service | HIP has no runtime/driver split; hipBLASLt and torch both launch through the HIP runtime, so one service covers what needed two kinds (and one painful lesson) on NVIDIA. |
+| kernel name on the activity record | `CODE_OBJECT` callback at load | Dispatch records carry only a `kernel_id`; the tool keeps an id→name map from code-object load callbacks. A tool attached after load would see anonymous kernels — irrelevant under injection, which is registered before HIP init. |
+| `cuptiGetTimestamp` (window clock) | `rocprofiler_get_timestamp` via ctypes | `injection.clock_now()` dispatches on the active vendor. Same-domain guarantee is load-bearing: a wrong clock silently windows out the whole trace. |
+| SYNCHRONIZATION records | — none | rocprofiler-sdk has no sync activity kind. AMD traces carry no `sync` events; consumers already tolerate absence. |
+| `registers_per_thread` | arch VGPR count | Taken from the code-object symbol; the AMD occupancy-limiting analog. |
+| dropped records: no signal | `drop_count` per buffer | The counter CUPTI never gave us. Emitted in-band as `{"kind":"meta","dropped_records":N}`; `read_shards` warns if non-zero, so a lossy AMD trace is *detectable* (the NVIDIA NVTX-lossiness question stays open). |
+
+Semantics normalized in the tool so downstream sees one schema:
+
+* **grid** — dispatch records report work-items (HSA convention); the tool
+  divides by workgroup size so `KernelEvent.grid_*` means blocks on both vendors.
+* **roctx has no range ids** — push/pop pairing is a per-thread stack in the
+  tool, ids synthesized from one atomic counter; `pair_markers` joins the halves
+  exactly as on NVIDIA.
+* **copy kinds** — mapped onto the CUPTI `CUpti_ActivityMemcpyKind` ints the
+  decoder already speaks.
+
+## Bring-up on a fresh MI355X box (bare, no k8s)
+
+```bash
+# 0) sanity: GPUs + sdk present
+rocm-smi
+ls /opt/rocm/include/rocprofiler-sdk/rocprofiler.h /opt/rocm/lib/librocprofiler-sdk.so*
+
+# 1) build the tool
+python -m gitm.tracer._rocm.build
+
+# 2) render the run env (note: no NVTX_INJECTION64_PATH on AMD)
+python - <<'EOF'
+from gitm.tracer.injection import run_env
+for k, v in run_env("/tmp/gitm/trace.jsonl", nvtx=True).items():
+    print(f"export {k}={v}")
+EOF
+
+# 3) smoke test: export the env, run any small torch/HIP workload while a
+#    second shell arms the window via gitm.tracer.capture(); confirm the shard
+#    $GITM_TRACE_OUT.<pid> fills with kernel records whose names resolve.
+```
+
+Verify during the smoke test, in order:
+
+1. **Tool loads**: the shard file appears at HIP init (even empty). If not,
+   check `ROCP_TOOL_LIBRARIES` is absolute and the process actually initializes
+   HIP.
+2. **Clock domain**: `injection.clock_now()` in the parent must land inside the
+   span of the shard's kernel timestamps. If the window filter returns empty on
+   a shard that clearly has records, this is the first suspect.
+3. **Correlation**: with `GITM_TRACE_NVTX=1` and a `torch.cuda.nvtx` range
+   around the launches, kernels inside the range must come back with `range_op`
+   set. This proves the roctx → marker-service path end to end.
+4. **Loss**: no `meta`/`dropped_records` warnings at merge.
+
+## Kubernetes
+
+`deploy/k8s/mi355x-kimi.yaml` is the apply unit: SGLang serving Kimi K2.5 on
+`amd.com/gpu: 8` plus the gitm harness as a sidecar, one pod, shared `/scratch`.
+Read the header comments — the placeholders (image digests, storage class,
+model id) must be filled, the AMD device plugin must be installed once per
+cluster, and `shareProcessNamespace: true` is required for correctness, not
+hygiene (shard-liveness probing crosses containers).
+
+The serving image needs no gitm install: an init container copies the built
+tool into `/scratch/lib`, and `ROCP_TOOL_LIBRARIES` points there. Keep the
+ROCm minor version of the gitm image and the serving image aligned — the tool's
+rocprofiler-sdk ABI must match the runtime that loads it.
+
+Run an experiment:
+
+```bash
+kubectl apply -f deploy/k8s/mi355x-kimi.yaml
+kubectl -n gitm-system wait --for=condition=ready pod -l app=kimi-k25 --timeout=60m
+kubectl -n gitm-system exec -it deploy/kimi-k25-mi355x -c gitm -- \
+    python -m gitm.bench --endpoint http://localhost:8000 ...
+```
+
+Speculative decode: the manifest enables Kimi's MTP head through SGLang's
+NextN-style flags. The streamed `avg_decoded_tokens_per_iter` is the live
+acceptance signal — **1.0 means the spec-decode path is not engaged** (that is
+plain autoregressive decode, whatever the flags say), >1.0 is the accepted
+draft rate the decode experiments measure.
+
+## Known caveats
+
+* `rocm_inject.c` is compiled against the installed rocprofiler-sdk headers;
+  like `cupti_core.c`'s versioned-struct pins, a field rename in a future sdk
+  fails the build loudly rather than corrupting offsets silently. It has not
+  yet been compiled on the MI355X box — expect the first
+  `python -m gitm.tracer._rocm.build` to be the real review of the sdk's
+  current field spellings.
+* In-process (non-injected) capture has no AMD backend; `capture()` degrades to
+  a well-formed no-op outside injection. Injection is the only mode that sees a
+  serving engine's children anyway, so this costs nothing for the experiments.
+* `gitm bench profile` on AMD shells out to legacy `rocprof` CSV stats
+  (`gitm/bench/profile.py`); on a ROCm 7 box prefer the injected tracer, and
+  treat that CLI path as due for a `rocprofv3` migration.

--- a/gitm/serve/vllm.py
+++ b/gitm/serve/vllm.py
@@ -674,7 +674,7 @@ def apply_tracing_env(env, trace_path, *, nvtx: bool, no_trace: bool) -> None:
     from gitm.tracer import injection
 
     if no_trace:
-        for var in (injection.ENV_LIB, injection.ENV_OUT,
+        for var in (injection.ENV_LIB, injection.ENV_ROCP, injection.ENV_OUT,
                     injection.ENV_NVTX, injection.ENV_NVTX_INJECT):
             env.pop(var, None)
         return
@@ -741,21 +741,29 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
         return 0, None
 
     apply_tracing_env(os.environ, trace_path, nvtx=nvtx, no_trace=no_trace)
+    vendor = injection.active_vendor()
     if no_trace:
-        print("==> tracing OFF (baseline arm): no CUPTI collection, no trace written")
+        print("==> tracing OFF (baseline arm): no collection, no trace written")
+    elif vendor == "amd":
+        print(f"==> {injection.ENV_ROCP}={os.environ[injection.ENV_ROCP]}")
     else:
-        print(f"==> {injection.ENV_LIB}={os.environ[injection.ENV_LIB]}")
+        print(f"==> {injection.ENV_LIB}={os.environ.get(injection.ENV_LIB, '')}")
     if nvtx:
-        # Report the NVTX injection path rather than assuming it. run_env sets it
-        # only when a libcupti was resolved, and a missing one is the failure that
-        # produces a trace full of markerless kernels with no error anywhere.
-        inject = os.environ.get(injection.ENV_NVTX_INJECT)
         print(f"==> {injection.ENV_NVTX}=1")
-        if inject:
-            print(f"==> {injection.ENV_NVTX_INJECT}={inject}")
+        if vendor == "amd":
+            # No second variable exists on AMD: rocTX ranges reach the injected
+            # tool through rocprofiler's own marker service.
+            pass
         else:
-            print(f"!!! {injection.ENV_NVTX_INJECT} unresolved — NVTX will hand no "
-                  "ranges to CUPTI and every kernel will come back unattributed")
+            # Report the NVTX injection path rather than assuming it. run_env sets
+            # it only when a libcupti was resolved, and a missing one is the failure
+            # that produces a trace full of markerless kernels with no error anywhere.
+            inject = os.environ.get(injection.ENV_NVTX_INJECT)
+            if inject:
+                print(f"==> {injection.ENV_NVTX_INJECT}={inject}")
+            else:
+                print(f"!!! {injection.ENV_NVTX_INJECT} unresolved — NVTX will hand no "
+                      "ranges to CUPTI and every kernel will come back unattributed")
 
     base = f"http://{args.host}:{args.port}"
     cmd = list(serve_argv)

--- a/gitm/tracer/_rocm/__init__.py
+++ b/gitm/tracer/_rocm/__init__.py
@@ -1,0 +1,103 @@
+"""ROCm collection support — the AMD half of the injected tracer.
+
+The collector itself is ``rocm_inject.c`` -> ``libgitm_rocm_inject.so`` (build
+with ``python -m gitm.tracer._rocm.build``), loaded into every HIP process via
+``ROCP_TOOL_LIBRARIES``. This module is the small host-side surface the
+capture pipeline needs without initializing HIP:
+
+* :func:`timestamp` — a reading of the SAME clock rocprofiler-sdk stamps
+  activity records with, which is what makes the capture window filter correct
+  across processes (the exact role ``gitm_cupti_timestamp`` plays on NVIDIA).
+  Read through ``librocprofiler-sdk``'s own ``rocprofiler_get_timestamp`` via
+  ctypes rather than reimplemented from its definition, so a change in the
+  sdk's clock source can never split the domains silently.
+* :func:`device_count` — GPU agents from the kfd sysfs topology. No HIP init,
+  so it is safe to call while the injected library owns collection.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+from pathlib import Path
+
+LIB_NAME = "libgitm_rocm_inject.so"
+
+_ROCM_HOMES = ("/opt/rocm",)  # versioned installs symlink /opt/rocm -> rocm-X.Y
+
+
+def lib_path() -> Path:
+    """Where the injection tool is built, whether or not it exists yet."""
+    return Path(__file__).resolve().parent / LIB_NAME
+
+
+def _sdk_lib_candidates() -> list[Path]:
+    homes = [Path(os.environ["ROCM_PATH"])] if os.environ.get("ROCM_PATH") else []
+    homes += [Path(h) for h in _ROCM_HOMES]
+    out = []
+    for h in homes:
+        out += [h / "lib" / "librocprofiler-sdk.so", h / "lib64" / "librocprofiler-sdk.so"]
+    return out
+
+
+_sdk_handle: ctypes.CDLL | None = None
+_sdk_tried = False
+
+
+def _sdk() -> ctypes.CDLL | None:
+    """librocprofiler-sdk, loaded once. Loading it does NOT register a tool —
+    registration only happens for libraries listed in ROCP_TOOL_LIBRARIES — so
+    this cannot fight the injected collector."""
+    global _sdk_handle, _sdk_tried
+    if _sdk_tried:
+        return _sdk_handle
+    _sdk_tried = True
+    names = [str(p) for p in _sdk_lib_candidates() if p.exists()]
+    found = ctypes.util.find_library("rocprofiler-sdk")
+    if found:
+        names.append(found)
+    for name in names:
+        try:
+            _sdk_handle = ctypes.CDLL(name)
+            break
+        except OSError:
+            continue
+    return _sdk_handle
+
+
+def timestamp() -> int | None:
+    """Nanoseconds in the rocprofiler record clock domain, or ``None``."""
+    sdk = _sdk()
+    if sdk is None:
+        return None
+    try:
+        fn = sdk.rocprofiler_get_timestamp
+    except AttributeError:
+        return None
+    fn.restype = ctypes.c_int
+    fn.argtypes = [ctypes.POINTER(ctypes.c_uint64)]
+    ts = ctypes.c_uint64(0)
+    if fn(ctypes.byref(ts)) != 0:  # ROCPROFILER_STATUS_SUCCESS == 0
+        return None
+    return ts.value or None
+
+
+def device_count() -> int:
+    """GPU count from the kfd topology; 0 on a non-ROCm host.
+
+    A kfd node is a GPU iff its ``gpu_id`` is non-zero — CPU sockets appear as
+    nodes too, with ``gpu_id`` 0.
+    """
+    nodes = Path("/sys/class/kfd/kfd/topology/nodes")
+    if not nodes.is_dir():
+        return 0
+    count = 0
+    for node in nodes.iterdir():
+        gpu_id = node / "gpu_id"
+        try:
+            if gpu_id.read_text().strip() not in ("", "0"):
+                count += 1
+        except OSError:
+            continue
+    return count

--- a/gitm/tracer/_rocm/build.py
+++ b/gitm/tracer/_rocm/build.py
@@ -1,0 +1,92 @@
+"""Compile the ROCm injection tool against the installed rocprofiler-sdk.
+
+    python -m gitm.tracer._rocm.build
+
+One target: ``libgitm_rocm_inject.so`` — a plain .so with no libpython, loaded
+by rocprofiler-register into every process that initializes HIP (via
+``$ROCP_TOOL_LIBRARIES``). This is the AMD counterpart of ``libgitm_inject.so``
+and writes the identical per-pid JSONL shards.
+
+Unlike the CUPTI build there is no driver/toolkit major-version matching dance:
+rocprofiler-sdk ships with the ROCm the driver was installed from, and there is
+exactly one on the box. Requirements are just the sdk headers + library
+(package ``rocprofiler-sdk``, present in the ``rocm/pytorch`` and ``rocm/vllm``
+images and in any full ROCm >= 6.2 install — MI355X hosts run ROCm 7.x) and a
+host C compiler; no hipcc, the sdk is a plain C API.
+
+On a host with no ROCm this exits non-zero and the tracer degrades to a no-op,
+matching the CUPTI build's behavior on a CUDA-less host.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE / "rocm_inject.c"
+LIB = HERE / "libgitm_rocm_inject.so"
+
+
+def _rocm_home() -> Path | None:
+    for env in ("ROCM_PATH", "ROCM_HOME"):
+        if os.environ.get(env):
+            p = Path(os.environ[env])
+            if p.is_dir():
+                return p
+    p = Path("/opt/rocm")
+    return p if p.is_dir() else None
+
+
+def _toolchain() -> tuple[Path, Path]:
+    """Locate rocprofiler-sdk headers + library, or exit with instructions."""
+    rocm = _rocm_home()
+    inc = lib = None
+    if rocm:
+        c = rocm / "include"
+        if (c / "rocprofiler-sdk" / "rocprofiler.h").exists():
+            inc = c
+        for d in (rocm / "lib", rocm / "lib64"):
+            if d.is_dir() and list(d.glob("librocprofiler-sdk.so*")):
+                lib = d
+                break
+    if inc is None or lib is None:
+        raise SystemExit(
+            "Could not locate rocprofiler-sdk (headers under "
+            "$ROCM_PATH/include/rocprofiler-sdk/ and librocprofiler-sdk.so). "
+            "Needs ROCm >= 6.2; on a slim image install the rocprofiler-sdk "
+            "package (apt: rocprofiler-sdk) and a C compiler. On non-ROCm "
+            "hosts the tracer is a no-op and this build is skipped."
+        )
+    return inc, lib
+
+
+def build() -> Path:
+    if not SRC.exists():
+        raise SystemExit(f"missing source: {SRC}")
+    inc, lib = _toolchain()
+    cc = os.environ.get("CC", "cc")
+    cmd = [
+        cc, "-shared", "-fPIC", "-O2", "-pthread",
+        f"-I{inc}",
+        str(SRC),
+        f"-L{lib}",
+        "-lrocprofiler-sdk",
+        f"-Wl,-rpath,{lib}",
+        "-o", str(LIB),
+    ]
+    print("compiling rocm injection tool:\n  " + " ".join(shlex.quote(c) for c in cmd))
+    subprocess.run(cmd, check=True)
+    print(f"built {LIB}")
+    return LIB
+
+
+if __name__ == "__main__":
+    try:
+        build()
+    except subprocess.CalledProcessError as exc:
+        print(f"compile failed (exit {exc.returncode})", file=sys.stderr)
+        raise SystemExit(exc.returncode) from exc

--- a/gitm/tracer/_rocm/rocm_inject.c
+++ b/gitm/tracer/_rocm/rocm_inject.c
@@ -1,0 +1,483 @@
+/*
+ * rocm_inject — rocprofiler-sdk collection for processes we don't control.
+ * The AMD counterpart of cupti_inject.c; emits the SAME per-pid JSONL shards.
+ *
+ * Built as libgitm_rocm_inject.so: a plain shared library with NO libpython.
+ * Point the ROCm runtime at it with
+ *
+ *     export ROCP_TOOL_LIBRARIES=/abs/path/to/libgitm_rocm_inject.so
+ *     export GITM_TRACE_OUT=/abs/path/to/trace.jsonl
+ *
+ * and rocprofiler-register (linked into the HIP/HSA runtimes since ROCm 6.2)
+ * dlopens it inside every process that initializes HIP — parent AND children —
+ * calling rocprofiler_configure() before a single kernel runs. Like
+ * CUDA_INJECTION64_PATH it is an ordinary environment variable inherited across
+ * fork/spawn, which is what lets it see a vLLM/SGLang EngineCore child the
+ * parent interpreter cannot instrument.
+ *
+ * Differences from the CUPTI collector that are structural, not omissions:
+ *
+ *   * Kernel names are NOT on the dispatch record. rocprofiler-sdk hands them
+ *     out once, at code-object load, via the CODE_OBJECT callback service; the
+ *     dispatch record carries only a kernel_id. We keep a kernel_id -> name map
+ *     and resolve at emit time. A dispatch whose load callback we missed (tool
+ *     attached late) emits an empty name and decodes as <anonymous>.
+ *   * There is no NVTX_INJECTION64_PATH analog and none is needed. rocTX
+ *     markers (what torch.cuda.nvtx.range_push compiles to on ROCm) are
+ *     delivered by the MARKER_CORE_API service of this same tool — the
+ *     two-mechanism split that bit us on the B200 does not exist here.
+ *   * roctx has no per-range id, so push/pop pairing is a per-thread stack in
+ *     this library (NVTX gave us marker ids for free). Ids are synthesized from
+ *     one atomic counter; the JSONL marker halves look identical to CUPTI's and
+ *     _cupti_decode.pair_markers joins them unchanged.
+ *   * grid on a dispatch record is in WORK-ITEMS (HSA convention), not blocks.
+ *     We divide by the workgroup size so KernelEvent.grid_* means the same
+ *     thing on both vendors.
+ *   * No SYNCHRONIZATION activity kind exists; AMD traces carry no sync
+ *     records. Consumers already tolerate their absence.
+ *   * registers_per_thread reports the kernel's arch VGPR count — the AMD
+ *     occupancy-limiting analog — captured from the code-object symbol.
+ *
+ * Same arming protocol as the CUPTI side: records are written only while
+ * $GITM_TRACE_OUT.arm exists, checked at most once per ARM_CACHE_MS so marker
+ * callbacks (which arrive one by one, not in buffers) don't stat() per range.
+ * Same durability model: JSONL streamed as buffers complete plus a periodic
+ * flush thread (GITM_TRACE_FLUSH_MS, default 100), so a SIGKILLed child loses
+ * at most one period. No signal handlers installed, for the same reason as the
+ * CUPTI side: EngineCore owns its SIGTERM path.
+ */
+
+#include <rocprofiler-sdk/marker/api_id.h> /* ROCPROFILER_MARKER_CORE_API_ID_* */
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <limits.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define GITM_NAME_MAX 1023          /* mirrors cupti_core.h */
+#define BUF_SIZE (32 * 1024 * 1024) /* 32 MiB, matches the CUPTI collector */
+#define DEFAULT_FLUSH_MS 100
+#define ARM_CACHE_MS 50
+#define MARKER_STACK_MAX 128
+
+/* GITM_MARKER_START/END from cupti_core.h — the JSONL contract, not CUPTI's. */
+#define GITM_MARKER_START 0
+#define GITM_MARKER_END 1
+
+static FILE *g_fp = NULL;
+static char g_arm_path[PATH_MAX];
+static int g_armed = 0;
+static uint64_t g_armed_checked_ms = 0;
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static rocprofiler_context_id_t g_ctx = {0};
+static rocprofiler_buffer_id_t g_buffer = {0};
+static int g_nvtx = 0; /* GITM_TRACE_NVTX: HIP-API + marker collection on */
+
+static pthread_t g_flusher;
+static int g_flusher_started = 0;
+static atomic_int g_stop_flusher = 0;
+static uint32_t g_flush_ms = DEFAULT_FLUSH_MS;
+
+/* ---- agent handle -> logical GPU ordinal ------------------------------- */
+
+#define MAX_AGENTS 64
+static struct {
+    uint64_t handle;
+    uint32_t ordinal;
+} g_agents[MAX_AGENTS];
+static int g_n_agents = 0;
+
+static rocprofiler_status_t
+agent_iter(rocprofiler_agent_version_t version, const void **agents,
+           size_t num_agents, void *user) {
+    (void)version;
+    (void)user;
+    uint32_t ordinal = 0;
+    for (size_t i = 0; i < num_agents && g_n_agents < MAX_AGENTS; i++) {
+        const rocprofiler_agent_v0_t *a = agents[i];
+        if (a->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+        g_agents[g_n_agents].handle = a->id.handle;
+        g_agents[g_n_agents].ordinal = ordinal++;
+        g_n_agents++;
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+static uint32_t agent_ordinal(rocprofiler_agent_id_t id) {
+    for (int i = 0; i < g_n_agents; i++) {
+        if (g_agents[i].handle == id.handle) return g_agents[i].ordinal;
+    }
+    return 0; /* CPU agent or unknown: same fallback the decoder tolerates */
+}
+
+/* ---- kernel_id -> {name, vgpr} map ------------------------------------- */
+
+#define KMAP_BUCKETS 4096
+typedef struct kmap_node {
+    uint64_t kernel_id;
+    uint32_t vgprs;
+    struct kmap_node *next;
+    char name[]; /* NUL-terminated, truncated to GITM_NAME_MAX */
+} kmap_node;
+
+static kmap_node *g_kmap[KMAP_BUCKETS];
+
+static void kmap_put(uint64_t kernel_id, const char *name, uint32_t vgprs) {
+    size_t len = name ? strlen(name) : 0;
+    if (len > GITM_NAME_MAX) len = GITM_NAME_MAX;
+    kmap_node *n = malloc(sizeof(kmap_node) + len + 1);
+    if (!n) return; /* a dispatch of this kernel decodes as <anonymous> */
+    n->kernel_id = kernel_id;
+    n->vgprs = vgprs;
+    memcpy(n->name, name ? name : "", len);
+    n->name[len] = '\0';
+    size_t b = kernel_id % KMAP_BUCKETS;
+    n->next = g_kmap[b];
+    g_kmap[b] = n; /* newest first: a reloaded id resolves to the new symbol */
+}
+
+static const kmap_node *kmap_get(uint64_t kernel_id) {
+    for (kmap_node *n = g_kmap[kernel_id % KMAP_BUCKETS]; n; n = n->next) {
+        if (n->kernel_id == kernel_id) return n;
+    }
+    return NULL;
+}
+
+/* ---- shard writing (same JSON contract as cupti_inject.c) --------------- */
+
+static void write_json_string(FILE *fp, const char *s) {
+    fputc('"', fp);
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+        switch (*p) {
+            case '"':  fputs("\\\"", fp); break;
+            case '\\': fputs("\\\\", fp); break;
+            case '\n': fputs("\\n", fp);  break;
+            case '\r': fputs("\\r", fp);  break;
+            case '\t': fputs("\\t", fp);  break;
+            default:
+                if (*p < 0x20) fprintf(fp, "\\u%04x", *p);
+                else fputc(*p, fp);
+        }
+    }
+    fputc('"', fp);
+}
+
+static uint64_t now_coarse_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)(ts.tv_nsec / 1000000u);
+}
+
+/* Refresh the armed flag, at most once per ARM_CACHE_MS. Called under g_lock.
+ * Buffer callbacks land every few MiB so the cache barely matters there; it
+ * exists for marker callbacks, which arrive per-range. */
+static void refresh_armed(void) {
+    uint64_t now = now_coarse_ms();
+    if (now - g_armed_checked_ms < ARM_CACHE_MS) return;
+    g_armed_checked_ms = now;
+    g_armed = (access(g_arm_path, F_OK) == 0);
+}
+
+/* rocprofiler_memory_copy_operation_t -> CUpti_ActivityMemcpyKind ints, which
+ * are what _cupti_decode._COPY_KIND speaks. Values from cupti_activity.h. */
+static int copy_kind_cupti(rocprofiler_memory_copy_operation_t op) {
+    switch (op) {
+        case ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE:   return 1; /* HTOD */
+        case ROCPROFILER_MEMORY_COPY_DEVICE_TO_HOST:   return 2; /* DTOH */
+        case ROCPROFILER_MEMORY_COPY_DEVICE_TO_DEVICE: return 8; /* DTOD */
+        case ROCPROFILER_MEMORY_COPY_HOST_TO_HOST:     return 9; /* HTOH */
+        default:                                       return 0; /* UNKNOWN */
+    }
+}
+
+/* ---- buffer callback: kernel dispatch / memory copy / HIP API ----------- */
+
+static void
+buffer_cb(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id,
+          rocprofiler_record_header_t **headers, size_t num_headers,
+          void *user_data, uint64_t drop_count) {
+    (void)context; (void)buffer_id; (void)user_data;
+
+    pthread_mutex_lock(&g_lock);
+    refresh_armed();
+    if (!g_fp || !g_armed) {
+        pthread_mutex_unlock(&g_lock);
+        return;
+    }
+    if (drop_count > 0) {
+        /* The counter the CUPTI side never had: LOSSLESS should keep this at
+         * zero, but if the sdk ever drops records, say so in-band so a lossy
+         * trace is distinguishable from a quiet one. */
+        fprintf(g_fp, "{\"kind\":\"meta\",\"dropped_records\":%llu}\n",
+                (unsigned long long)drop_count);
+    }
+
+    for (size_t i = 0; i < num_headers; i++) {
+        rocprofiler_record_header_t *h = headers[i];
+        if (h->category != ROCPROFILER_BUFFER_CATEGORY_TRACING) continue;
+
+        if (h->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
+            rocprofiler_buffer_tracing_kernel_dispatch_record_t *k = h->payload;
+            const kmap_node *sym = kmap_get(k->dispatch_info.kernel_id);
+            /* grid arrives in work-items; normalize to CUDA-style blocks. */
+            uint32_t wx = k->dispatch_info.workgroup_size.x;
+            uint32_t wy = k->dispatch_info.workgroup_size.y;
+            uint32_t wz = k->dispatch_info.workgroup_size.z;
+            uint32_t gx = wx ? k->dispatch_info.grid_size.x / wx : 0;
+            uint32_t gy = wy ? k->dispatch_info.grid_size.y / wy : 0;
+            uint32_t gz = wz ? k->dispatch_info.grid_size.z / wz : 0;
+            fputs("{\"kind\":\"kernel\",\"name\":", g_fp);
+            write_json_string(g_fp, sym ? sym->name : "");
+            fprintf(g_fp,
+                    ",\"start_ns\":%llu,\"end_ns\":%llu,\"device_id\":%u,"
+                    "\"context_id\":0,\"stream_id\":%llu,\"correlation_id\":%llu,"
+                    "\"grid\":[%u,%u,%u],\"block\":[%u,%u,%u],"
+                    "\"static_shared_mem\":%u,\"dynamic_shared_mem\":0,"
+                    "\"registers_per_thread\":%u}\n",
+                    (unsigned long long)k->start_timestamp,
+                    (unsigned long long)k->end_timestamp,
+                    agent_ordinal(k->dispatch_info.agent_id),
+                    (unsigned long long)k->dispatch_info.queue_id.handle,
+                    (unsigned long long)k->correlation_id.internal,
+                    gx, gy, gz, wx, wy, wz,
+                    k->dispatch_info.group_segment_size,
+                    sym ? sym->vgprs : 0);
+        } else if (h->kind == ROCPROFILER_BUFFER_TRACING_MEMORY_COPY) {
+            rocprofiler_buffer_tracing_memory_copy_record_t *m = h->payload;
+            /* device_id: the GPU endpoint — dst for H2D, src otherwise. */
+            uint32_t dev =
+                (m->operation == ROCPROFILER_MEMORY_COPY_HOST_TO_DEVICE)
+                    ? agent_ordinal(m->dst_agent_id)
+                    : agent_ordinal(m->src_agent_id);
+            fprintf(g_fp,
+                    "{\"kind\":\"memcpy\",\"copy_kind\":%d,\"bytes\":%llu,"
+                    "\"start_ns\":%llu,\"end_ns\":%llu,\"device_id\":%u,"
+                    "\"context_id\":0,\"stream_id\":0,\"correlation_id\":%llu}\n",
+                    copy_kind_cupti(m->operation),
+                    (unsigned long long)m->bytes,
+                    (unsigned long long)m->start_timestamp,
+                    (unsigned long long)m->end_timestamp,
+                    dev, (unsigned long long)m->correlation_id.internal);
+        } else if (h->kind == ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API) {
+            /* The host-side launch record of the correlation chain — the
+             * CUPTI RUNTIME/DRIVER analog. HIP has no runtime/driver split:
+             * hipBLASLt and torch both launch through the HIP runtime, so one
+             * service covers what needed two kinds on NVIDIA. */
+            rocprofiler_buffer_tracing_hip_api_record_t *a = h->payload;
+            fprintf(g_fp,
+                    "{\"kind\":\"runtime\",\"start_ns\":%llu,\"end_ns\":%llu,"
+                    "\"correlation_id\":%llu,\"thread_id\":%llu}\n",
+                    (unsigned long long)a->start_timestamp,
+                    (unsigned long long)a->end_timestamp,
+                    (unsigned long long)a->correlation_id.internal,
+                    (unsigned long long)a->thread_id);
+        }
+    }
+    fflush(g_fp);
+    pthread_mutex_unlock(&g_lock);
+}
+
+/* ---- callback tracing: code objects (names) + roctx markers ------------- */
+
+static atomic_uint g_marker_seq = 1;
+static __thread struct {
+    uint32_t ids[MARKER_STACK_MAX];
+    int depth;
+} tls_ranges;
+
+static void emit_marker(const char *name, uint32_t marker_id, int flags,
+                        uint64_t thread_id) {
+    rocprofiler_timestamp_t ts = 0;
+    rocprofiler_get_timestamp(&ts);
+    pthread_mutex_lock(&g_lock);
+    refresh_armed();
+    if (g_fp && g_armed) {
+        fputs("{\"kind\":\"marker\",\"name\":", g_fp);
+        write_json_string(g_fp, name ? name : "");
+        fprintf(g_fp,
+                ",\"timestamp_ns\":%llu,\"marker_id\":%u,\"marker_flags\":%d,"
+                "\"thread_id\":%llu}\n",
+                (unsigned long long)ts, marker_id, flags,
+                (unsigned long long)thread_id);
+    }
+    pthread_mutex_unlock(&g_lock);
+}
+
+static void
+callback_cb(rocprofiler_callback_tracing_record_t record,
+            rocprofiler_user_data_t *user_data, void *callback_data) {
+    (void)user_data; (void)callback_data;
+
+    if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT) {
+        if (record.operation !=
+            ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+            return;
+        if (record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD) return;
+        rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t
+            *d = record.payload;
+        pthread_mutex_lock(&g_lock);
+        kmap_put(d->kernel_id, d->kernel_name, d->arch_vgpr_count);
+        pthread_mutex_unlock(&g_lock);
+        return;
+    }
+
+    if (record.kind != ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API) return;
+    if (record.phase != ROCPROFILER_CALLBACK_PHASE_ENTER) return;
+    rocprofiler_callback_tracing_marker_api_data_t *d = record.payload;
+
+    if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePushA) {
+        uint32_t id = atomic_fetch_add(&g_marker_seq, 1);
+        if (tls_ranges.depth < MARKER_STACK_MAX) {
+            tls_ranges.ids[tls_ranges.depth] = id;
+        }
+        /* Past MARKER_STACK_MAX the push is emitted but not tracked; its pop
+         * pairs with nothing and pair_markers drops the half, which is the
+         * documented behavior for unpaired halves. 128 deep is ~4x anything
+         * vLLM layerwise instrumentation produces. */
+        tls_ranges.depth++;
+        emit_marker(d->args.roctxRangePushA.message, id, GITM_MARKER_START,
+                    record.thread_id);
+    } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxRangePop) {
+        if (tls_ranges.depth <= 0) return; /* pop with no push: ignore */
+        tls_ranges.depth--;
+        if (tls_ranges.depth >= MARKER_STACK_MAX) return; /* untracked push */
+        emit_marker(NULL, tls_ranges.ids[tls_ranges.depth], GITM_MARKER_END,
+                    record.thread_id);
+    } else if (record.operation == ROCPROFILER_MARKER_CORE_API_ID_roctxMarkA) {
+        /* A point marker: emit both halves at one timestamp so it decodes as
+         * a zero-length range rather than an unpaired half. */
+        uint32_t id = atomic_fetch_add(&g_marker_seq, 1);
+        emit_marker(d->args.roctxMarkA.message, id, GITM_MARKER_START,
+                    record.thread_id);
+        emit_marker(NULL, id, GITM_MARKER_END, record.thread_id);
+    }
+}
+
+/* ---- flush thread ------------------------------------------------------- */
+
+static void *flusher_main(void *arg) {
+    (void)arg;
+    while (!atomic_load(&g_stop_flusher)) {
+        usleep((useconds_t)g_flush_ms * 1000u);
+        rocprofiler_flush_buffer(g_buffer);
+    }
+    return NULL;
+}
+
+/* ---- tool lifecycle ----------------------------------------------------- */
+
+static int tool_init(rocprofiler_client_finalize_t fini, void *tool_data) {
+    (void)fini; (void)tool_data;
+
+    rocprofiler_query_available_agents(
+        ROCPROFILER_AGENT_INFO_VERSION_0, agent_iter,
+        sizeof(rocprofiler_agent_v0_t), NULL);
+
+    if (rocprofiler_create_context(&g_ctx) != ROCPROFILER_STATUS_SUCCESS)
+        return -1;
+    if (rocprofiler_create_buffer(g_ctx, BUF_SIZE, BUF_SIZE / 2,
+                                  ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                                  buffer_cb, NULL,
+                                  &g_buffer) != ROCPROFILER_STATUS_SUCCESS)
+        return -1;
+
+    rocprofiler_configure_buffer_tracing_service(
+        g_ctx, ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH, NULL, 0, g_buffer);
+    rocprofiler_configure_buffer_tracing_service(
+        g_ctx, ROCPROFILER_BUFFER_TRACING_MEMORY_COPY, NULL, 0, g_buffer);
+    /* Kernel names are useless without this: dispatch records carry only ids. */
+    rocprofiler_configure_callback_tracing_service(
+        g_ctx, ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT, NULL, 0,
+        callback_cb, NULL);
+
+    if (g_nvtx) {
+        /* Correlation records, gated exactly like the CUPTI side: HIP API
+         * records are a multiple of the kernel count on a decode step, and
+         * that cost is what the with/without comparison measures. */
+        rocprofiler_configure_buffer_tracing_service(
+            g_ctx, ROCPROFILER_BUFFER_TRACING_HIP_RUNTIME_API, NULL, 0,
+            g_buffer);
+        rocprofiler_configure_callback_tracing_service(
+            g_ctx, ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API, NULL, 0,
+            callback_cb, NULL);
+    }
+
+    /* Deliver buffer callbacks on our own thread, not the runtime's. */
+    rocprofiler_callback_thread_t cb_thread;
+    if (rocprofiler_create_callback_thread(&cb_thread) ==
+        ROCPROFILER_STATUS_SUCCESS) {
+        rocprofiler_assign_callback_thread(g_buffer, cb_thread);
+    }
+
+    if (rocprofiler_start_context(g_ctx) != ROCPROFILER_STATUS_SUCCESS)
+        return -1;
+
+    const char *ms = getenv("GITM_TRACE_FLUSH_MS");
+    if (ms && *ms) g_flush_ms = (uint32_t)strtoul(ms, NULL, 10);
+    if (g_flush_ms == 0) g_flush_ms = DEFAULT_FLUSH_MS;
+    if (pthread_create(&g_flusher, NULL, flusher_main, NULL) == 0)
+        g_flusher_started = 1;
+    return 0;
+}
+
+static void tool_fini(void *tool_data) {
+    (void)tool_data;
+    if (g_flusher_started) {
+        atomic_store(&g_stop_flusher, 1);
+        pthread_join(g_flusher, NULL);
+        g_flusher_started = 0;
+    }
+    rocprofiler_stop_context(g_ctx);
+    rocprofiler_flush_buffer(g_buffer); /* drains into buffer_cb -> g_fp */
+    pthread_mutex_lock(&g_lock);
+    if (g_fp) {
+        fflush(g_fp);
+        fclose(g_fp);
+        g_fp = NULL;
+    }
+    pthread_mutex_unlock(&g_lock);
+}
+
+rocprofiler_tool_configure_result_t *
+rocprofiler_configure(uint32_t version, const char *runtime_version,
+                      uint32_t priority, rocprofiler_client_id_t *id) {
+    (void)version; (void)runtime_version; (void)priority;
+    id->name = "gitm";
+
+    /* Same dormancy contract as InitializeInjection(): a tracer that cannot
+     * open its output has no business degrading the workload it rode into.
+     * Returning NULL declines registration and the process runs untraced. */
+    const char *out = getenv("GITM_TRACE_OUT");
+    if (!out || !*out) return NULL;
+
+    char shard[PATH_MAX];
+    if (snprintf(shard, sizeof(shard), "%s.%d", out, (int)getpid()) >=
+        (int)sizeof(shard))
+        return NULL;
+    if (snprintf(g_arm_path, sizeof(g_arm_path), "%s.arm", out) >=
+        (int)sizeof(g_arm_path))
+        return NULL;
+
+    g_fp = fopen(shard, "a");
+    if (!g_fp) return NULL;
+    setvbuf(g_fp, NULL, _IOFBF, 1 << 20);
+
+    const char *nvtx = getenv("GITM_TRACE_NVTX");
+    g_nvtx = nvtx && *nvtx && strcmp(nvtx, "0") != 0;
+
+    static rocprofiler_tool_configure_result_t result = {
+        sizeof(rocprofiler_tool_configure_result_t), tool_init, tool_fini,
+        NULL};
+    return &result;
+}

--- a/gitm/tracer/capture.py
+++ b/gitm/tracer/capture.py
@@ -54,11 +54,12 @@ def capture(
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    injected = injection.active()
+    injected_vendor = injection.active_vendor()
+    injected = injected_vendor is not None
     backend = None if injected else _backend()
     started_ns = time.time_ns()
     if injected:
-        source = "cupti"
+        source = "rocprof" if injected_vendor == "amd" else "cupti"
     elif backend is not None:
         vendor = getattr(backend, "vendor", "") or ""
         if vendor == "amd":
@@ -72,8 +73,8 @@ def capture(
         workload_id=workload_id,
         fingerprint=fingerprint,
         run_id=run_id or uuid.uuid4().hex,
-        device_count=_device_count(backend, injected),
-        vendor="nvidia" if injected else (backend.vendor if backend else "none"),
+        device_count=_device_count(backend, injected_vendor),
+        vendor=injected_vendor if injected_vendor else (backend.vendor if backend else "none"),
         captured_at_ns=started_ns,
         duration_ns=0,
         source=source,  # type: ignore[arg-type]
@@ -90,13 +91,14 @@ def capture(
         # here), and unlinking it would silently redirect every kernel record into a
         # deleted inode.
         injection.clear_stale_shards()
-        window_start = injection.cupti_now()
+        window_start = injection.clock_now()
         if window_start is None:
             warnings.warn(
-                "injected capture cannot read the CUPTI clock, so the window can't "
+                "injected capture cannot read the record clock, so the window can't "
                 "be bounded: the trace will include everything the traced processes "
-                "did, including model load and CUDA-graph capture. Build the shim "
-                "(python -m gitm.tracer._cupti.build) to fix.",
+                "did, including model load and graph capture. Build the shim "
+                "(python -m gitm.tracer._cupti.build on NVIDIA; on AMD, check that "
+                "librocprofiler-sdk.so is loadable) to fix.",
                 stacklevel=2,
             )
         injection.arm()
@@ -118,7 +120,7 @@ def capture(
     finally:
         ended_ns = time.time_ns()
         if injected:
-            window_end = injection.cupti_now()
+            window_end = injection.clock_now()
             # Stay armed while other processes' in-flight CUPTI buffers land — we
             # can't reach into a child to force a flush, so we wait out its flush
             # period. Disarming first would drop the tail of the trace.
@@ -175,14 +177,19 @@ def write_trace_jsonl(path: str | Path, trace: Trace) -> None:
 _write_jsonl = write_trace_jsonl
 
 
-def _device_count(backend, injected: bool) -> int:
+def _device_count(backend, injected_vendor: str | None) -> int:
     """Device count for the trace header.
 
     Under injection we never construct a backend — collection belongs to the driver-
-    loaded library — but the compiled shim is still importable and counting devices
-    doesn't touch CUPTI's activity callbacks, so it stays safe to ask.
+    loaded library — but the compiled shim (NVIDIA) and the kfd topology (AMD) are
+    still readable, and neither touches the collector's activity callbacks, so it
+    stays safe to ask.
     """
-    if injected:
+    if injected_vendor == "amd":
+        from gitm.tracer import _rocm
+
+        counter = _rocm.device_count
+    elif injected_vendor is not None:
         from gitm.tracer._cupti import load_shim
 
         shim = load_shim()

--- a/gitm/tracer/injection.py
+++ b/gitm/tracer/injection.py
@@ -33,10 +33,17 @@ from pathlib import Path
 from gitm.tracer.schema import TraceEvent
 
 ENV_LIB = "CUDA_INJECTION64_PATH"
+#: The AMD loading hook: rocprofiler-register (in the HIP runtime, ROCm >= 6.2)
+#: dlopens every library listed here at HIP init — the same inherited-env,
+#: follows-children property CUDA_INJECTION64_PATH has. Colon-separated list.
+ENV_ROCP = "ROCP_TOOL_LIBRARIES"
 ENV_OUT = "GITM_TRACE_OUT"
-#: Turns on RUNTIME/DRIVER/MARKER collection in the collector (cupti_core.c).
+#: Turns on RUNTIME/DRIVER/MARKER collection in the collector (cupti_core.c),
+#: and HIP-API/rocTX collection in the ROCm one (rocm_inject.c).
 ENV_NVTX = "GITM_TRACE_NVTX"
 #: Read by NVTX itself, not by us and not by the CUDA driver — see run_env().
+#: NVIDIA-only: rocTX markers reach the ROCm collector through its own marker
+#: tracing service, so the two-mechanism split does not exist on AMD.
 ENV_NVTX_INJECT = "NVTX_INJECTION64_PATH"
 ENV_SETTLE = "GITM_TRACE_SETTLE_S"
 
@@ -57,14 +64,40 @@ def lib_path() -> Path:
     return Path(_cupti.__file__).resolve().parent / LIB_NAME
 
 
-def active() -> bool:
-    """True when this run is being collected by our injection library.
-    Checks that the injection path actually points at ``libgitm_inject.so``: another
-    profiler (nsys sets this variable too) means the trace is not ours to merge, and
-    we must not silently claim its records or skip our own in-process collection.
+def rocm_lib_path() -> Path:
+    """Where the ROCm injection tool is built, whether or not it exists yet."""
+    from gitm.tracer import _rocm
+
+    return _rocm.lib_path()
+
+
+def active_vendor() -> str | None:
+    """``"nvidia"``/``"amd"`` when this run is collected by OUR injected library,
+    else ``None``.
+
+    Checks that the hook actually points at our library: another profiler
+    (nsys sets ``CUDA_INJECTION64_PATH`` too; rocprofv3 sets
+    ``ROCP_TOOL_LIBRARIES``) means the trace is not ours to merge, and we must
+    not silently claim its records or skip our own in-process collection.
+    ``ROCP_TOOL_LIBRARIES`` is a colon-separated list, so ours may ride
+    alongside another tool's entry.
     """
+    if not os.environ.get(ENV_OUT):
+        return None
     lib = os.environ.get(ENV_LIB, "")
-    return bool(lib) and Path(lib).name == LIB_NAME and bool(os.environ.get(ENV_OUT))
+    if lib and Path(lib).name == LIB_NAME:
+        return "nvidia"
+    from gitm.tracer._rocm import LIB_NAME as ROCM_LIB_NAME
+
+    for entry in os.environ.get(ENV_ROCP, "").split(":"):
+        if entry and Path(entry).name == ROCM_LIB_NAME:
+            return "amd"
+    return None
+
+
+def active() -> bool:
+    """True when this run is being collected by our injection library."""
+    return active_vendor() is not None
 
 
 def libcupti_path() -> Path | None:
@@ -83,20 +116,47 @@ def libcupti_path() -> Path | None:
     return so if so.exists() else None
 
 
-def run_env(out_path: str | Path, *, nvtx: bool = False) -> dict[str, str]:
+def detect_vendor() -> str:
+    """``"amd"`` on a ROCm box, else ``"nvidia"``.
+
+    kfd topology is the ground truth for AMD GPUs and exists without any
+    library loaded; NVIDIA stays the default so a CPU-only dev box renders the
+    same env it always has.
+    """
+    from gitm.tracer import _rocm
+
+    return "amd" if _rocm.device_count() > 0 else "nvidia"
+
+
+def run_env(
+    out_path: str | Path, *, nvtx: bool = False, vendor: str | None = None
+) -> dict[str, str]:
     """The environment a traced run needs, ready to export.
 
     ``nvtx`` additionally turns on the correlation records that resolve an
-    anonymous GEMM to a layer and an op. It sets two variables, and the second
-    is the one nobody guesses: **NVTX and CUDA injection are separate
-    mechanisms.** ``CUDA_INJECTION64_PATH`` is read by the CUDA driver and is
-    how our collector gets loaded; NVTX is header-only and consults
+    anonymous GEMM to a layer and an op.
+
+    On NVIDIA it sets two variables, and the second is the one nobody guesses:
+    **NVTX and CUDA injection are separate mechanisms.**
+    ``CUDA_INJECTION64_PATH`` is read by the CUDA driver and is how our
+    collector gets loaded; NVTX is header-only and consults
     ``NVTX_INJECTION64_PATH`` to decide which tool receives push/pop. Enabling
     ``CUPTI_ACTIVITY_KIND_MARKER`` gives CUPTI somewhere to put ranges but does
     not make NVTX hand them over — verified on a B200, where markers stayed at
     zero until this was set.
+
+    On AMD there is deliberately no third variable: rocTX push/pop (what
+    ``torch.cuda.nvtx`` maps to under ROCm) is delivered to the SAME injected
+    tool by rocprofiler-sdk's marker tracing service, so ``GITM_TRACE_NVTX=1``
+    alone flips correlation on. ``vendor`` overrides autodetection for tests
+    and for rendering an env on a machine other than the one that will run it.
     """
-    env = {ENV_LIB: str(lib_path()), ENV_OUT: str(Path(out_path).resolve())}
+    out = str(Path(out_path).resolve())
+    if (vendor or detect_vendor()) == "amd":
+        return {ENV_ROCP: str(rocm_lib_path()), ENV_OUT: out} | (
+            {ENV_NVTX: "1"} if nvtx else {}
+        )
+    env = {ENV_LIB: str(lib_path()), ENV_OUT: out}
     if nvtx:
         env[ENV_NVTX] = "1"
         cupti = libcupti_path()
@@ -238,6 +298,7 @@ def read_shards(start_ns: int | None = None, end_ns: int | None = None) -> list[
 
     records: list[dict] = []
     dropped_lines = 0
+    collector_drops = 0
     for shard in shard_paths():
         try:
             text = shard.read_text(encoding="utf-8", errors="replace")
@@ -274,6 +335,13 @@ def read_shards(start_ns: int | None = None, end_ns: int | None = None) -> list[
             if rec.get("kind") in ("marker", "runtime"):
                 records.append(rec)
                 continue
+            # In-band loss report from the ROCm collector (rocprofiler-sdk
+            # counts drops; CUPTI never told us). Not an event — surface it.
+            if rec.get("kind") == "meta":
+                drops = rec.get("dropped_records")
+                if isinstance(drops, int):
+                    collector_drops += drops
+                continue
 
             ts = rec.get("start_ns")
             if not isinstance(ts, int):
@@ -289,6 +357,14 @@ def read_shards(start_ns: int | None = None, end_ns: int | None = None) -> list[
         warnings.warn(
             f"injected trace coverage: dropped {dropped_lines} malformed or incomplete "
             "shard line(s)",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    if collector_drops:
+        warnings.warn(
+            f"injected trace coverage: the collector reported {collector_drops} "
+            "record(s) dropped before reaching the shard — the trace is lossy; "
+            "raise GITM_TRACE_FLUSH_MS frequency or the buffer size",
             RuntimeWarning,
             stacklevel=2,
         )
@@ -323,3 +399,19 @@ def cupti_now() -> int | None:
     except Exception:
         return None
     return ts or None
+
+
+def clock_now() -> int | None:
+    """The record-clock reading for whichever vendor's collector is injected.
+
+    NVIDIA reads through the CUPTI shim, AMD through
+    ``rocprofiler_get_timestamp`` (ctypes, no HIP init) — each the same clock
+    its collector stamps records with, which is the whole point: the window
+    bounds and the record timestamps must share a domain or the filter
+    silently drops everything.
+    """
+    if active_vendor() == "amd":
+        from gitm.tracer import _rocm
+
+        return _rocm.timestamp()
+    return cupti_now()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ packages = ["gitm"]
 "gitm/tracer/_cupti/cupti_core.c" = "gitm/tracer/_cupti/cupti_core.c"
 "gitm/tracer/_cupti/cupti_shim.c" = "gitm/tracer/_cupti/cupti_shim.c"
 "gitm/tracer/_cupti/cupti_inject.c" = "gitm/tracer/_cupti/cupti_inject.c"
+"gitm/tracer/_rocm/rocm_inject.c" = "gitm/tracer/_rocm/rocm_inject.c"
 "gitm/kernels/library.yaml" = "gitm/kernels/library.yaml"
 "gitm/optimizer/templates/headroom_customer.md.j2" = "gitm/optimizer/templates/headroom_customer.md.j2"
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -56,6 +56,45 @@ def test_inactive_when_another_profiler_owns_the_injection_hook(run_env, monkeyp
 
 def test_active_with_our_lib_and_an_output(run_env):
     assert injection.active()
+    assert injection.active_vendor() == "nvidia"
+
+
+def test_active_vendor_amd_via_rocp_tool_libraries(tmp_path, monkeypatch):
+    """ROCP_TOOL_LIBRARIES is the AMD hook — colon-separated, and ours may ride
+    alongside another tool's entry without disowning the run."""
+    from gitm.tracer import _rocm
+
+    monkeypatch.delenv(injection.ENV_LIB, raising=False)
+    monkeypatch.setenv(injection.ENV_OUT, str(tmp_path / "trace.jsonl"))
+    monkeypatch.setenv(
+        injection.ENV_ROCP, f"/opt/other/libtool.so:/opt/gitm/{_rocm.LIB_NAME}"
+    )
+    assert injection.active_vendor() == "amd"
+
+
+def test_inactive_when_only_another_rocm_tool_is_listed(tmp_path, monkeypatch):
+    """rocprofv3 sets ROCP_TOOL_LIBRARIES too. Those records are not ours."""
+    monkeypatch.delenv(injection.ENV_LIB, raising=False)
+    monkeypatch.setenv(injection.ENV_OUT, str(tmp_path / "trace.jsonl"))
+    monkeypatch.setenv(injection.ENV_ROCP, "/opt/rocm/lib/librocprofv3-tool.so")
+    assert injection.active_vendor() is None
+
+
+def test_run_env_amd_sets_the_rocm_hook_and_no_nvtx_injection_path(tmp_path):
+    """On AMD, nvtx=True must NOT render NVTX_INJECTION64_PATH: rocTX reaches
+    the injected tool through rocprofiler's own marker service, and exporting
+    the NVIDIA variable would only mislead whoever reads the env."""
+    env = injection.run_env(tmp_path / "t.jsonl", nvtx=True, vendor="amd")
+    assert injection.ENV_ROCP in env
+    assert env[injection.ENV_NVTX] == "1"
+    assert injection.ENV_LIB not in env
+    assert injection.ENV_NVTX_INJECT not in env
+
+
+def test_run_env_nvidia_shape_is_unchanged(tmp_path):
+    env = injection.run_env(tmp_path / "t.jsonl", vendor="nvidia")
+    assert injection.ENV_LIB in env
+    assert injection.ENV_ROCP not in env
 
 
 # --------------------------------------------------------------------------- #
@@ -86,6 +125,20 @@ def test_window_filter_drops_records_outside_the_capture_window(run_env):
     events = injection.read_shards(start_ns=100, end_ns=200)
 
     assert [e.name for e in events] == ["decode_step"]
+
+
+def test_collector_drop_report_warns_and_is_not_an_event(run_env):
+    """The ROCm collector writes {"kind":"meta","dropped_records":N} when
+    rocprofiler drops records. It must surface as a loss warning, not decode as
+    an event and not count as a malformed line."""
+    shard = run_env.with_name(run_env.name + ".111")
+    shard.write_text(
+        json.dumps({"kind": "meta", "dropped_records": 7}) + "\n"
+        + _kernel("k", 100, 200) + "\n"
+    )
+    with pytest.warns(RuntimeWarning, match="7 record"):
+        events = injection.read_shards()
+    assert [e.name for e in events] == ["k"]
 
 
 def test_partial_trailing_line_from_a_killed_process_is_tolerated(run_env):


### PR DESCRIPTION
Port the injected tracer to AMD via rocprofiler-sdk (ROCm >= 6.2):
libgitm_rocm_inject.so is loaded through ROCP_TOOL_LIBRARIES — the
CUDA_INJECTION64_PATH analog, same follows-children property — and
writes the identical per-pid JSONL shards, so shard merge, decode,
correlation and taxonomy are shared unchanged.

* gitm/tracer/_rocm/: the tool (kernel dispatch, memory copy, HIP API,
  rocTX markers via per-thread stack; kernel names from code-object
  load callbacks; grid normalized from work-items to blocks) + build
* injection/capture: vendor-aware active_vendor()/clock_now()/run_env();
  no NVTX_INJECTION64_PATH analog on AMD — rocTX flows through the same
  tool, GITM_TRACE_NVTX=1 alone enables correlation
* read_shards surfaces rocprofiler's in-band dropped-record counts —
  loss visibility CUPTI never provided
* serve: no-trace baseline arm also clears ROCP_TOOL_LIBRARIES
* deploy/k8s/mi355x-kimi.yaml: SGLang Kimi K2.5 (amd.com/gpu: 8, MTP
  spec-decode flags) + gitm sidecar, shared /scratch, initContainer
  copies the tool .so; shareProcessNamespace required for shard
  liveness probing. Dockerfile.rocm builds the gitm-rocm image.
* docs/rocm.md: mechanism map + bring-up runbook

rocm_inject.c is not yet compiled against a real sdk; first on-box
build is the review of current field spellings.
