### PR TITLE
Fix GLM runtime dispatch and NVTX attribution; add benchmark validation

### DIFF
--- a/docs/glm52_runtime_validation.md
+++ b/docs/glm52_runtime_validation.md
@@ -1,0 +1,136 @@
+# GLM 5.2 runtime validation
+
+This is a preparation and offline attribution scheme, not evidence that GLM ran
+on H200. The local checks exercise Python dispatch, graph construction and
+synthetic CUPTI records. The native collector, installed vLLM implementation,
+checkpoint compatibility and real performance require the benchmark server.
+
+## Audit findings and repairs
+
+| Path | Failure | Repair |
+| --- | --- | --- |
+| `gitm capture serve --model ...` | Parser did not accept `--model`; default command served another pinned experiment. | Explicit model builds `vllm serve MODEL`; conflicting full command is refused. |
+| `serve/model_config.py` | GLM was detected, then passed to the DeepSeek config gate/reader. | Dispatch GLM to its own reader. |
+| `serve/attach.py` | Sidecar predictor only distinguished hybrid from DeepSeek. | Dispatch GLM to `predict_glm_graph`. |
+| `tracer/injection.py` → `_cupti_decode.py` | Production shards merged before marker pairing and correlation; worker-local IDs could collide. | Preserve shard PID, partition before pairing/correlation, retain PID on kernels. |
+| `tracer/vllm_stats.py` | Missing MLA/indexer/norm/embedding mappings; shared-expert children mapped as dense FFN. | Add GLM mappings and ancestor-aware expert mappings. |
+| `_cupti_decode.py` | vLLM module labels recognized only Python's single-quoted repr. | Accept JSON double-quoted labels too. |
+| `optimizer/deviation.py`, `monitor.py` | Any enclosing range overrode the kernel, including arbitrary containers and standalone quant/norm/collective helpers. | Common resolver preserves recognized op ranges, falls back for unknown labels, separates named helpers. |
+| `deviate --by-phase` | Returned before graph construction and ignored JSON mode. | With a model, include graph comparison and a separate phase diagnostic; JSON includes both. |
+| Multi-worker deviation | Sum of all worker time compared against one rank's floor. | Require one worker/device selection for graph comparisons; no cross-worker phase propagation. |
+
+No undefined-name import errors were found by the Python static check. Existing
+dense-family `NotImplementedError` paths are outside GLM dispatch. The planner is
+an analytical graph, not executable inference kernels. Its approximate terms do
+not certify that a serving backend implements the same graph.
+
+## Match the server to the prediction
+
+The catalogue's `glm-5.2-fp8` entry assumes FP8 KV storage as well as FP8 weights,
+with BF16 exceptions and FP32 routing. Merely selecting the FP8 checkpoint does
+not select FP8 KV storage. Enable it explicitly when comparing to this entry.
+Save the exact checkpoint revision/config, vLLM/torch/CUDA versions, GPU topology,
+launch command, logs, run manifest and serving summary with every result.
+
+On the Linux GPU server, first exercise the existing preflight with the actual
+serve command. This checks the installed environment; do not bypass rejected
+flags to obtain a nominally successful run.
+
+```bash
+gitm capture serve --dry-run --tp 8 --out validation/preflight -- \
+  vllm serve zai-org/GLM-5.2-FP8 \
+  --tensor-parallel-size 8 --enable-expert-parallel \
+  --kv-cache-dtype fp8 --max-num-seqs 32
+```
+
+Then take a bounded eager identity capture. Explicit command form exposes all
+serving decisions; `gitm capture serve --model zai-org/GLM-5.2-FP8` is supported
+but its other defaults do not reproduce the benchmark shape by themselves.
+
+```bash
+gitm capture serve --nvtx --tp 8 --concurrency 32 --requests 64 \
+  --input-tokens 8192 --output-tokens 128 --out validation/eager -- \
+  vllm serve zai-org/GLM-5.2-FP8 \
+  --tensor-parallel-size 8 --enable-expert-parallel \
+  --kv-cache-dtype fp8 --max-num-seqs 32 --enforce-eager
+```
+
+The input length is a client target, not proof of tokenized prompt length. The
+window includes prefill, ramp-up, decode and drain. Concurrency 32 does not prove
+that every scheduler step has batch 32, and KV length grows during generation.
+Record scheduler steps and actual token counts. Do not derive `N` from completed
+requests, kernel count, or output tokens divided by 32.
+
+`capture attach` requires a server started with the injection environment; it
+cannot retrofit CUPTI into an arbitrary live process. For another window on a
+server launched here, use `--keep-server`, then `gitm capture attach --list` and
+select that server's PID. NVTX must also have been enabled at startup.
+
+## Gate attribution before reading ratios
+
+Inventory workers and attribution (the first invocation intentionally fails the
+single-worker gate on a merged trace, but writes the inventory):
+
+```bash
+python -m gitm.optimizer.validate_trace validation/eager/trace.jsonl \
+  > validation/inventory.json
+
+# Choose a kernel-producing worker PID from inventory.json, not the frontend PID.
+python -m gitm.optimizer.validate_trace validation/eager/trace.jsonl \
+  --pid WORKER_PID --device 0 > validation/worker-audit.json
+```
+
+Use the reported worker-local device ID; it may not be 0. Repeat for all eight
+workers. Re-capture older merged traces that lack PIDs: identical local device
+IDs cannot reconstruct lost worker identities or undo incorrect correlation.
+The defaults target H200, batch 32, KV 8192, TP8/EP8, eight workers,
+90% modeled device time and 80% canonical NVTX device time. Thresholds are
+explicit review criteria, not calibrated performance guarantees. A failure
+returns exit code 1; unreadable input/model returns 2. Exit 0 passes attribution
+criteria only. Missing ops and the largest raw NVTX/name disagreements remain
+review items even when coverage passes.
+
+Check especially:
+
+* IndexShare: no indexer projection/score on shared layers. The validator checks
+  canonical range op/layer pairs against the predicted graph.
+* MLA q/kv projections: anonymous GEMMs need specific ranges. An enclosing
+  attention block does not establish which projection ran.
+* Shared versus routed expert work, and standalone activation quantization,
+  norms, permute/combine and collectives inside larger module ranges.
+* Fused projections and absorbed MLA: the catalogue models unabsorbed MLA.
+  An absent `attn_kv_b` is a possible backend difference, not automatic speedup.
+* Name-only mappings are guesses. Do not transfer a bare GEMM name from eager
+  mode to graph mode as a unique identity; the same name can serve many ops.
+
+## Compare a measured step window
+
+```bash
+gitm plan glm-5.2-fp8 --gpu H200 --batch 32 --kv-len 8192 \
+  --tp 8 --ep 8 --json > validation/plan.json
+
+gitm deviate decode-window.jsonl --model glm-5.2-fp8 --gpu H200 \
+  --batch 32 --kv-len 8192 --tp 8 --ep 8 --steps N \
+  --pid WORKER_PID --device 0 --by-phase --json > validation/deviation.json
+```
+
+`decode-window.jsonl` must be a window selected using measured scheduler step
+boundaries, with its actual shape and `N`. The capture client does not currently
+produce that fixed-shape decode slice automatically. For variable shapes, price
+each observed step's batch/context/prefill separately; do not multiply a single
+static step by an unrelated count. `--by-phase` is a diagnostic breakdown, not
+a decode filter: unknown names and nearest-anchor inference cannot prove a
+homogeneous decode step, especially with chunked prefill. Multi-worker phase
+reports use direct kernel-name evidence only.
+
+Finally repeat the same workload in normal graph mode with CUPTI and without
+`--nvtx`/`--enforce-eager`, plus a `--no-trace` baseline. Compare throughput and
+latency to quantify instrumentation overhead. Eager identity timings cannot
+validate graph-mode launch overhead or fusion. Keep missing attribution visible
+and retain the raw trace; a coverage gap is not optimization headroom.
+
+The live sidecar uses batch 1 and maximum model length as a placeholder shape;
+it is useful for config dispatch inspection, not a measured scheduler-step floor.
+Use the explicit plan above for the requested reference. Per-kernel deviation
+filters also cannot validate multi-kernel fused/grouped nodes; use summed op
+totals over measured steps for this scheme.

