### PR TITLE
rocm image: missing librocprofiler-sdk runtime deps + in-image verify green

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Both Dockerfiles COPY only: pyproject.toml constraints.txt README.md
+# gitm/ benchmarks/ tests/ docs/ scripts/ deploy/. Everything else is dead
+# weight in the build context (vllm/ alone is ~400MB).
+.git
+vllm
+evidence
+assets
+harness
+runtime-experiment-harness
+telemetry
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.ruff_cache
+*.egg-info
+dist
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,11 @@ COPY benchmarks ./benchmarks
 COPY tests ./tests
 COPY docs ./docs
 COPY scripts ./scripts
+# tests/test_deploy_manifests.py validates the manifests and the Dockerfiles'
+# non-root USER; without these the image's CMD (verify_infra.sh -> pytest)
+# fails those checks.
+COPY deploy ./deploy
+COPY Dockerfile Dockerfile.rocm ./
 RUN python -m pip install -e ".[dev,bench,nvidia]" -c constraints.txt
 
 # Build the CUPTI tracer shim against this image's CUDA toolkit.

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -27,6 +27,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # Base toolchain + AMD's apt repo, then rocprofiler-sdk ONLY — this pulls the
 # HSA runtime and rocprofiler-register as deps, not the multi-GB math libraries.
+# hsa-amd-aqlprofile + libdw1t64 are runtime deps of librocprofiler-sdk.so that
+# apt does NOT pull in; without them the sidecar's dlopen for clock_now() fails
+# and every windowed capture is silently empty (timestamp() -> None).
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl gnupg build-essential \
         python3 python3-venv python3-dev git \
@@ -37,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         > /etc/apt/sources.list.d/rocm.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         rocprofiler-sdk hsa-rocr-dev hsakmt-roct-dev hip-dev \
+        hsa-amd-aqlprofile libdw1t64 \
     && rm -rf /var/lib/apt/lists/*
 
 # Ubuntu 24.04 marks the system python externally-managed; a venv keeps pip
@@ -53,6 +57,11 @@ COPY benchmarks ./benchmarks
 COPY tests ./tests
 COPY docs ./docs
 COPY scripts ./scripts
+# tests/test_deploy_manifests.py validates the manifests and the Dockerfiles'
+# non-root USER; without these the image's CMD (verify_infra.sh -> pytest)
+# fails those checks.
+COPY deploy ./deploy
+COPY Dockerfile Dockerfile.rocm ./
 RUN pip install -e ".[dev,bench]" -c constraints.txt
 
 # Build the ROCm tracer tool against this image's rocprofiler-sdk.

--- a/scripts/verify_infra.sh
+++ b/scripts/verify_infra.sh
@@ -28,10 +28,10 @@ check "pytest (full suite)"            "$PY -m pytest -q"
 check "ruff (lint, new surface)"       "ruff check gitm/bench gitm/tracer/_cupti gitm/tracer/_cupti_decode.py gitm/tracer/cupti.py gitm/optimizer/apply.py benchmarks tests/test_bench.py tests/test_bench_datasets.py tests/test_cupti.py tests/test_hft_harness.py tests/test_framework_harnesses.py tests/test_apply_rollback.py"
 check "import sanity (all new modules)" "$PY - <<'EOF'
 import importlib
-for m in ['gitm.bench.schema','gitm.bench.manifest','gitm.bench.baseline','gitm.bench.profile','gitm.bench.edge_manifest','gitm.bench.results','gitm.bench.runner','gitm.bench.reproduce','gitm.bench.cli','gitm.tracer.cupti','gitm.tracer._cupti_decode','gitm.optimizer.apply','gitm.benchmarks.hft.harness','gitm.runtime_driver','gitm.workloads','benchmarks.hft.generate','benchmarks.hft.harness','benchmarks.biotech.fetch','benchmarks.biotech.harness','benchmarks.edge.fetch','benchmarks.edge.harness','benchmarks.skeleton.measure_overhead']:
+for m in ['gitm.bench.schema','gitm.bench.manifest','gitm.bench.baseline','gitm.bench.profile','gitm.bench.edge_manifest','gitm.bench.results','gitm.bench.runner','gitm.bench.reproduce','gitm.bench.cli','gitm.tracer.cupti','gitm.tracer._cupti_decode','gitm.optimizer.apply','gitm.benchmarks.hft.harness','gitm.runtime_driver','gitm.workloads','benchmarks.hft.generate','benchmarks.hft.harness','benchmarks.biotech.fetch','benchmarks.biotech.harness','benchmarks.edge.fetch','benchmarks.edge.harness','benchmarks.overhead.measure_overhead']:
     importlib.import_module(m)
 EOF"
-check "intervention library validates" "$PY -c 'from gitm.kernels import load_library; assert len(load_library())==18'"
+check "intervention library validates" "$PY -c 'from gitm.kernels import load_library; assert len(load_library())==28'"
 check "wheel build + data files"        "$PY -m build --wheel >/dev/null 2>&1 && $PY - <<'EOF'
 import zipfile, glob
 n = zipfile.ZipFile(sorted(glob.glob('dist/*.whl'))[-1]).namelist()
@@ -85,7 +85,7 @@ r=optimize(workload='vllm-decode', budget='1s', target=0.15)
 assert pathlib.Path(r['summary']['report_path']).exists()\""
 check "gitm doctor"  "GITM_SCRATCH=\$(mktemp -d) $PY -m gitm.cli doctor"
 check "gitm.bench CLI help" "$PY -m gitm.bench --help"
-check "overhead harness runs" "$PY -m benchmarks.skeleton.measure_overhead --runs 2 --steps 30"
+check "overhead harness runs" "$PY -m benchmarks.overhead.measure_overhead --runs 2 --steps 30"
 
 echo "==================== TIER 3: GPU box (auto-detected) ===================="
 if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -40,8 +40,11 @@ def test_no_clusterrole_binding_grants_api_access():
 
 
 def test_container_runs_as_non_root_user():
-    text = (_ROOT / "Dockerfile").read_text()
-    # a USER directive that isn't root, appearing after the build steps
-    user_lines = [ln for ln in text.splitlines() if ln.strip().startswith("USER ")]
-    assert user_lines, "Dockerfile must drop to a non-root USER"
-    assert all("root" not in ln for ln in user_lines)
+    dockerfiles = sorted(_ROOT.glob("Dockerfile*"))
+    assert dockerfiles, "no Dockerfile found beside the test tree"
+    for path in dockerfiles:
+        text = path.read_text()
+        # a USER directive that isn't root, appearing after the build steps
+        user_lines = [ln for ln in text.splitlines() if ln.strip().startswith("USER ")]
+        assert user_lines, f"{path.name} must drop to a non-root USER"
+        assert all("root" not in ln for ln in user_lines), path.name


### PR DESCRIPTION
librocprofiler-sdk.so has two runtime deps AMD's apt does not pull in
(hsa-amd-aqlprofile, libdw1t64); without them the sidecar's dlopen for
clock_now() fails and timestamp() silently returns None — every windowed
capture would be empty. Verified end-to-end via linux/amd64 buildx: first
real compile of rocm_inject.c against rocprofiler-sdk 7.0 is clean, the
tool exports rocprofiler_configure, and timestamp() returns real values.

Also make the image CMD (verify_infra.sh) fully green:
- copy deploy/ + Dockerfiles into both images so test_deploy_manifests
  runs self-contained; extend the non-root USER check to Dockerfile.rocm
- fix stale refs: benchmarks.skeleton -> benchmarks.overhead, library
  count 18 -> 28
- add .dockerignore (context 600MB -> ~10MB; vllm/ was never COPY'd)