--- a/gitm/optimizer/deviation.py
+++ b/gitm/optimizer/deviation.py
@@ -191,6 +191,21 @@ def classify_op(kernel_name: str) -> str | None:
             return op
     return None
 
+
+def observed_op(name: str, range_op: str | None = None) -> str | None:
+    """Resolve known NVTX ops; opaque module/container labels are not identities.
+
+    Standalone quantisation, norms and MoE data movement inside a projection
+    range have their own graph terms. Do not charge them to its GEMM as well.
+    """
+    guessed = classify_op(name)
+    if range_op not in _OP_RULES:
+        return guessed or range_op
+    if guessed in ("act_quant", "rms_norm", "moe_permute", "moe_combine",
+                   "tp_all_reduce", "moe_all_to_all"):
+        return guessed
+    return range_op
+
 @dataclass
 class DeviationResult:
     """Which observed kernels departed from the predicted graph, and how much it compresses."""
@@ -266,7 +281,7 @@ def deviating_kernel_indices(
 
     kept: list[int] = []
     for i, ok in enumerate(obs):
-        op = ok.range_op or classify_op(ok.name)
+        op = observed_op(ok.name, ok.range_op)
         pn = by_op.get(op) if op is not None else None
         if pn is None:
             kept.append(i)  # unmodeled op → keep as a departure
@@ -308,7 +323,7 @@ def deviation_summary(
     kept_ops: dict[str, int] = {}
     for i in dev.kept_indices:
         ok = obs[i]
-        op = ok.range_op or classify_op(ok.name) or "<unmodeled>"
+        op = observed_op(ok.name, ok.range_op) or "<unmodeled>"
         kept_ops[op] = kept_ops.get(op, 0) + 1
     return {
         "n_observed": dev.n_observed,
@@ -327,7 +342,8 @@ def write_deviation_jsonl(reduced: Trace, path: str | Path) -> None:
     """
     write_trace_jsonl(path, reduced)
 
-def stream_observed(path: str | Path) -> tuple[dict[str, list], int, int, int]:
+def stream_observed(path: str | Path, *, pid: int | None = None,
+                    device: int | None = None) -> tuple[dict[str, list], int, int, int]:
     """``(per_op, n_kernels, total_ns, span_ns)`` from a trace, without loading it.
 
     ``per_op`` maps a predicted-op name to ``[count, total_ns]``, with
@@ -341,7 +357,7 @@ def stream_observed(path: str | Path) -> tuple[dict[str, list], int, int, int]:
     n = total = 0
     t_min: int | None = None
     t_max: int | None = None
-    cache: dict[str, str | None] = {}
+    cache: dict[tuple[str, str | None], str | None] = {}
 
     with Path(path).open(encoding="utf-8") as fh:
         for line in fh:
@@ -349,17 +365,20 @@ def stream_observed(path: str | Path) -> tuple[dict[str, list], int, int, int]:
                 d = json.loads(line)
             except ValueError:
                 continue
-            if d.get("kind") != "kernel":
+            if not isinstance(d, dict) or d.get("kind") != "kernel":
+                continue
+            if pid is not None and d.get("pid") != pid:
+                continue
+            if device is not None and d.get("device_id") != device:
                 continue
             start, end = d.get("start_ns"), d.get("end_ns")
-            if start is None or end is None:
+            if not isinstance(start, int) or not isinstance(end, int) or end <= start:
                 continue
             name = d.get("name") or ""
-            op = d.get("range_op")
-            if not op:
-                if name not in cache:
-                    cache[name] = classify_op(name)
-                op = cache[name]
+            key = (name, d.get("range_op"))
+            if key not in cache:
+                cache[key] = observed_op(*key)
+            op = cache[key]
             slot = per_op.setdefault(op or "<unmodeled>", [0, 0])
             dur = max(0, end - start)
             slot[0] += 1
@@ -373,7 +392,29 @@ def stream_observed(path: str | Path) -> tuple[dict[str, list], int, int, int]:
     return per_op, n, total, span
 
 
-def phase_anchors(path: str | Path) -> list[tuple[int, str]]:
+def observed_scopes(path: str | Path, *, pid=None, device=None) -> set[tuple]:
+    """Worker/device identities, never inferred from a process-local device ID."""
+    import json
+
+    scopes = set()
+    with Path(path).open(encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                d = json.loads(line)
+            except ValueError:
+                continue
+            if not isinstance(d, dict) or d.get("kind") != "kernel":
+                continue
+            if pid is not None and d.get("pid") != pid:
+                continue
+            if device is not None and d.get("device_id") != device:
+                continue
+            scopes.add((d.get("pid"), d.get("device_id")))
+    return scopes
+
+
+def phase_anchors(path: str | Path, *, pid: int | None = None,
+                  device: int | None = None) -> list[tuple[int, str]]:
     """``[(start_ns, phase)]`` for every kernel that names its own phase, sorted.
 
     These are the fixed points the rest of the timeline is inferred from. Gated
@@ -400,6 +441,12 @@ def phase_anchors(path: str | Path) -> list[tuple[int, str]]:
                 d = json.loads(line)
             except ValueError:
                 continue
+            if not isinstance(d, dict) or d.get("kind") != "kernel":
+                continue
+            if pid is not None and d.get("pid") != pid:
+                continue
+            if device is not None and d.get("device_id") != device:
+                continue
             name, start = d.get("name") or "", d.get("start_ns")
             if start is None:
                 continue
@@ -411,7 +458,8 @@ def phase_anchors(path: str | Path) -> list[tuple[int, str]]:
     return out
 
 
-def stream_by_phase(path: str | Path, *, propagate: bool = True):
+def stream_by_phase(path: str | Path, *, propagate: bool = True,
+                    pid: int | None = None, device: int | None = None):
     """``(by_phase, stats)`` — kernels bucketed by phase and taxonomy.
 
     ``by_phase`` is ``{phase: {bucket: [count, ns]}}``. ``stats`` reports how the
@@ -435,7 +483,10 @@ def stream_by_phase(path: str | Path, *, propagate: bool = True):
 
     from gitm.tracer.kernel_taxonomy import classify_kernel, classify_phase
 
-    anchors = phase_anchors(path) if propagate else []
+    # A nearby timestamp on another worker is not evidence for this one's phase.
+    scopes = observed_scopes(path, pid=pid, device=device)
+    anchors = (phase_anchors(path, pid=pid, device=device)
+               if propagate and len(scopes) <= 1 else [])
     times = [a[0] for a in anchors]
 
     by_phase: dict[str, dict[str, list]] = {}
@@ -450,10 +501,14 @@ def stream_by_phase(path: str | Path, *, propagate: bool = True):
                 d = json.loads(line)
             except ValueError:
                 continue
-            if d.get("kind") != "kernel":
+            if not isinstance(d, dict) or d.get("kind") != "kernel":
+                continue
+            if pid is not None and d.get("pid") != pid:
+                continue
+            if device is not None and d.get("device_id") != device:
                 continue
             start, end = d.get("start_ns"), d.get("end_ns")
-            if start is None or end is None:
+            if not isinstance(start, int) or not isinstance(end, int) or end <= start:
                 continue
             name = d.get("name") or ""
             if name not in ph_cache:
@@ -562,6 +617,8 @@ def render_deviation(
     out = [f"observed  {n_kernels:,} kernels, {obs_s:.3f} s device time{busy}"]
     if steps:
         out.append(f"window    {steps:,} steps -> {obs_s / steps * 1e3:.3f} ms/step observed")
+    elif pred is not None:
+        out.append("UNSCALED: --steps is missing; window totals vs one step are not a benchmark ratio.")
     out.append("")
 
     if pred is None:
@@ -585,7 +642,8 @@ def render_deviation(
                        "observed but not predicted")
             continue
         ratio = obs_ms / floor_ms
-        verdict = "within band" if ratio <= 1.0 + band else f"{ratio:.1f}x over floor"
+        verdict = ("below floor: check coverage" if ratio < 1.0 - band else
+                   "within band" if ratio <= 1.0 + band else f"{ratio:.1f}x over floor")
         out.append(f"  {op:24s} {obs_ms:9.1f} {floor_ms:9.1f} {ratio:7.2f} "
                    f"{count:11,}  {verdict}")
 
@@ -626,11 +684,13 @@ def add_deviate_arguments(ap):
                     help="How many prompts those tokens belong to — sets lm_head rows.")
     ap.add_argument("--tp", type=int, default=1)
     ap.add_argument("--ep", type=int, default=1)
+    ap.add_argument("--pid", type=int, default=None, help="Select one captured worker PID.")
+    ap.add_argument("--device", type=int, default=None, help="Select a worker-local device ID.")
     ap.add_argument("--no-graph", action="store_true",
                     help="Report observed op totals only, with no prediction.")
     ap.add_argument("--by-phase", dest="by_phase", action="store_true",
-                    help="Split kernels into prefill and decode instead of comparing "
-                         "against a predicted floor.")
+                    help="Include a diagnostic phase breakdown; with --model also "
+                         "compare the whole selected window against the graph.")
     ap.add_argument("--json", dest="as_json", action="store_true")
     return ap
 
@@ -646,6 +706,8 @@ def main(argv: list[str] | None = None) -> int:
         description="Subtract a predicted graph from a captured trace.",
     ))
     args = ap.parse_args(argv)
+    if args.steps is not None and args.steps <= 0:
+        ap.error("--steps must be positive")
 
     if not args.trace.is_file():
         print(f"cannot read trace: {args.trace}")
@@ -654,12 +716,24 @@ def main(argv: list[str] | None = None) -> int:
     # model — and requiring one would make the cheapest view the most awkward.
     if not args.model and not args.no_graph and not args.by_phase:
         ap.error("--model is required unless --no-graph or --by-phase")
+    if args.model and not args.no_graph:
+        scopes = observed_scopes(args.trace, pid=args.pid, device=args.device)
+        if len(scopes) > 1:
+            print("cannot compare merged workers to a per-rank graph; select --pid "
+                  "and/or --device. Workers: " + str(sorted(scopes, key=str)))
+            return 2
 
-    if args.by_phase:
-        print(render_by_phase(*stream_by_phase(args.trace)))
+    phase_report = (stream_by_phase(args.trace, pid=args.pid, device=args.device)
+                    if args.by_phase else None)
+    if args.by_phase and not args.model:
+        if args.as_json:
+            print(json.dumps({"by_phase": phase_report[0], "phase_stats": phase_report[1]}))
+        else:
+            print(render_by_phase(*phase_report))
         return 0
 
-    per_op, n_kernels, total_ns, span_ns = stream_observed(args.trace)
+    per_op, n_kernels, total_ns, span_ns = stream_observed(
+        args.trace, pid=args.pid, device=args.device)
     if not n_kernels:
         print(f"no kernel records in {args.trace} — nothing to subtract.")
         return 1
@@ -698,6 +772,10 @@ def main(argv: list[str] | None = None) -> int:
             "device_time_s": total_ns / 1e9,
             "window_s": span_ns / 1e9,
             "steps": args.steps,
+            "pid": args.pid,
+            "device": args.device,
+            "by_phase": phase_report[0] if phase_report else None,
+            "phase_stats": phase_report[1] if phase_report else None,
             "band_width": band,
             "ops": {
                 op: {
@@ -713,4 +791,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(render_deviation(per_op, pred, n_kernels=n_kernels, total_ns=total_ns,
                            span_ns=span_ns, steps=args.steps, band=band))
+    if phase_report:
+        print("\nPhase diagnostic (inferred phases do not isolate a decode-only window):")
+        print(render_by_phase(*phase_report))
     return 0

--- a/gitm/optimizer/monitor.py
+++ b/gitm/optimizer/monitor.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 
-from gitm.optimizer.deviation import classify_op
+from gitm.optimizer.deviation import observed_op
 from gitm.optimizer.invariants import INVARIANTS, Invariant, Violation
 from gitm.optimizer.multibasis import confirmed_positions
 from gitm.planner.graph import Graph, PredictedNode
@@ -128,7 +128,7 @@ def residuals(trace: Trace, graph: Graph) -> Residuals:
         classes.setdefault(pn.op, {}).setdefault(_class_key(pn), pn)
 
     for ok in obs:
-        op = ok.range_op or classify_op(ok.name)
+        op = observed_op(ok.name, ok.range_op)
         if op is None:
             continue
         cls = list(classes.get(op, {}).values())

--- a/gitm/optimizer/validate_trace.py
+++ b/gitm/optimizer/validate_trace.py
@@ -1,0 +1,151 @@
+"""Offline attribution gate for a benchmark capture; never claims GPU validation.
+
+Run ``python -m gitm.optimizer.validate_trace --help``. Reports device-time
+coverage and raw NVTX/name disagreements for review before comparing timings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from gitm.optimizer.deviation import classify_op, observed_op
+from gitm.tracer.kernel_taxonomy import NAME_MAX, classify_phase
+
+
+def audit_trace(path: Path, graph, *, pid=None, device=None) -> dict:
+    expected = {n.op for n in graph.nodes}
+    expected_layers = {(n.op, n.layer) for n in graph.nodes}
+    workers: dict[tuple, int] = {}
+    ops: dict[str, list[int]] = {}
+    disagreements: dict[tuple, int] = {}
+    invalid = malformed = truncated = total = nvtx = covered = kernels = 0
+    bad_layers = 0
+    phases: dict[str, int] = {}
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            try:
+                d = json.loads(line)
+            except ValueError:
+                malformed += 1
+                continue
+            if not isinstance(d, dict):
+                malformed += 1
+                continue
+            if d.get("kind") != "kernel":
+                continue
+            scope = (d.get("pid"), d.get("device_id"))
+            workers[scope] = workers.get(scope, 0) + 1
+            if pid is not None and scope[0] != pid:
+                continue
+            if device is not None and scope[1] != device:
+                continue
+            start, end = d.get("start_ns"), d.get("end_ns")
+            if (not isinstance(start, int) or not isinstance(end, int) or end <= start):
+                invalid += 1
+                continue
+            name = d.get("name") or ""
+            raw = d.get("range_op")
+            if not isinstance(name, str) or (raw is not None and not isinstance(raw, str)):
+                malformed += 1
+                continue
+            duration = end - start
+            kernels += 1
+            total += duration
+            op = observed_op(name, raw)
+            slot = ops.setdefault(op or "<unmodeled>", [0, 0])
+            slot[0] += 1
+            slot[1] += duration
+            if op in expected:
+                covered += duration
+            if raw in expected:
+                nvtx += duration
+                layer = d.get("range_layer")
+                if layer is not None and (raw, layer) not in expected_layers:
+                    bad_layers += 1
+            guess = classify_op(name)
+            if raw and guess and raw != guess:
+                key = (raw, guess, op, name)
+                disagreements[key] = disagreements.get(key, 0) + duration
+            if len(name.encode("utf-8")) >= NAME_MAX:
+                truncated += 1
+            phase = classify_phase(name) or "unknown"
+            phases[phase] = phases.get(phase, 0) + duration
+    selected = [s for s in workers if (pid is None or s[0] == pid)
+                and (device is None or s[1] == device)]
+    return {
+        "kernels": kernels, "device_time_ns": total,
+        "workers": [{"pid": p, "device": d, "kernels": n}
+                    for (p, d), n in workers.items()],
+        "selected_workers": len(selected),
+        "modeled_time_share": covered / total if total else 0,
+        "canonical_nvtx_time_share": nvtx / total if total else 0,
+        "malformed_lines": malformed, "invalid_kernels": invalid,
+        "truncated_names": truncated, "unexpected_layer_tags": bad_layers,
+        "missing_ops": sorted(expected - ops.keys()),
+        "ops": ops, "direct_phase_time_ns": phases,
+        "nvtx_name_disagreements": [
+            {"range_op": r, "name_op": g, "resolved_op": o, "name": n, "time_ns": t}
+            for (r, g, o, n), t in sorted(disagreements.items(), key=lambda x: -x[1])[:50]
+        ],
+    }
+
+
+def main(argv=None) -> int:
+    from gitm.planner.registry import _hardware, _load, _predict
+    from gitm.planner.roofline import BatchConfig, ShardingConfig
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("trace", type=Path)
+    ap.add_argument("--model", default="glm-5.2-fp8")
+    ap.add_argument("--gpu", default="H200")
+    ap.add_argument("--batch", type=int, default=32)
+    ap.add_argument("--kv-len", type=int, default=8192)
+    ap.add_argument("--tp", type=int, default=8)
+    ap.add_argument("--ep", type=int, default=8)
+    ap.add_argument("--pid", type=int)
+    ap.add_argument("--device", type=int)
+    ap.add_argument("--expected-workers", type=int, default=8)
+    ap.add_argument("--min-coverage", type=float, default=0.9)
+    ap.add_argument("--min-nvtx", type=float, default=0.8)
+    args = ap.parse_args(argv)
+    if not 0 <= args.min_coverage <= 1 or not 0 <= args.min_nvtx <= 1:
+        ap.error("coverage thresholds must be between 0 and 1")
+    try:
+        spec, family, note = _load(args.model)
+        if spec is None:
+            raise ValueError("model has no config-backed graph")
+        graph = _predict(spec, family, _hardware(args.gpu),
+                         BatchConfig(batch=args.batch, kv_cache_len=args.kv_len),
+                         ShardingConfig(tp=args.tp, ep=args.ep))
+        report = audit_trace(args.trace, graph, pid=args.pid, device=args.device)
+    except (OSError, ValueError) as e:
+        print(json.dumps({"passed": False, "errors": [str(e)]}))
+        return 2
+    errors = []
+    if len(report["workers"]) != args.expected_workers:
+        errors.append("worker count differs from --expected-workers")
+    if report["selected_workers"] != 1:
+        errors.append("select exactly one worker using --pid and/or --device")
+    for field in ("malformed_lines", "invalid_kernels", "truncated_names",
+                  "unexpected_layer_tags"):
+        if report[field]:
+            errors.append(field)
+    if not report["kernels"]:
+        errors.append("no valid selected kernels")
+    if report["modeled_time_share"] < args.min_coverage:
+        errors.append("modeled device-time coverage below threshold")
+    if report["canonical_nvtx_time_share"] < args.min_nvtx:
+        errors.append("canonical NVTX device-time coverage below threshold")
+    report.update(passed=not errors, errors=errors, model=args.model, provenance=note,
+                  limitation="Attribution gate only. Verify scheduler step counts, batch, "
+                  "KV lengths, phase, serving precision and backend separately.")
+    print(json.dumps(report, indent=2))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gitm/serve/attach.py
+++ b/gitm/serve/attach.py
@@ -442,7 +442,11 @@ def _emit_predicted_graph(target: discover.Target, out_dir: Path) -> None:
     from gitm.planner.context import build_planner_context, hardware_spec_for
 
     hw = hardware_spec_for(build_planner_context().peak)
-    if resolved.family == "hybrid":
+    if resolved.family == "glm_moe_dsa":
+        from gitm.planner.glm_graph import predict_glm_graph
+
+        g = predict_glm_graph(resolved.spec, hw, resolved.batch, resolved.sharding)
+    elif resolved.family == "hybrid":
         from gitm.planner.hybrid_graph import predict_hybrid_graph
 
         g = predict_hybrid_graph(resolved.spec, hw, resolved.batch, resolved.sharding)

--- a/gitm/serve/model_config.py
+++ b/gitm/serve/model_config.py
@@ -364,11 +364,11 @@ def live_moe_spec(
             model_ref=model_ref,
         )
 
-    if family == "hybrid":
-        from gitm.planner.hybrid_graph import spec_from_hf_config as _hybrid_spec
+    if family in ("hybrid", "glm_moe_dsa"):
+        from gitm.planner.registry import spec_from_hf_config as _family_spec
 
         try:
-            spec = _hybrid_spec(cfg, name=model_ref)
+            spec = _family_spec(cfg, name=model_ref)
         except ValueError as e:
             # The reader refuses to substitute another checkpoint's value for a
             # shape this config does not declare.

--- a/gitm/serve/vllm.py
+++ b/gitm/serve/vllm.py
@@ -600,6 +600,8 @@ def drive_load(base: str, model: str, prompts: list[str], *, concurrency: int,
 def add_serve_arguments(ap: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """The launch path's flags. Shared verbatim between ``gitm capture serve`` and the
     standalone script so the two can never drift into different defaults."""
+    ap.add_argument("--model", default=None,
+                    help="Checkpoint to serve. Alternatively pass a full command after --.")
     ap.add_argument("--out", default=None,
                     help="output dir (default $GITM_SCRATCH/traces/vllm-serve-<ts>)")
     ap.add_argument("--port", type=int, default=8000)
@@ -643,7 +645,7 @@ def add_serve_arguments(ap: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     argv = sys.argv[1:] if argv is None else argv
-    serve_argv = DEFAULT_SERVE_ARGV
+    serve_argv = None
     if "--" in argv:
         i = argv.index("--")
         argv, serve_argv = argv[:i], argv[i + 1:]
@@ -700,7 +702,12 @@ def launch_and_capture(args, serve_argv: list[str] | None = None):
               "collected by the tracer --no-trace disables.")
         return 2, None
 
-    serve_argv = list(serve_argv) if serve_argv else list(DEFAULT_SERVE_ARGV)
+    model = getattr(args, "model", None)
+    if model and serve_argv:
+        print("--model and a full serve command after -- are mutually exclusive.")
+        return 2, None
+    serve_argv = (list(serve_argv) if serve_argv else
+                  ["vllm", "serve", model] if model else list(DEFAULT_SERVE_ARGV))
 
     stamp = time.strftime("%Y%m%d-%H%M%S")
     out_dir = Path(args.out) if args.out else traces_dir() / f"vllm-serve-{stamp}"

--- a/gitm/tracer/_cupti_decode.py
+++ b/gitm/tracer/_cupti_decode.py
@@ -106,6 +106,7 @@ def decode_kernel(d: dict) -> KernelEvent:
         registers_per_thread=int(d.get("registers_per_thread", 0)),
         range_op=d.get("range_op"),
         range_layer=_opt_int(d.get("range_layer")),
+        pid=_opt_int(d.get("pid")),
     )
 
 
@@ -163,7 +164,7 @@ def decode_record(d: dict) -> TraceEvent | None:
 MARKER_START, MARKER_END = 0, 1
 
 #: vLLM's ``--enable-layerwise-nvtx-tracing`` names each range with the repr of a
-_VLLM_MODULE_RE = re.compile(r"'Module':\s*'([^']*)'")
+_VLLM_MODULE_RE = re.compile(r"[\"']Module[\"']:\s*[\"']([^\"']*)[\"']")
 
 
 def normalize_range_name(name: str) -> str:
@@ -258,6 +259,15 @@ def decode_records(records: list[dict]) -> list[TraceEvent]:
     Sorting by ``start_ns`` gives a stable timeline regardless of the order
     CUPTI flushed buffers (concurrent kernels on multiple streams interleave).
     """
+    # Both marker IDs and launch correlation IDs are process-local. Partition
+    # before pairing either; merging first silently borrows another rank's op.
+    pids = {d.get("pid") for d in records}
+    if len(pids) > 1:
+        by_pid: dict[int | None, list[dict]] = {}
+        for d in records:
+            by_pid.setdefault(d.get("pid"), []).append(d)
+        events = [e for group in by_pid.values() for e in decode_records(group)]
+        return sorted(events, key=lambda e: e.start_ns)
     correlated = correlate_kernels_to_ranges(pair_markers(records))
     enriched_kernels = iter(correlated)
     events: list[TraceEvent] = []

--- a/gitm/tracer/injection.py
+++ b/gitm/tracer/injection.py
@@ -322,6 +322,7 @@ def read_shards(start_ns: int | None = None, end_ns: int | None = None) -> list[
             if not isinstance(rec, dict):
                 dropped_lines += 1
                 continue
+            rec["pid"] = _shard_pid(shard)
             # Correlation records (runtime/driver launches and NVTX marker
             # halves) are consumed by decode_records to build the range index and
             # are never emitted as events.

--- a/gitm/tracer/kernel_taxonomy.py
+++ b/gitm/tracer/kernel_taxonomy.py
@@ -34,7 +34,7 @@ NAME_MAX = 1023
 
 # Ordered: first match wins, case-insensitive substring against the (mangled) name.
 # Order is load-bearing where vocabularies overlap:
-#   * MoE first — `marlin_moe`/`moe_align` also contain "gemm"/"align", and an MoE
+#   * MoE before GEMM — `marlin_moe`/`moe_align` also contain "gemm"/"align", and an MoE
 #     GEMM is more usefully an MoE kernel than a GEMM.
 #   * collectives before GEMM — NCCL's kernels mention neither, but custom all-reduce
 #     paths do carry "reduce", which the elementwise rules would otherwise claim.
@@ -44,15 +44,15 @@ NAME_MAX = 1023
 #     the generic quant rules, which are then left with the standalone
 #     quantise/dequantise passes.
 _RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("moe", ("moe", "expert", "topk_softmax", "grouped_gemm", "group_gemm",
-             "groupedgemm", "gather_scatter", "sort_tokens", "routing", "router")),
     # "cross_device_reduce" is vLLM's own custom all-reduce (the fast path TP=2 takes
     # on NVLink). Without it the generic "reduce" needle files it as elementwise and
     # the collective cost disappears into the noise — which is the one cost a TP run
     # exists to measure.
     ("collective", ("nccl", "all_reduce", "allreduce", "reduce_scatter", "reducescatter",
                     "all_gather", "allgather", "custom_ar", "cross_device", "one_shot",
-                    "two_shot")),
+                    "two_shot", "all_to_all", "alltoall", "dispatch_combine")),
+    ("moe", ("moe", "expert", "topk_softmax", "grouped_gemm", "group_gemm",
+             "groupedgemm", "gather_scatter", "sort_tokens", "routing", "router")),
     # Speculative decoding: drafting scaffolding and rejection sampling.
     #
     #   * `eagle_step_slot_mapping_metadata_kernel` contains "slot_mapping" and
@@ -128,7 +128,7 @@ _RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
                    "paged_attn", "attention", "attn_score", "splitkv", "merge_attn",
                    "mha_fwd", "cutlass_mla", "flash_mla", "mla_sparse", "sparse_mla",
                    "indexer", "lightning_index", "batchprefill", "batchdecode",
-                   "pagedkv", "prepare_varlen", "compute_attn")),
+                   "pagedkv", "prepare_varlen", "compute_attn", "sparse_fwd")),
     ("kv_cache", ("reshape_and_cache", "slot_mapping", "copy_blocks", "swap_blocks",
                   "concat_and_cache", "block_table")),
     # "nvjet" is cuBLAS's JIT-generated Hopper/Blackwell GEMM family

--- a/gitm/tracer/schema.py
+++ b/gitm/tracer/schema.py
@@ -20,6 +20,7 @@ class _TraceEventBase(BaseModel):
     stream_id: int
     device_id: int
     correlation_id: int | None = None
+    pid: int | None = None
 
 
 class KernelEvent(_TraceEventBase):

--- a/gitm/tracer/vllm_stats.py
+++ b/gitm/tracer/vllm_stats.py
@@ -562,6 +562,18 @@ _LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?=\.|$)")
 #: land on the same node, or residuals would be split across two spellings of
 #: one op and each half would look healthier than the whole.
 _MODULE_OPS: dict[str, str] = {
+    "q_a_proj": "attn_q_a",
+    "q_b_proj": "attn_q_b",
+    "kv_a_proj_with_mqa": "attn_kv_a",
+    "kv_a_proj": "attn_kv_a",
+    "kv_b_proj": "attn_kv_b",
+    "q_a_layernorm": "rms_norm",
+    "kv_a_layernorm": "rms_norm",
+    "input_layernorm": "rms_norm",
+    "post_attention_layernorm": "rms_norm",
+    "norm": "rms_norm",
+    "embed_tokens": "embed_tokens",
+    "eh_proj": "mtp_eh_proj",
     # attention projections
     "qkv_proj": "qkv_proj",
     "q_proj": "qkv_proj",
@@ -618,6 +630,17 @@ def op_for_module(qualname: str) -> tuple[str, int | None] | None:
         return None
     leaf = qualname.rsplit(".", 1)[-1]
     op = _MODULE_OPS.get(leaf) or _CONTAINER_OPS.get(leaf)
+    parts = qualname.split(".")
+    if "indexer" in parts:
+        op = {"wq_b": "attn_index_proj", "wk": "attn_index_proj",
+              "weights_proj": "attn_index_proj", "indexer": "attn_index_score",
+              "k_norm": "rms_norm"}.get(leaf, op)
+    if leaf in ("gate_up_proj", "down_proj", "gate_proj", "up_proj"):
+        if any(p in ("shared_expert", "shared_experts", "_shared_expert",
+                     "_shared_experts") for p in parts):
+            op = "moe_shared"
+        elif "experts" in parts:
+            op = "moe_routed"
     if op is None:
         return None
     m = _LAYER_RE.search(qualname)

--- a/tests/test_correlate_single_process.py
+++ b/tests/test_correlate_single_process.py
@@ -245,7 +245,7 @@ def test_an_unmapped_module_keeps_its_own_name_rather_than_being_dropped():
     gap rather than a silent one."""
     from gitm.tracer._cupti_decode import normalize_range_name
 
-    assert normalize_range_name(_vllm_range(f"{_QWEN}.2.input_layernorm")) == "L2/input_layernorm"
+    assert normalize_range_name(_vllm_range(f"{_QWEN}.2.unmapped_module")) == "L2/unmapped_module"
 
 
 def test_the_block_range_is_named_layer_not_its_index():

--- a/tests/test_glm_runtime_validation.py
+++ b/tests/test_glm_runtime_validation.py
@@ -1,0 +1,156 @@
+"""Production seams which graph arithmetic tests cannot exercise."""
+
+import json
+
+import pytest
+
+from gitm.optimizer.deviation import main as deviate
+from gitm.optimizer.deviation import observed_op
+from gitm.optimizer.validate_trace import audit_trace
+from gitm.planner.model_catalogue import predict
+from gitm.serve import discover, model_config
+from gitm.tracer import injection
+from gitm.tracer._cupti_decode import normalize_range_name
+from tests.test_glm_graph import GLM_CONFIG
+
+
+@pytest.mark.parametrize(("path", "op"), [
+    ("self_attn.q_a_proj", "attn_q_a"),
+    ("self_attn.kv_a_proj_with_mqa", "attn_kv_a"),
+    ("self_attn.q_b_proj", "attn_q_b"),
+    ("self_attn.kv_b_proj", "attn_kv_b"),
+    ("self_attn.indexer.wq_b", "attn_index_proj"),
+    ("self_attn.indexer.wk", "attn_index_proj"),
+    ("self_attn.indexer.weights_proj", "attn_index_proj"),
+    ("self_attn.indexer", "attn_index_score"),
+    ("mlp.shared_experts.down_proj", "moe_shared"),
+    ("mlp.experts.0.gate_up_proj", "moe_routed"),
+    ("input_layernorm", "rms_norm"),
+])
+def test_glm_module_ranges_match_graph_vocabulary(path, op):
+    module = f"model.layers.4.{path}"
+    for label in (str({"Module": module}), json.dumps({"Module": module})):
+        assert normalize_range_name(label) == f"L4/{op}"
+
+
+def test_nested_helpers_do_not_inflate_projection():
+    assert observed_op("scaled_fp8_quant", "attn_q_a") == "act_quant"
+    assert observed_op("rms_norm", "layer") == "rms_norm"
+    assert observed_op("opaque_gemm", "attn_q_a") == "attn_q_a"
+    assert observed_op("moe_sum", "moe_routed") == "moe_combine"
+
+
+def test_live_glm_reader_preserves_glm_spec(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps(GLM_CONFIG))
+    target = discover.Target(pid=1, cmdline=["vllm", "serve", str(tmp_path),
+                             "-tp", "8", "--enable-expert-parallel"])
+    live = model_config.live_moe_spec(target, environ={})
+    assert isinstance(live, model_config.LiveSpec)
+    assert live.family == "glm_moe_dsa"
+    assert live.spec.n_full_indexer_layers == 21
+    assert live.sharding.tp == live.sharding.ep == 8
+
+
+def test_production_shards_do_not_cross_correlate(tmp_path, monkeypatch):
+    base = tmp_path / "trace.jsonl"
+    monkeypatch.setenv(injection.ENV_OUT, str(base))
+    for pid, op in ((100, "attn_q_a"), (200, "attn_kv_a")):
+        rows = [
+            {"kind": "marker", "marker_id": 1, "marker_flags": 0,
+             "timestamp_ns": 10, "thread_id": 7, "name": f"L4/{op}"},
+            {"kind": "marker", "marker_id": 1, "marker_flags": 1,
+             "timestamp_ns": 30, "thread_id": 7},
+            {"kind": "runtime", "correlation_id": 3, "thread_id": 7,
+             "start_ns": 15, "end_ns": 20},
+            {"kind": "kernel", "name": "opaque_gemm", "correlation_id": 3,
+             "start_ns": 50, "end_ns": 60, "device_id": 0, "stream_id": 1,
+             "grid": [1, 1, 1], "block": [32, 1, 1]},
+        ]
+        base.with_name(f"trace.jsonl.{pid}").write_text(
+            "\n".join(json.dumps(r) for r in rows))
+    events = injection.read_shards()
+    assert {e.pid: e.range_op for e in events} == {100: "attn_q_a", 200: "attn_kv_a"}
+
+
+def test_phase_option_does_not_discard_graph_or_json(tmp_path, capsys):
+    path = tmp_path / "trace.jsonl"
+    path.write_text(json.dumps({"kind": "kernel", "name": "opaque_gemm",
+                    "range_op": "attn_q_a", "pid": 100, "device_id": 0,
+                    "start_ns": 1, "end_ns": 101}))
+    assert deviate([str(path), "--model", "glm-5.2-fp8", "--gpu", "H200",
+                    "--tp", "8", "--ep", "8", "--steps", "2",
+                    "--pid", "100", "--by-phase", "--json"]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["ops"]["attn_q_a"]["floor_s"] > 0
+    assert report["by_phase"]["unknown"]
+
+
+def test_audit_exposes_invalid_tags_and_worker_selection(tmp_path):
+    graph, _ = predict("glm-5.2-fp8")
+    path = tmp_path / "trace.jsonl"
+    rows = [{"kind": "kernel", "name": "opaque_gemm", "range_op": "attn_index_proj",
+             "range_layer": 3, "pid": pid, "device_id": 0,
+             "start_ns": 10, "end_ns": 110} for pid in (100, 200)]
+    path.write_text("\n".join(json.dumps(r) for r in rows))
+    report = audit_trace(path, graph, pid=100)
+    assert report["selected_workers"] == 1
+    assert len(report["workers"]) == 2
+    assert report["device_time_ns"] == 100
+    # IndexShare layer 3 must not launch an indexer projection.
+    assert report["unexpected_layer_tags"] == 1
+
+
+def test_capture_model_reaches_preflight_without_default_experiment(tmp_path, monkeypatch):
+    from gitm.cli import main
+    from gitm.serve import vllm
+
+    commands = []
+    monkeypatch.setattr(vllm, "preflight", lambda cmd, *a, **kw: commands.append(cmd) or [])
+    assert main(["capture", "serve", "--model", "zai-org/GLM-5.2-FP8",
+                 "--tp", "8", "--dry-run", "--out", str(tmp_path)]) == 0
+    assert commands[0][:3] == ["vllm", "serve", "zai-org/GLM-5.2-FP8"]
+
+
+def test_glm_live_sidecar_uses_glm_predictor(tmp_path, monkeypatch):
+    from gitm.serve.attach import _emit_predicted_graph
+
+    (tmp_path / "config.json").write_text(json.dumps(GLM_CONFIG))
+    target = discover.Target(pid=1, cmdline=["vllm", "serve", str(tmp_path)])
+    _emit_predicted_graph(target, tmp_path)
+    payload = json.loads((tmp_path / "predicted_moe_graph.json").read_text())
+    assert payload["family"] == "glm_moe_dsa"
+    assert "attn_q_a" in {n["op"] for n in payload["nodes"]}
+
+
+def test_merged_workers_are_refused_by_deviation(tmp_path, capsys):
+    path = tmp_path / "trace.jsonl"
+    path.write_text("\n".join(json.dumps({"kind": "kernel", "name": "rms_norm",
+                    "pid": p, "device_id": 0, "start_ns": 1, "end_ns": 100})
+                    for p in (100, 200)))
+    assert deviate([str(path), "--model", "glm-5.2-fp8"]) == 2
+    assert "per-rank" in capsys.readouterr().out
+
+
+def test_collective_and_sparse_attention_taxonomies_agree():
+    from gitm.optimizer.deviation import classify_op
+    from gitm.tracer.kernel_taxonomy import classify_kernel
+
+    assert classify_kernel("moe_all_to_all") == "collective"
+    assert classify_op("moe_all_to_all") == "moe_all_to_all"
+    assert classify_kernel("sparse_fwd_kernel") == "attention"
+    assert classify_op("sparse_fwd_kernel") == "attn_score_value"
+
+
+@pytest.mark.parametrize("tag,code", [("attn_q_a", 0), ("unknown_module", 1)])
+def test_validation_command_gates_attribution(tmp_path, capsys, tag, code):
+    from gitm.optimizer.validate_trace import main
+
+    path = tmp_path / "trace.jsonl"
+    path.write_text(json.dumps({"kind": "kernel", "name": "opaque_gemm",
+                    "range_op": tag, "range_layer": 0, "pid": 100, "device_id": 0,
+                    "start_ns": 1, "end_ns": 100}))
+    assert main([str(path), "--pid", "100", "--expected-workers", "1"]) == code
+    report = json.loads(capsys.readouterr().out)
+    assert report["passed"] == (code == 0)
+    # Coverage passing does not hide unobserved graph terms.
+    assert report["missing_ops"]

--- a/tests/test_vllm_stats_v1.py
+++ b/tests/test_vllm_stats_v1.py
@@ -142,7 +142,7 @@ def test_layer_index_is_read_from_the_path_not_a_counter():
     assert op_for_module("model.layers.3.self_attn.qkv_proj") == ("qkv_proj", 3)
     assert op_for_module("model.layers.11.mlp.experts") == ("moe_routed", 11)
     assert op_for_module("lm_head") == ("lm_head", None)
-    assert op_for_module("model.embed_tokens") is None
+    assert op_for_module("model.embed_tokens") == ("embed_tokens", None)
     assert op_for_module("") is None
 
 


### PR DESCRIPTION
GLM captures could be paired with the wrong graph or NVTX identity: live config and sidecar dispatch fell through to DeepSeek, worker shards were merged before process-local correlation, and MLA/indexer and shared-expert modules lacked accurate mappings. This change routes GLM correctly, preserves worker PIDs through correlation, and aligns module and kernel classification.

Adds `capture serve --model`, keeps graph comparison when `deviate --by-phase` is supplied, and requires a single worker/device for per-rank comparisons. An offline attribution gate reports coverage, missing ops, invalid layer tags, truncated names, and NVTX/name disagreements. The benchmark runbook documents eager identity capture, graph-mode timing, and scheduler evidence needed for valid step comparisons.

Validation on latest origin/main (4b95c69): 398 targeted tests passed, 1 skipped; Ruff passed for changed Python files; git diff --check passed. Includes 22 new regression tests. Actual H200/CUDA/vLLM execution and performance validation remain required; the attribution gate does not establish a fixed-shape decode window.
